### PR TITLE
[Task 2.2] アクセスログミドルウェアと自動ローテート

### DIFF
--- a/prisma/migrations/access-log-partition.sql
+++ b/prisma/migrations/access-log-partition.sql
@@ -1,0 +1,113 @@
+-- =============================================================================
+-- Migration: アクセスログ 月次パーティション & 自動ローテート
+-- Requirement 17.6
+-- =============================================================================
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 1. 親テーブル（月次 RANGE パーティション on requestedAt）
+-- ─────────────────────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS access_logs (
+  id           TEXT        NOT NULL,
+  method       TEXT        NOT NULL,
+  path         TEXT        NOT NULL,
+  "statusCode" INT         NOT NULL,
+  "durationMs" INT         NOT NULL,
+  "ipAddress"  TEXT        NOT NULL,
+  "userAgent"  TEXT        NOT NULL,
+  "userId"     TEXT,
+  "requestId"  TEXT        NOT NULL,
+  "requestedAt" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (id, "requestedAt")
+) PARTITION BY RANGE ("requestedAt");
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 2. インデックス
+-- ─────────────────────────────────────────────────────────────────────────────
+
+CREATE INDEX IF NOT EXISTS access_logs_requested_at_idx
+  ON access_logs ("requestedAt" DESC);
+
+CREATE INDEX IF NOT EXISTS access_logs_user_requested_idx
+  ON access_logs ("userId", "requestedAt" DESC);
+
+CREATE INDEX IF NOT EXISTS access_logs_path_requested_idx
+  ON access_logs (path, "requestedAt" DESC);
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 3. 当月・翌月パーティションを作成
+-- ─────────────────────────────────────────────────────────────────────────────
+
+DO $$
+DECLARE
+  cur_month  DATE := DATE_TRUNC('month', NOW());
+  next_month DATE := DATE_TRUNC('month', NOW() + INTERVAL '1 month');
+  cur_label  TEXT := TO_CHAR(cur_month, 'YYYY_MM');
+  next_label TEXT := TO_CHAR(next_month, 'YYYY_MM');
+BEGIN
+  EXECUTE FORMAT(
+    'CREATE TABLE IF NOT EXISTS access_logs_%s
+     PARTITION OF access_logs
+     FOR VALUES FROM (%L) TO (%L)',
+    cur_label, cur_month::TEXT, next_month::TEXT
+  );
+  EXECUTE FORMAT(
+    'CREATE TABLE IF NOT EXISTS access_logs_%s
+     PARTITION OF access_logs
+     FOR VALUES FROM (%L) TO (%L)',
+    next_label, next_month::TEXT, (next_month + INTERVAL '1 month')::TEXT
+  );
+END
+$$;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 4. 翌月パーティション自動作成 + 12ヶ月超パーティション自動ドロップ関数
+--    本番では pg_cron で毎日 00:05 に実行する:
+--    SELECT cron.schedule('rotate-access-logs', '5 0 * * *',
+--      'SELECT rotate_access_log_partitions()');
+-- ─────────────────────────────────────────────────────────────────────────────
+
+CREATE OR REPLACE FUNCTION rotate_access_log_partitions()
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  next_month     DATE := DATE_TRUNC('month', NOW() + INTERVAL '1 month');
+  drop_threshold DATE := DATE_TRUNC('month', NOW() - INTERVAL '12 months');
+  next_label     TEXT := TO_CHAR(next_month, 'YYYY_MM');
+  drop_label     TEXT := TO_CHAR(drop_threshold, 'YYYY_MM');
+  partition_name TEXT;
+BEGIN
+  -- 翌月パーティションを先行作成（存在しない場合のみ）
+  partition_name := 'access_logs_' || next_label;
+  IF NOT EXISTS (
+    SELECT FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relname = partition_name AND n.nspname = 'public'
+  ) THEN
+    EXECUTE FORMAT(
+      'CREATE TABLE %I PARTITION OF access_logs
+       FOR VALUES FROM (%L) TO (%L)',
+      partition_name,
+      next_month::TEXT,
+      (next_month + INTERVAL '1 month')::TEXT
+    );
+  END IF;
+
+  -- 12ヶ月超の古いパーティションをドロップ（Requirement 17.6: 1年間保持）
+  partition_name := 'access_logs_' || drop_label;
+  IF EXISTS (
+    SELECT FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relname = partition_name AND n.nspname = 'public'
+  ) THEN
+    EXECUTE FORMAT('DROP TABLE IF EXISTS %I', partition_name);
+  END IF;
+END;
+$$;
+
+COMMENT ON TABLE access_logs IS
+  'APIアクセスログ（1年間保持 / 月次パーティション）。Requirement 17.6。';
+
+COMMENT ON FUNCTION rotate_access_log_partitions() IS
+  '翌月パーティション作成 + 12ヶ月超パーティション自動ドロップ。pg_cron で毎日実行する。';

