### PR TITLE
feat: Task 1.2 — Docker Compose で開発用 PostgreSQL 16 と Redis 7 を起動

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,7 @@ web_modules/
 # dotenv environment variable files
 .env
 .env.*
+.env.local
 !.env.example
 
 # parcel-bundler cache (https://parceljs.org/)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,63 @@
+name: hr-management-system
+
+services:
+  # ─────────────────────────────────────────────────────────────
+  # PostgreSQL 16 — 永続ストレージ
+  # ─────────────────────────────────────────────────────────────
+  postgres:
+    image: postgres:16-alpine
+    container_name: hr-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      POSTGRES_DB: ${POSTGRES_DB:-hr_management}
+    ports:
+      - "${POSTGRES_PORT:-5432}:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+      - ./docker/postgres/init.sql:/docker-entrypoint-initdb.d/01-init.sql:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-postgres} -d ${POSTGRES_DB:-hr_management}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    networks:
+      - hr-network
+
+  # ─────────────────────────────────────────────────────────────
+  # Redis 7 — セッション・レート制限・BullMQ・AI キャッシュ共用
+  # ─────────────────────────────────────────────────────────────
+  redis:
+    image: redis:7-alpine
+    container_name: hr-redis
+    restart: unless-stopped
+    command: >
+      redis-server
+      --maxmemory 256mb
+      --maxmemory-policy allkeys-lru
+      --appendonly yes
+      --appendfsync everysec
+    ports:
+      - "${REDIS_PORT:-6379}:6379"
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    networks:
+      - hr-network
+
+volumes:
+  postgres_data:
+    driver: local
+  redis_data:
+    driver: local
+
+networks:
+  hr-network:
+    driver: bridge

--- a/docker/postgres/init.sql
+++ b/docker/postgres/init.sql
@@ -1,0 +1,19 @@
+-- ─────────────────────────────────────────────────────────────
+-- HR Management System — PostgreSQL 初期化スクリプト
+-- このスクリプトはコンテナ初回起動時に自動実行されます
+-- ─────────────────────────────────────────────────────────────
+
+-- pgcrypto: AES-256 カラム暗号化 (pgp_sym_encrypt / pgp_sym_decrypt)
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+-- pg_trgm: 社員名の部分一致検索 (GIN インデックス対応)
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+-- uuid-ossp: UUID 生成 (Prisma のデフォルト ID 生成をサポート)
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+-- ─────────────────────────────────────────────────────────────
+-- Shadow DB (Prisma マイグレーション用)
+-- ─────────────────────────────────────────────────────────────
+-- マイグレーション時に Shadow DB が必要な場合は環境変数で設定してください。
+-- 本番環境では SHADOW_DATABASE_URL を別途設定することを推奨します。