--- a/prisma/migrations/access-log-partition.sql
+++ b/prisma/migrations/access-log-partition.sql
@@ -73,7 +73,11 @@ LANGUAGE plpgsql
 AS $$
 DECLARE
   next_month     DATE := DATE_TRUNC('month', NOW() + INTERVAL '1 month');
-  drop_threshold DATE := DATE_TRUNC('month', NOW() - INTERVAL '12 months');
+  -- 13ヶ月前の月頭 = そのパーティションの最終行が NOW()-13month 以前に確実に収まる
+  -- 例: 2026-04-01 実行 → drop_threshold = 2025-03-01
+  --     2025_03 パーティション (2025-03-01〜2025-03-31) のデータは全て13ヶ月以上前
+  --     → 1年間（12ヶ月）保持を確実に満たしてからドロップ
+  drop_threshold DATE := DATE_TRUNC('month', NOW() - INTERVAL '13 months');
   next_label     TEXT := TO_CHAR(next_month, 'YYYY_MM');
   drop_label     TEXT := TO_CHAR(drop_threshold, 'YYYY_MM');
   partition_name TEXT;
@@ -94,7 +98,8 @@ BEGIN
     );
   END IF;
 
-  -- 12ヶ月超の古いパーティションをドロップ（Requirement 17.6: 1年間保持）
+  -- 13ヶ月前の月パーティションをドロップ（Requirement 17.6: 1年間保持を確実に満たす）
+  -- 12ヶ月前だと月末データがまだ12ヶ月以内に入るため、13ヶ月前を使用する
   partition_name := 'access_logs_' || drop_label;
   IF EXISTS (
     SELECT FROM pg_class c

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -207,3 +207,31 @@ model AuditLog {
   @@index([action, occurredAt])
   @@map("audit_logs")
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// アクセスログ (Requirement 17.6)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// API アクセスログ（1年間保持 / 月次パーティショニング）
+/// - 全 /api/** リクエストをミドルウェアで非同期記録
+/// - 月次パーティションを12ヶ月経過後に日次 cron でドロップ
+model AccessLog {
+  id         String   @id @default(cuid())
+  method     String
+  path       String
+  statusCode Int
+  durationMs Int
+  ipAddress  String
+  userAgent  String
+  /// null = 未認証リクエスト
+  userId     String?
+  requestId  String
+
+  /// リクエスト受信日時（パーティショニングキー）
+  requestedAt DateTime @default(now())
+
+  @@index([requestedAt])
+  @@index([userId, requestedAt])
+  @@index([path, requestedAt])
+  @@map("access_logs")
+}

--- a/src/lib/access-log/access-log-middleware.ts
+++ b/src/lib/access-log/access-log-middleware.ts
@@ -1,0 +1,56 @@
+import type { NextRequest } from 'next/server'
+import { createAccessLogRepository } from './access-log-repository'
+import type { AccessLogRepository } from './access-log-repository'
+
+type NextFn = (req: NextRequest) => Promise<Response>
+
+export interface AccessLogMiddleware {
+  (req: NextRequest, next: NextFn): Promise<Response>
+}
+
+function extractIp(req: NextRequest): string {
+  return req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ?? req.ip ?? 'unknown'
+}
+
+function extractRequestId(req: NextRequest): string {
+  return req.headers.get('x-request-id') ?? crypto.randomUUID()
+}
+
+/**
+ * アクセスログミドルウェア
+ * /api/** パスのみ記録し、fire-and-forget で非同期に書き込む（Requirement 17.6）
+ */
+export function createAccessLogMiddleware(repo?: AccessLogRepository): AccessLogMiddleware {
+  const repository = repo ?? createAccessLogRepository()
+
+  return async (req: NextRequest, next: NextFn): Promise<Response> => {
+    const path = req.nextUrl.pathname
+
+    // /api/** パスのみ記録対象
+    if (!path.startsWith('/api/')) {
+      return next(req)
+    }
+
+    const start = Date.now()
+    const response = await next(req)
+    const durationMs = Date.now() - start
+
+    // fire-and-forget — ログ失敗がリクエストに影響しないようにする
+    repository
+      .insert({
+        method: req.method as 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'HEAD' | 'OPTIONS',
+        path,
+        statusCode: response.status,
+        durationMs,
+        ipAddress: extractIp(req),
+        userAgent: req.headers.get('user-agent') ?? 'unknown',
+        userId: null, // 認証ミドルウェアで設定するため初期値は null
+        requestId: extractRequestId(req),
+      })
+      .catch(() => {
+        // ログ書き込み失敗は無視（本番では structured logger に転送する）
+      })
+
+    return response
+  }
+}

--- a/src/lib/access-log/access-log-repository.ts
+++ b/src/lib/access-log/access-log-repository.ts
@@ -1,0 +1,71 @@
+import { PrismaClient } from '@prisma/client'
+import type { AccessLogEntry, AccessLogQuery } from './access-log-types'
+
+export interface AccessLogRepository {
+  insert(entry: AccessLogEntry): Promise<void>
+  findMany(query: AccessLogQuery): Promise<{ data: AccessLogRecord[]; total: number }>
+}
+
+export interface AccessLogRecord {
+  id: string
+  method: string
+  path: string
+  statusCode: number
+  durationMs: number
+  ipAddress: string
+  userAgent: string
+  userId: string | null
+  requestId: string
+  requestedAt: Date
+}
+
+class PrismaAccessLogRepository implements AccessLogRepository {
+  constructor(private readonly db: PrismaClient) {}
+
+  async insert(entry: AccessLogEntry): Promise<void> {
+    await this.db.accessLog.create({
+      data: {
+        method: entry.method,
+        path: entry.path,
+        statusCode: entry.statusCode,
+        durationMs: entry.durationMs,
+        ipAddress: entry.ipAddress,
+        userAgent: entry.userAgent,
+        userId: entry.userId,
+        requestId: entry.requestId,
+      },
+    })
+  }
+
+  async findMany(query: AccessLogQuery): Promise<{ data: AccessLogRecord[]; total: number }> {
+    const where = {
+      ...(query.userId ? { userId: query.userId } : {}),
+      ...(query.path ? { path: { contains: query.path } } : {}),
+      ...(query.statusCode ? { statusCode: query.statusCode } : {}),
+      ...(query.from || query.to
+        ? {
+            requestedAt: {
+              ...(query.from ? { gte: new Date(query.from) } : {}),
+              ...(query.to ? { lte: new Date(query.to) } : {}),
+            },
+          }
+        : {}),
+    }
+
+    const [data, total] = await Promise.all([
+      this.db.accessLog.findMany({
+        where,
+        orderBy: { requestedAt: 'desc' },
+        skip: (query.page - 1) * query.limit,
+        take: query.limit,
+      }),
+      this.db.accessLog.count({ where }),
+    ])
+
+    return { data, total }
+  }
+}
+
+export function createAccessLogRepository(db?: PrismaClient): AccessLogRepository {
+  return new PrismaAccessLogRepository(db ?? new PrismaClient())
+}

--- a/src/lib/access-log/access-log-types.ts
+++ b/src/lib/access-log/access-log-types.ts
@@ -1,0 +1,37 @@
+import { z } from 'zod'
+
+const HTTP_METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'] as const
+
+// ─────────────────────────────────────────────────────────────────────────────
+// アクセスログエントリ（ミドルウェアが記録する1リクエスト分）
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const accessLogEntrySchema = z.object({
+  method: z.enum(HTTP_METHODS),
+  path: z.string().min(1),
+  statusCode: z.number().int().min(100).max(599),
+  durationMs: z.number().min(0),
+  ipAddress: z.string(),
+  userAgent: z.string(),
+  /** null = 未認証リクエスト */
+  userId: z.string().nullable(),
+  requestId: z.string(),
+})
+
+export type AccessLogEntry = z.infer<typeof accessLogEntrySchema>
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ADMIN 向け参照クエリ（Requirement 17.6）
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const accessLogQuerySchema = z.object({
+  userId: z.string().optional(),
+  path: z.string().optional(),
+  statusCode: z.number().int().optional(),
+  from: z.string().datetime().optional(),
+  to: z.string().datetime().optional(),
+  page: z.number().int().min(1).default(1),
+  limit: z.number().int().min(1).max(100).default(20),
+})
+
+export type AccessLogQuery = z.infer<typeof accessLogQuerySchema>

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,16 @@
+import { type NextRequest, NextResponse } from 'next/server'
+import { createAccessLogMiddleware } from '@/lib/access-log/access-log-middleware'
+
+const accessLog = createAccessLogMiddleware()
+
+export async function middleware(request: NextRequest): Promise<NextResponse> {
+  return accessLog(request, async (req) => {
+    // 認証ミドルウェアは後続のタスク（Task 6.1）で実装予定
+    // ここでは Next.js のデフォルトレスポンスをそのまま返す
+    return NextResponse.next({ request: req })
+  }) as Promise<NextResponse>
+}
+
+export const config = {
+  matcher: ['/api/:path*'],
+}

--- a/src/tests/access-log/access-log-middleware-integration.test.ts
+++ b/src/tests/access-log/access-log-middleware-integration.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import path from 'path'
+
+/**
+ * Next.js middleware.ts がアプリ実行経路に正しく接続されていることを確認する
+ */
+describe('Next.js middleware integration', () => {
+  const middlewarePath = path.resolve(process.cwd(), 'src/middleware.ts')
+  const content = readFileSync(middlewarePath, 'utf-8')
+
+  it('should import createAccessLogMiddleware', () => {
+    expect(content).toContain('createAccessLogMiddleware')
+  })
+
+  it('should export middleware function', () => {
+    expect(content).toContain('export async function middleware')
+  })
+
+  it('should configure matcher for /api/** paths', () => {
+    expect(content).toContain("'/api/:path*'")
+  })
+
+  it('should export config with matcher', () => {
+    expect(content).toContain('export const config')
+    expect(content).toContain('matcher')
+  })
+})
+
+/**
+ * パーティション削除ロジックが 13ヶ月前を使うことで 1年間保持を確実に満たすことを確認する
+ */
+describe('Partition rotation retention policy', () => {
+  const sqlPath = path.resolve(process.cwd(), 'prisma/migrations/access-log-partition.sql')
+  const sql = readFileSync(sqlPath, 'utf-8')
+
+  it('should use 13 months interval for drop threshold (not 12)', () => {
+    // 12ヶ月だと月末データが保持期間内に入るため、13ヶ月を使うことで1年間保持を保証する
+    expect(sql).toContain("INTERVAL '13 months'")
+    expect(sql).not.toMatch(/drop_threshold.*INTERVAL '12 months'/)
+  })
+
+  it('should create next month partition before dropping old ones', () => {
+    // 関数内でのコメント順序を確認（セクション見出しではなく本体内のコメント）
+    const createIdx = sql.indexOf('-- 翌月パーティションを先行作成')
+    const dropIdx = sql.indexOf('-- 13ヶ月前の月パーティションをドロップ')
+    expect(createIdx).toBeGreaterThan(-1)
+    expect(dropIdx).toBeGreaterThan(-1)
+    expect(createIdx).toBeLessThan(dropIdx)
+  })
+})

--- a/src/tests/access-log/access-log-middleware.test.ts
+++ b/src/tests/access-log/access-log-middleware.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { createAccessLogMiddleware } from '@/lib/access-log/access-log-middleware'
+import type { NextRequest } from 'next/server'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Mocks
+// ─────────────────────────────────────────────────────────────────────────────
+
+const mockEmit = vi.fn()
+const mockNext = vi.fn()
+
+vi.mock('@/lib/access-log/access-log-repository', () => ({
+  createAccessLogRepository: vi.fn(() => ({
+    insert: mockEmit,
+  })),
+}))
+
+function makeRequest(
+  options: {
+    method?: string
+    path?: string
+    ip?: string
+    userAgent?: string
+    userId?: string | null
+  } = {},
+): NextRequest {
+  const url = `http://localhost${options.path ?? '/api/test'}`
+  return {
+    method: options.method ?? 'GET',
+    nextUrl: { pathname: options.path ?? '/api/test' },
+    url,
+    ip: options.ip ?? '127.0.0.1',
+    headers: {
+      get: (key: string) => {
+        if (key === 'user-agent') return options.userAgent ?? 'TestAgent/1.0'
+        if (key === 'x-request-id') return 'req-test-123'
+        if (key === 'x-forwarded-for') return options.ip ?? '127.0.0.1'
+        return null
+      },
+    },
+  } as unknown as NextRequest
+}
+
+function makeResponse(status = 200) {
+  return { status } as Response
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('createAccessLogMiddleware', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockEmit.mockResolvedValue(undefined)
+    mockNext.mockResolvedValue(makeResponse(200))
+  })
+
+  it('should call next() and return the response', async () => {
+    const middleware = createAccessLogMiddleware()
+    const req = makeRequest()
+    const response = makeResponse(200)
+    mockNext.mockResolvedValue(response)
+
+    const result = await middleware(req, mockNext)
+
+    expect(mockNext).toHaveBeenCalledOnce()
+    expect(result).toBe(response)
+  })
+
+  it('should record method, path, statusCode, ipAddress, userAgent', async () => {
+    const middleware = createAccessLogMiddleware()
+    const req = makeRequest({
+      method: 'POST',
+      path: '/api/users',
+      ip: '10.0.0.1',
+      userAgent: 'Chrome/100',
+    })
+    mockNext.mockResolvedValue(makeResponse(201))
+
+    await middleware(req, mockNext)
+
+    expect(mockEmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'POST',
+        path: '/api/users',
+        statusCode: 201,
+        ipAddress: '10.0.0.1',
+        userAgent: 'Chrome/100',
+      }),
+    )
+  })
+
+  it('should record durationMs as a non-negative number', async () => {
+    const middleware = createAccessLogMiddleware()
+    const req = makeRequest()
+    mockNext.mockResolvedValue(makeResponse(200))
+
+    await middleware(req, mockNext)
+
+    expect(mockEmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        durationMs: expect.any(Number),
+      }),
+    )
+    const recorded = mockEmit.mock.calls[0][0]
+    expect(recorded.durationMs).toBeGreaterThanOrEqual(0)
+  })
+
+  it('should not throw when repository insert fails (fire-and-forget)', async () => {
+    mockEmit.mockRejectedValue(new Error('DB error'))
+    const middleware = createAccessLogMiddleware()
+    const req = makeRequest()
+    mockNext.mockResolvedValue(makeResponse(200))
+
+    await expect(middleware(req, mockNext)).resolves.not.toThrow()
+  })
+
+  it('should only log /api/** paths', async () => {
+    const middleware = createAccessLogMiddleware()
+    const req = makeRequest({ path: '/_next/static/chunk.js' })
+    mockNext.mockResolvedValue(makeResponse(200))
+
+    await middleware(req, mockNext)
+
+    expect(mockEmit).not.toHaveBeenCalled()
+  })
+})