--- a/package.json
+++ b/package.json
@@ -20,17 +20,23 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
+    "check:connections": "tsx scripts/check-connections.ts",
     "prepare": "husky"
   },
   "dependencies": {
     "next": "^15.3.0",
+    "pg": "^8.13.0",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "redis": "^4.7.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.1",
     "@playwright/test": "^1.50.1",
+    "@tailwindcss/postcss": "^4.0.0",
+    "@types/js-yaml": "^4.0.9",
     "@types/node": "^22.0.0",
+    "@types/pg": "^8.11.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@typescript-eslint/eslint-plugin": "^8.0.0",
@@ -39,11 +45,12 @@
     "eslint": "^9.0.0",
     "eslint-config-next": "^15.3.0",
     "husky": "^9.1.0",
+    "js-yaml": "^4.1.1",
     "lint-staged": "^15.5.0",
     "prettier": "^3.4.0",
     "prettier-plugin-tailwindcss": "^0.6.0",
     "tailwindcss": "^4.0.0",
-    "@tailwindcss/postcss": "^4.0.0",
+    "tsx": "^4.19.0",
     "typescript": "^5.8.0",
     "vitest": "^3.0.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,12 +11,18 @@ importers:
       next:
         specifier: ^15.3.0
         version: 15.5.15(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      pg:
+        specifier: ^8.13.0
+        version: 8.20.0
       react:
         specifier: ^19.0.0
         version: 19.2.5
       react-dom:
         specifier: ^19.0.0
         version: 19.2.5(react@19.2.5)
+      redis:
+        specifier: ^4.7.0
+        version: 4.7.1
     devDependencies:
       '@eslint/eslintrc':
         specifier: ^3.3.1
@@ -27,9 +33,15 @@ importers:
       '@tailwindcss/postcss':
         specifier: ^4.0.0
         version: 4.2.2
+      '@types/js-yaml':
+        specifier: ^4.0.9
+        version: 4.0.9
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.17
+      '@types/pg':
+        specifier: ^8.11.0
+        version: 8.20.0
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -44,7 +56,7 @@ importers:
         version: 8.58.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       '@vitest/coverage-v8':
         specifier: ^3.0.0
-        version: 3.2.4(vitest@3.2.4(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))
+        version: 3.2.4(vitest@3.2.4(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
       eslint:
         specifier: ^9.0.0
         version: 9.39.4(jiti@2.6.1)
@@ -54,6 +66,9 @@ importers:
       husky:
         specifier: ^9.1.0
         version: 9.1.7
+      js-yaml:
+        specifier: ^4.1.1
+        version: 4.1.1
       lint-staged:
         specifier: ^15.5.0
         version: 15.5.2
@@ -66,12 +81,15 @@ importers:
       tailwindcss:
         specifier: ^4.0.0
         version: 4.2.2
+      tsx:
+        specifier: ^4.19.0
+        version: 4.21.0
       typescript:
         specifier: ^5.8.0
         version: 5.9.3
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
 
 packages:
 
@@ -566,6 +584,35 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  '@redis/bloom@1.2.0':
+    resolution: {integrity: sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+
+  '@redis/client@1.6.1':
+    resolution: {integrity: sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==}
+    engines: {node: '>=14'}
+
+  '@redis/graph@1.1.1':
+    resolution: {integrity: sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+
+  '@redis/json@1.0.7':
+    resolution: {integrity: sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+
+  '@redis/search@1.2.0':
+    resolution: {integrity: sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+
+  '@redis/time-series@1.1.0':
+    resolution: {integrity: sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+
   '@rollup/rollup-android-arm-eabi@4.60.1':
     resolution: {integrity: sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==}
     cpu: [arm]
@@ -800,6 +847,9 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/js-yaml@4.0.9':
+    resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
@@ -808,6 +858,9 @@ packages:
 
   '@types/node@22.19.17':
     resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
+
+  '@types/pg@8.20.0':
+    resolution: {integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==}
 
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
@@ -1178,6 +1231,10 @@ packages:
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
+  cluster-key-slot@1.1.2:
+    resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
+    engines: {node: '>=0.10.0'}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -1534,6 +1591,10 @@ packages:
   generator-function@2.0.1:
     resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
     engines: {node: '>= 0.4'}
+
+  generic-pool@3.9.0:
+    resolution: {integrity: sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==}
+    engines: {node: '>= 4'}
 
   get-east-asian-width@1.5.0:
     resolution: {integrity: sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==}
@@ -2130,6 +2191,40 @@ packages:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
     engines: {node: '>= 14.16'}
 
+  pg-cloudflare@1.3.0:
+    resolution: {integrity: sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==}
+
+  pg-connection-string@2.12.0:
+    resolution: {integrity: sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==}
+
+  pg-int8@1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+
+  pg-pool@3.13.0:
+    resolution: {integrity: sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==}
+    peerDependencies:
+      pg: '>=8.0'
+
+  pg-protocol@1.13.0:
+    resolution: {integrity: sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==}
+
+  pg-types@2.2.0:
+    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
+    engines: {node: '>=4'}
+
+  pg@8.20.0:
+    resolution: {integrity: sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
+  pgpass@1.0.5:
+    resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -2167,6 +2262,22 @@ packages:
   postcss@8.5.9:
     resolution: {integrity: sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==}
     engines: {node: ^10 || ^12 || >=14}
+
+  postgres-array@2.0.0:
+    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
+    engines: {node: '>=4'}
+
+  postgres-bytea@1.0.1:
+    resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-date@1.0.7:
+    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-interval@1.2.0:
+    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
+    engines: {node: '>=0.10.0'}
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -2259,6 +2370,9 @@ packages:
   react@19.2.5:
     resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
     engines: {node: '>=0.10.0'}
+
+  redis@4.7.1:
+    resolution: {integrity: sha512-S1bJDnqLftzHXHP8JsT5II/CtHWQrASX5K96REjWjlmWKrviSOLWmM7QnRLstAWsu1VBBV1ffV6DzCvxNP0UJQ==}
 
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
@@ -2381,6 +2495,10 @@ packages:
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
 
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
@@ -2526,6 +2644,11 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -2679,6 +2802,13 @@ packages:
   wrap-ansi@9.0.2:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
+
+  xtend@4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
+
+  yallist@4.0.0:
+    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
 
   yaml@2.8.3:
     resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
@@ -3049,6 +3179,32 @@ snapshots:
     dependencies:
       playwright: 1.59.1
 
+  '@redis/bloom@1.2.0(@redis/client@1.6.1)':
+    dependencies:
+      '@redis/client': 1.6.1
+
+  '@redis/client@1.6.1':
+    dependencies:
+      cluster-key-slot: 1.1.2
+      generic-pool: 3.9.0
+      yallist: 4.0.0
+
+  '@redis/graph@1.1.1(@redis/client@1.6.1)':
+    dependencies:
+      '@redis/client': 1.6.1
+
+  '@redis/json@1.0.7(@redis/client@1.6.1)':
+    dependencies:
+      '@redis/client': 1.6.1
+
+  '@redis/search@1.2.0(@redis/client@1.6.1)':
+    dependencies:
+      '@redis/client': 1.6.1
+
+  '@redis/time-series@1.1.0(@redis/client@1.6.1)':
+    dependencies:
+      '@redis/client': 1.6.1
+
   '@rollup/rollup-android-arm-eabi@4.60.1':
     optional: true
 
@@ -3215,6 +3371,8 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/js-yaml@4.0.9': {}
+
   '@types/json-schema@7.0.15': {}
 
   '@types/json5@0.0.29': {}
@@ -3222,6 +3380,12 @@ snapshots:
   '@types/node@22.19.17':
     dependencies:
       undici-types: 6.21.0
+
+  '@types/pg@8.20.0':
+    dependencies:
+      '@types/node': 22.19.17
+      pg-protocol: 1.13.0
+      pg-types: 2.2.0
 
   '@types/react-dom@19.2.3(@types/react@19.2.14)':
     dependencies:
@@ -3381,7 +3545,7 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))':
+  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -3396,7 +3560,7 @@ snapshots:
       std-env: 3.10.0
       test-exclude: 7.0.2
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)
+      vitest: 3.2.4(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -3408,13 +3572,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))':
+  '@vitest/mocker@3.2.4(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)
+      vite: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -3631,6 +3795,8 @@ snapshots:
       string-width: 7.2.0
 
   client-only@0.0.1: {}
+
+  cluster-key-slot@1.1.2: {}
 
   color-convert@2.0.1:
     dependencies:
@@ -4146,6 +4312,8 @@ snapshots:
   functions-have-names@1.2.3: {}
 
   generator-function@2.0.1: {}
+
+  generic-pool@3.9.0: {}
 
   get-east-asian-width@1.5.0: {}
 
@@ -4739,6 +4907,41 @@ snapshots:
 
   pathval@2.0.1: {}
 
+  pg-cloudflare@1.3.0:
+    optional: true
+
+  pg-connection-string@2.12.0: {}
+
+  pg-int8@1.0.1: {}
+
+  pg-pool@3.13.0(pg@8.20.0):
+    dependencies:
+      pg: 8.20.0
+
+  pg-protocol@1.13.0: {}
+
+  pg-types@2.2.0:
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.1
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
+
+  pg@8.20.0:
+    dependencies:
+      pg-connection-string: 2.12.0
+      pg-pool: 3.13.0(pg@8.20.0)
+      pg-protocol: 1.13.0
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.3.0
+
+  pgpass@1.0.5:
+    dependencies:
+      split2: 4.2.0
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.2: {}
@@ -4769,6 +4972,16 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  postgres-array@2.0.0: {}
+
+  postgres-bytea@1.0.1: {}
+
+  postgres-date@1.0.7: {}
+
+  postgres-interval@1.2.0:
+    dependencies:
+      xtend: 4.0.2
+
   prelude-ls@1.2.1: {}
 
   prettier-plugin-tailwindcss@0.6.14(prettier@3.8.3):
@@ -4795,6 +5008,15 @@ snapshots:
   react-is@16.13.1: {}
 
   react@19.2.5: {}
+
+  redis@4.7.1:
+    dependencies:
+      '@redis/bloom': 1.2.0(@redis/client@1.6.1)
+      '@redis/client': 1.6.1
+      '@redis/graph': 1.1.1(@redis/client@1.6.1)
+      '@redis/json': 1.0.7(@redis/client@1.6.1)
+      '@redis/search': 1.2.0(@redis/client@1.6.1)
+      '@redis/time-series': 1.1.0(@redis/client@1.6.1)
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -5002,6 +5224,8 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  split2@4.2.0: {}
+
   stable-hash@0.0.5: {}
 
   stackback@0.0.2: {}
@@ -5154,6 +5378,13 @@ snapshots:
 
   tslib@2.8.1: {}
 
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.7
+      get-tsconfig: 4.14.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
@@ -5230,13 +5461,13 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  vite-node@3.2.4(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3):
+  vite-node@3.2.4(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)
+      vite: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -5251,7 +5482,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3):
+  vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
@@ -5264,13 +5495,14 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
       lightningcss: 1.32.0
+      tsx: 4.21.0
       yaml: 2.8.3
 
-  vitest@3.2.4(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3):
+  vitest@3.2.4(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))
+      '@vitest/mocker': 3.2.4(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -5288,8 +5520,8 @@ snapshots:
       tinyglobby: 0.2.16
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)
-      vite-node: 3.2.4(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)
+      vite: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite-node: 3.2.4(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.17
@@ -5376,6 +5608,10 @@ snapshots:
       ansi-styles: 6.2.3
       string-width: 7.2.0
       strip-ansi: 7.2.0
+
+  xtend@4.0.2: {}
+
+  yallist@4.0.0: {}
 
   yaml@2.8.3: {}
 

--- a/scripts/check-connections.ts
+++ b/scripts/check-connections.ts
@@ -1,0 +1,148 @@
+#!/usr/bin/env tsx
+/**
+ * ローカル開発環境の接続確認スクリプト
+ *
+ * 使い方:
+ *   pnpm check:connections
+ *
+ * 確認内容:
+ *   - PostgreSQL 16 への接続
+ *   - pgcrypto / pg_trgm 拡張が有効か
+ *   - Redis 7 への接続
+ *   - PING レスポンス
+ */
+
+import { Client } from 'pg'
+import { createClient } from 'redis'
+
+const GREEN = '\x1b[32m'
+const RED = '\x1b[31m'
+const YELLOW = '\x1b[33m'
+const RESET = '\x1b[0m'
+const BOLD = '\x1b[1m'
+
+function ok(msg: string) {
+  console.log(`${GREEN}✓${RESET} ${msg}`)
+}
+
+function fail(msg: string) {
+  console.log(`${RED}✗${RESET} ${msg}`)
+}
+
+function info(msg: string) {
+  console.log(`${YELLOW}→${RESET} ${msg}`)
+}
+
+async function checkPostgres(): Promise<boolean> {
+  const url =
+    process.env['DATABASE_URL'] ?? 'postgresql://postgres:postgres@localhost:5432/hr_management'
+
+  info(`PostgreSQL: ${url.replace(/:([^:@]+)@/, ':***@')}`)
+
+  const client = new Client({ connectionString: url })
+  try {
+    await client.connect()
+    ok('PostgreSQL 接続成功')
+
+    // バージョン確認
+    const versionResult = await client.query<{ version: string }>('SELECT version()')
+    const version = versionResult.rows[0]?.version ?? ''
+    if (version.includes('PostgreSQL 16')) {
+      ok(`PostgreSQL バージョン: ${version.split(' ').slice(0, 2).join(' ')}`)
+    } else {
+      fail(
+        `PostgreSQL 16 が必要ですが、${version.split(' ').slice(0, 2).join(' ')} が検出されました`,
+      )
+    }
+
+    // pgcrypto 拡張確認
+    const pgcryptoResult = await client.query<{ count: string }>(
+      "SELECT COUNT(*) FROM pg_extension WHERE extname = 'pgcrypto'",
+    )
+    if (Number(pgcryptoResult.rows[0]?.count) > 0) {
+      ok('pgcrypto 拡張: 有効')
+    } else {
+      fail('pgcrypto 拡張: 無効（docker/postgres/init.sql を確認してください）')
+    }
+
+    // pg_trgm 拡張確認
+    const trgmResult = await client.query<{ count: string }>(
+      "SELECT COUNT(*) FROM pg_extension WHERE extname = 'pg_trgm'",
+    )
+    if (Number(trgmResult.rows[0]?.count) > 0) {
+      ok('pg_trgm 拡張: 有効')
+    } else {
+      fail('pg_trgm 拡張: 無効（docker/postgres/init.sql を確認してください）')
+    }
+
+    return true
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error)
+    fail(`PostgreSQL 接続失敗: ${message}`)
+    fail('docker compose up -d を実行してください')
+    return false
+  } finally {
+    await client.end().catch(() => undefined)
+  }
+}
+
+async function checkRedis(): Promise<boolean> {
+  const url = process.env['REDIS_URL'] ?? 'redis://localhost:6379'
+  info(`Redis: ${url}`)
+
+  const client = createClient({ url })
+  try {
+    await client.connect()
+    ok('Redis 接続成功')
+
+    // PING 確認
+    const pong = await client.ping()
+    if (pong === 'PONG') {
+      ok('Redis PING: PONG')
+    } else {
+      fail(`Redis PING: 予期しないレスポンス "${pong}"`)
+    }
+
+    // バージョン確認
+    const info = await client.info('server')
+    const versionMatch = /redis_version:(\S+)/.exec(info)
+    if (versionMatch) {
+      const version = versionMatch[1] ?? ''
+      if (version.startsWith('7.')) {
+        ok(`Redis バージョン: ${version}`)
+      } else {
+        fail(`Redis 7 が必要ですが、${version} が検出されました`)
+      }
+    }
+
+    return true
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error)
+    fail(`Redis 接続失敗: ${message}`)
+    fail('docker compose up -d を実行してください')
+    return false
+  } finally {
+    await client.disconnect().catch(() => undefined)
+  }
+}
+
+async function main() {
+  console.log(`\n${BOLD}HR Management System — 接続確認${RESET}\n`)
+
+  const pgOk = await checkPostgres()
+  console.log()
+  const redisOk = await checkRedis()
+  console.log()
+
+  if (pgOk && redisOk) {
+    console.log(`${GREEN}${BOLD}✓ すべての接続確認が完了しました！${RESET}\n`)
+    process.exit(0)
+  } else {
+    console.log(
+      `${RED}${BOLD}✗ 一部の接続に失敗しました。上記のエラーを確認してください。${RESET}\n`,
+    )
+    process.exit(1)
+  }
+}
+
+main()

--- a/src/tests/config/docker-setup.test.ts
+++ b/src/tests/config/docker-setup.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Task 1.2: Docker Compose で開発用 PostgreSQL 16 と Redis 7 を起動
+ *
+ * RED → GREEN: これらのテストがすべて通過すれば Task 1.2 完了
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync, existsSync } from 'node:fs'
+import { resolve } from 'node:path'
+import * as yaml from 'js-yaml'
+
+const root = resolve(__dirname, '../../../')
+
+// ─────────────────────────────────────────────
+// 1. docker-compose.yml の存在と構造
+// ─────────────────────────────────────────────
+describe('docker-compose.yml', () => {
+  it('docker-compose.yml が存在する', () => {
+    expect(existsSync(resolve(root, 'docker-compose.yml'))).toBe(true)
+  })
+
+  it('有効な YAML として解析できる', () => {
+    const content = readFileSync(resolve(root, 'docker-compose.yml'), 'utf-8')
+    expect(() => yaml.load(content)).not.toThrow()
+  })
+
+  it('postgres サービスが定義されている', () => {
+    const content = readFileSync(resolve(root, 'docker-compose.yml'), 'utf-8')
+    const doc = yaml.load(content) as Record<string, unknown>
+    const services = doc['services'] as Record<string, unknown>
+    expect(services).toHaveProperty('postgres')
+  })
+
+  it('redis サービスが定義されている', () => {
+    const content = readFileSync(resolve(root, 'docker-compose.yml'), 'utf-8')
+    const doc = yaml.load(content) as Record<string, unknown>
+    const services = doc['services'] as Record<string, unknown>
+    expect(services).toHaveProperty('redis')
+  })
+})
+
+// ─────────────────────────────────────────────
+// 2. PostgreSQL 16 の設定
+// ─────────────────────────────────────────────
+describe('PostgreSQL 設定', () => {
+  function getPostgresService() {
+    const content = readFileSync(resolve(root, 'docker-compose.yml'), 'utf-8')
+    const doc = yaml.load(content) as Record<string, unknown>
+    const services = doc['services'] as Record<string, unknown>
+    return services['postgres'] as Record<string, unknown>
+  }
+
+  it('PostgreSQL 16 イメージを使用している', () => {
+    const pg = getPostgresService()
+    expect(pg['image']).toMatch(/postgres:16/)
+  })
+
+  it('ポート 5432 がマッピングされている', () => {
+    const pg = getPostgresService()
+    const ports = pg['ports'] as string[]
+    expect(ports.some((p) => p.includes('5432'))).toBe(true)
+  })
+
+  it('ヘルスチェックが設定されている', () => {
+    const pg = getPostgresService()
+    expect(pg['healthcheck']).toBeDefined()
+  })
+
+  it('データボリュームが設定されている', () => {
+    const pg = getPostgresService()
+    const volumes = pg['volumes'] as string[]
+    expect(Array.isArray(volumes)).toBe(true)
+    expect(volumes.length).toBeGreaterThan(0)
+  })
+})
+
+// ─────────────────────────────────────────────
+// 3. PostgreSQL 拡張初期化スクリプト
+// ─────────────────────────────────────────────
+describe('PostgreSQL 拡張設定', () => {
+  it('初期化 SQL スクリプトが存在する', () => {
+    const candidates = ['docker/postgres/init.sql', 'docker/init.sql', 'infra/postgres/init.sql']
+    const found = candidates.some((f) => existsSync(resolve(root, f)))
+    expect(found).toBe(true)
+  })
+
+  it('pgcrypto 拡張が有効化される', () => {
+    const candidates = ['docker/postgres/init.sql', 'docker/init.sql', 'infra/postgres/init.sql']
+    const file = candidates.find((f) => existsSync(resolve(root, f)))
+    const content = readFileSync(resolve(root, file!), 'utf-8')
+    expect(content.toLowerCase()).toContain('pgcrypto')
+  })
+
+  it('pg_trgm 拡張が有効化される', () => {
+    const candidates = ['docker/postgres/init.sql', 'docker/init.sql', 'infra/postgres/init.sql']
+    const file = candidates.find((f) => existsSync(resolve(root, f)))
+    const content = readFileSync(resolve(root, file!), 'utf-8')
+    expect(content.toLowerCase()).toContain('pg_trgm')
+  })
+})
+
+// ─────────────────────────────────────────────
+// 4. Redis 7 の設定
+// ─────────────────────────────────────────────
+describe('Redis 設定', () => {
+  function getRedisService() {
+    const content = readFileSync(resolve(root, 'docker-compose.yml'), 'utf-8')
+    const doc = yaml.load(content) as Record<string, unknown>
+    const services = doc['services'] as Record<string, unknown>
+    return services['redis'] as Record<string, unknown>
+  }
+
+  it('Redis 7 イメージを使用している', () => {
+    const redis = getRedisService()
+    expect(redis['image']).toMatch(/redis:7/)
+  })
+
+  it('ポート 6379 がマッピングされている', () => {
+    const redis = getRedisService()
+    const ports = redis['ports'] as string[]
+    expect(ports.some((p) => p.includes('6379'))).toBe(true)
+  })
+
+  it('ヘルスチェックが設定されている', () => {
+    const redis = getRedisService()
+    expect(redis['healthcheck']).toBeDefined()
+  })
+
+  it('データボリュームが設定されている', () => {
+    const redis = getRedisService()
+    const volumes = redis['volumes'] as string[]
+    expect(Array.isArray(volumes)).toBe(true)
+    expect(volumes.length).toBeGreaterThan(0)
+  })
+})
+
+// ─────────────────────────────────────────────
+// 5. 接続確認スクリプト
+// ─────────────────────────────────────────────
+describe('接続確認スクリプト', () => {
+  it('接続確認スクリプトが存在する', () => {
+    const candidates = [
+      'scripts/check-db.ts',
+      'scripts/check-db.js',
+      'scripts/check-connections.ts',
+      'scripts/check-connections.sh',
+    ]
+    const found = candidates.some((f) => existsSync(resolve(root, f)))
+    expect(found).toBe(true)
+  })
+})
+
+// ─────────────────────────────────────────────
+// 6. .gitignore に .env.local が含まれる
+// ─────────────────────────────────────────────
+describe('.gitignore', () => {
+  it('.env.local が .gitignore に含まれる', () => {
+    const content = readFileSync(resolve(root, '.gitignore'), 'utf-8')
+    expect(content).toContain('.env.local')
+  })
+})


### PR DESCRIPTION
## Summary

- `docker-compose.yml` に PostgreSQL 16 と Redis 7 サービスを定義
- `docker/postgres/init.sql` で pgcrypto / pg_trgm / uuid-ossp 拡張を自動有効化
- `scripts/check-connections.ts` で接続確認スクリプトを実装（`pnpm check:connections`）
- Vitest で 17 テストすべて GREEN

## Test plan

- [x] `pnpm test` — 17 tests all pass
- [x] `docker compose up -d` — PostgreSQL / Redis が起動する
- [x] `pnpm check:connections` — 接続確認スクリプトがすべて ✓ を返す

Closes #2