--- a/src/tests/access-log/access-log-schema.test.ts
+++ b/src/tests/access-log/access-log-schema.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import path from 'path'
+
+describe('AccessLog Prisma Schema', () => {
+  const schemaPath = path.resolve(process.cwd(), 'prisma/schema.prisma')
+  const schema = readFileSync(schemaPath, 'utf-8')
+
+  it('should define AccessLog model', () => {
+    expect(schema).toContain('model AccessLog')
+  })
+
+  it('should define required fields', () => {
+    const modelMatch = schema.match(/model AccessLog \{[\s\S]*?\}/)
+    expect(modelMatch).not.toBeNull()
+    const model = modelMatch![0]
+
+    expect(model).toContain('id')
+    expect(model).toContain('method')
+    expect(model).toContain('path')
+    expect(model).toContain('statusCode')
+    expect(model).toContain('durationMs')
+    expect(model).toContain('ipAddress')
+    expect(model).toContain('userAgent')
+    expect(model).toContain('userId')
+    expect(model).toContain('requestedAt')
+  })
+
+  it('should map to access_logs table', () => {
+    expect(schema).toContain('@@map("access_logs")')
+  })
+
+  it('should have index on requestedAt for time-range queries', () => {
+    const modelMatch = schema.match(/model AccessLog \{[\s\S]*?\}/)
+    expect(modelMatch).not.toBeNull()
+    const model = modelMatch![0]
+    expect(model).toMatch(/@@index\(\[.*requestedAt.*\]\)/)
+  })
+})

--- a/src/tests/access-log/access-log-types.test.ts
+++ b/src/tests/access-log/access-log-types.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest'
+import { accessLogEntrySchema, accessLogQuerySchema } from '@/lib/access-log/access-log-types'
+
+describe('accessLogEntrySchema', () => {
+  it('should validate a correct entry', () => {
+    const result = accessLogEntrySchema.safeParse({
+      method: 'GET',
+      path: '/api/users',
+      statusCode: 200,
+      durationMs: 123,
+      ipAddress: '127.0.0.1',
+      userAgent: 'Mozilla/5.0',
+      userId: 'user-1',
+      requestId: 'req-abc123',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('should accept null userId for unauthenticated requests', () => {
+    const result = accessLogEntrySchema.safeParse({
+      method: 'POST',
+      path: '/api/auth/login',
+      statusCode: 401,
+      durationMs: 50,
+      ipAddress: '10.0.0.1',
+      userAgent: 'curl/7.0',
+      userId: null,
+      requestId: 'req-xyz',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('should reject missing required fields', () => {
+    const result = accessLogEntrySchema.safeParse({
+      method: 'GET',
+      // missing path, statusCode, etc.
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('should reject invalid HTTP method', () => {
+    const result = accessLogEntrySchema.safeParse({
+      method: 'INVALID',
+      path: '/api/users',
+      statusCode: 200,
+      durationMs: 10,
+      ipAddress: '127.0.0.1',
+      userAgent: 'Test',
+      userId: null,
+      requestId: 'req-1',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('should reject negative durationMs', () => {
+    const result = accessLogEntrySchema.safeParse({
+      method: 'GET',
+      path: '/api/users',
+      statusCode: 200,
+      durationMs: -1,
+      ipAddress: '127.0.0.1',
+      userAgent: 'Test',
+      userId: null,
+      requestId: 'req-1',
+    })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('accessLogQuerySchema', () => {
+  it('should validate query with all optional filters', () => {
+    const result = accessLogQuerySchema.safeParse({
+      userId: 'user-1',
+      path: '/api/users',
+      statusCode: 200,
+      from: '2026-01-01T00:00:00Z',
+      to: '2026-12-31T23:59:59Z',
+      page: 1,
+      limit: 50,
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('should use defaults when no filters provided', () => {
+    const result = accessLogQuerySchema.safeParse({})
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.page).toBe(1)
+      expect(result.data.limit).toBe(20)
+    }
+  })
+
+  it('should reject limit greater than 100', () => {
+    const result = accessLogQuerySchema.safeParse({ limit: 101 })
+    expect(result.success).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

- `AccessLog` Prisma モデルを追加（月次 RANGE パーティショニング設計）
- `createAccessLogMiddleware`: `/api/**` パスのみ対象、fire-and-forget で非同期記録（Req 17.6）
- `createAccessLogRepository`: `findMany` でフィルター・ページング対応（ADMIN 参照 API 向け）
- `access-log-partition.sql`: 翌月パーティション先行作成 + `rotate_access_log_partitions()` 関数（12ヶ月超自動ドロップ）
- pg_cron 設定コメントを SQL に記載（`5 0 * * *` で毎日実行）

## Test plan

- [x] `access-log-schema.test.ts` — Prisma スキーマのモデル・フィールド・インデックス確認（4 tests）
- [x] `access-log-types.test.ts` — Zod スキーマ検証（8 tests）
- [x] `access-log-middleware.test.ts` — next() 呼び出し・フィールド記録・durationMs・fire-and-forget・パスフィルタ（5 tests）
- [x] 全テスト 147 passing（リグレッションなし）

Closes #7