### PR TITLE
[Task 3.1] BullMQ ワーカーの共通基盤を構築

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,12 @@
     "prepare": "husky"
   },
   "dependencies": {
-    "neverthrow": "^8.0.0",
+    "@bull-board/api": "^7.0.0",
+    "@bull-board/hono": "^7.0.0",
     "@prisma/client": "^6.0.0",
+    "bullmq": "^5.74.1",
+    "ioredis": "^5.10.1",
+    "neverthrow": "^8.0.0",
     "next": "^15.3.0",
     "pg": "^8.13.0",
     "prisma": "^6.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,12 +8,24 @@ importers:
 
   .:
     dependencies:
-      neverthrow:
-        specifier: ^8.0.0
-        version: 8.2.0
+      '@bull-board/api':
+        specifier: ^7.0.0
+        version: 7.0.0(@bull-board/ui@7.0.0)
+      '@bull-board/hono':
+        specifier: ^7.0.0
+        version: 7.0.0(hono@4.12.14)
       '@prisma/client':
         specifier: ^6.0.0
         version: 6.19.3(prisma@6.19.3(magicast@0.3.5)(typescript@5.9.3))(typescript@5.9.3)
+      bullmq:
+        specifier: ^5.74.1
+        version: 5.74.1
+      ioredis:
+        specifier: ^5.10.1
+        version: 5.10.1
+      neverthrow:
+        specifier: ^8.0.0
+        version: 8.2.0
       next:
         specifier: ^15.3.0
         version: 15.5.15(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -133,6 +145,19 @@ packages:
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
+
+  '@bull-board/api@7.0.0':
+    resolution: {integrity: sha512-ISNspLHVmUWUSq/eLw+wd1FuBBUnqpLbYP2xUNmehpfKhS+NoZWMbBvqjUYVeE/HLfUkRcR1edzMKpl5n9zlSw==}
+    peerDependencies:
+      '@bull-board/ui': 7.0.0
+
+  '@bull-board/hono@7.0.0':
+    resolution: {integrity: sha512-olpxmQX06Bf0XEgbH5z2a800woXmB4uiLGM1noMdORBg3GvdImevw/nfxV9XxAPBN4dcnQ99VVAEqOvwrMObvQ==}
+    peerDependencies:
+      hono: ^4
+
+  '@bull-board/ui@7.0.0':
+    resolution: {integrity: sha512-AnKeklpDn0iMFgu4ukDU6uTNmw4oudl07G4k2Fh95SknKDrXSiWRV0N1TGUawMqyfG1Yi5P/W/8d7raBq/Uw6w==}
 
   '@emnapi/core@1.9.2':
     resolution: {integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==}
@@ -490,6 +515,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@ioredis/commands@1.5.1':
+    resolution: {integrity: sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw==}
+
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
@@ -513,6 +541,36 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
+    resolution: {integrity: sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.3':
+    resolution: {integrity: sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.3':
+    resolution: {integrity: sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.3':
+    resolution: {integrity: sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.3':
+    resolution: {integrity: sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3':
+    resolution: {integrity: sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==}
+    cpu: [x64]
+    os: [win32]
 
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
@@ -1226,6 +1284,9 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
+  bullmq@5.74.1:
+    resolution: {integrity: sha512-GfJEos2zoOGM9xqkB7VZouwwFuejKFqm667cBcmbBekJXKqqXWk4QYP3Uy2pzgUwCbg1cR7GgGmGczM7fnhWSA==}
+
   c12@3.1.0:
     resolution: {integrity: sha512-uWoS8OU1MEIsOv8p/5a82c3H31LsWVR5qiyXVfBNOzfffjUWtPnhAb4BYI2uG2HfGmZmFjCtui5XNWaps+iFuw==}
     peerDependencies:
@@ -1322,6 +1383,10 @@ packages:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
 
+  cron-parser@4.9.0:
+    resolution: {integrity: sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==}
+    engines: {node: '>=12.0.0'}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -1383,6 +1448,10 @@ packages:
   defu@6.1.7:
     resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
 
+  denque@2.1.0:
+    resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
+    engines: {node: '>=0.10'}
+
   destr@2.0.5:
     resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
 
@@ -1407,6 +1476,11 @@ packages:
 
   effect@3.21.0:
     resolution: {integrity: sha512-PPN80qRokCd1f015IANNhrwOnLO7GrrMQfk4/lnZRE/8j7UPWrNNjPV0uBrZutI/nHzernbW+J0hdqQysHiSnQ==}
+
+  ejs@5.0.2:
+    resolution: {integrity: sha512-IpbUaI/CAW86l3f+T8zN0iggSc0LmMZLcIW5eRVStLVNCoTXkE0YlncbbH50fp8Cl6zHIky0sW2uUbhBqGw0Jw==}
+    engines: {node: '>=0.12.18'}
+    hasBin: true
 
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
@@ -1776,6 +1850,10 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  hono@4.12.14:
+    resolution: {integrity: sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==}
+    engines: {node: '>=16.9.0'}
+
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
@@ -1807,6 +1885,10 @@ packages:
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  ioredis@5.10.1:
+    resolution: {integrity: sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==}
+    engines: {node: '>=12.22.0'}
 
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
@@ -2091,8 +2173,17 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  lodash.defaults@4.2.0:
+    resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
+
+  lodash.isarguments@3.1.0:
+    resolution: {integrity: sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==}
+
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
   log-update@6.1.0:
     resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
@@ -2107,6 +2198,10 @@ packages:
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
+  luxon@3.7.2:
+    resolution: {integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==}
+    engines: {node: '>=12'}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -2162,6 +2257,13 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  msgpackr-extract@3.0.3:
+    resolution: {integrity: sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==}
+    hasBin: true
+
+  msgpackr@1.11.5:
+    resolution: {integrity: sha512-UjkUHN0yqp9RWKy0Lplhh+wlpdt9oQBYgULZOiFhV3VclSF1JnSQWZ5r9gORQlNYaUKQoR8itv7g7z1xDDuACA==}
+
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -2200,12 +2302,19 @@ packages:
       sass:
         optional: true
 
+  node-abort-controller@3.1.1:
+    resolution: {integrity: sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==}
+
   node-exports-info@1.6.0:
     resolution: {integrity: sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==}
     engines: {node: '>= 0.4'}
 
   node-fetch-native@1.6.7:
     resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
+
+  node-gyp-build-optional-packages@5.2.2:
+    resolution: {integrity: sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==}
+    hasBin: true
 
   npm-run-path@5.3.0:
     resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
@@ -2514,6 +2623,17 @@ packages:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
 
+  redis-errors@1.2.0:
+    resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
+    engines: {node: '>=4'}
+
+  redis-info@3.1.0:
+    resolution: {integrity: sha512-ER4L9Sh/vm63DkIE0bkSjxluQlioBiBgf5w1UuldaW/3vPcecdljVDisZhmnCMvsxHNiARTTDDHGg9cGwTfrKg==}
+
+  redis-parser@3.0.0:
+    resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
+    engines: {node: '>=4'}
+
   redis@4.7.1:
     resolution: {integrity: sha512-S1bJDnqLftzHXHP8JsT5II/CtHWQrASX5K96REjWjlmWKrviSOLWmM7QnRLstAWsu1VBBV1ffV6DzCvxNP0UJQ==}
 
@@ -2648,6 +2768,9 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  standard-as-callback@2.1.0:
+    resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
@@ -2835,6 +2958,10 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  uuid@11.1.0:
+    resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
+    hasBin: true
+
   vite-node@3.2.4:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
@@ -2992,6 +3119,22 @@ snapshots:
       '@babel/helper-validator-identifier': 7.28.5
 
   '@bcoe/v8-coverage@1.0.2': {}
+
+  '@bull-board/api@7.0.0(@bull-board/ui@7.0.0)':
+    dependencies:
+      '@bull-board/ui': 7.0.0
+      redis-info: 3.1.0
+
+  '@bull-board/hono@7.0.0(hono@4.12.14)':
+    dependencies:
+      '@bull-board/api': 7.0.0(@bull-board/ui@7.0.0)
+      '@bull-board/ui': 7.0.0
+      ejs: 5.0.2
+      hono: 4.12.14
+
+  '@bull-board/ui@7.0.0':
+    dependencies:
+      '@bull-board/api': 7.0.0(@bull-board/ui@7.0.0)
 
   '@emnapi/core@1.9.2':
     dependencies:
@@ -3241,6 +3384,8 @@ snapshots:
   '@img/sharp-win32-x64@0.34.5':
     optional: true
 
+  '@ioredis/commands@1.5.1': {}
+
   '@isaacs/cliui@8.0.2':
     dependencies:
       string-width: 5.1.2
@@ -3270,6 +3415,24 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3':
+    optional: true
 
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
@@ -3932,6 +4095,18 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
+  bullmq@5.74.1:
+    dependencies:
+      cron-parser: 4.9.0
+      ioredis: 5.10.1
+      msgpackr: 1.11.5
+      node-abort-controller: 3.1.1
+      semver: 7.7.4
+      tslib: 2.8.1
+      uuid: 11.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   c12@3.1.0(magicast@0.3.5):
     dependencies:
       chokidar: 4.0.3
@@ -4028,6 +4203,10 @@ snapshots:
 
   consola@3.4.2: {}
 
+  cron-parser@4.9.0:
+    dependencies:
+      luxon: 3.7.2
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -4084,6 +4263,8 @@ snapshots:
 
   defu@6.1.7: {}
 
+  denque@2.1.0: {}
+
   destr@2.0.5: {}
 
   detect-libc@2.1.2: {}
@@ -4106,6 +4287,8 @@ snapshots:
     dependencies:
       '@standard-schema/spec': 1.1.0
       fast-check: 3.23.2
+
+  ejs@5.0.2: {}
 
   emoji-regex@10.6.0: {}
 
@@ -4645,6 +4828,8 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hono@4.12.14: {}
+
   html-escaper@2.0.2: {}
 
   human-signals@5.0.0: {}
@@ -4667,6 +4852,20 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.2
       side-channel: 1.1.0
+
+  ioredis@5.10.1:
+    dependencies:
+      '@ioredis/commands': 1.5.1
+      cluster-key-slot: 1.1.2
+      debug: 4.4.3
+      denque: 2.1.0
+      lodash.defaults: 4.2.0
+      lodash.isarguments: 3.1.0
+      redis-errors: 1.2.0
+      redis-parser: 3.0.0
+      standard-as-callback: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
 
   is-array-buffer@3.0.5:
     dependencies:
@@ -4953,7 +5152,13 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  lodash.defaults@4.2.0: {}
+
+  lodash.isarguments@3.1.0: {}
+
   lodash.merge@4.6.2: {}
+
+  lodash@4.18.1: {}
 
   log-update@6.1.0:
     dependencies:
@@ -4970,6 +5175,8 @@ snapshots:
   loupe@3.2.1: {}
 
   lru-cache@10.4.3: {}
+
+  luxon@3.7.2: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -5018,6 +5225,22 @@ snapshots:
 
   ms@2.1.3: {}
 
+  msgpackr-extract@3.0.3:
+    dependencies:
+      node-gyp-build-optional-packages: 5.2.2
+    optionalDependencies:
+      '@msgpackr-extract/msgpackr-extract-darwin-arm64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-darwin-x64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-linux-arm': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-linux-arm64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-linux-x64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-win32-x64': 3.0.3
+    optional: true
+
+  msgpackr@1.11.5:
+    optionalDependencies:
+      msgpackr-extract: 3.0.3
+
   nanoid@3.3.11: {}
 
   napi-postinstall@0.3.4: {}
@@ -5052,6 +5275,8 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
+  node-abort-controller@3.1.1: {}
+
   node-exports-info@1.6.0:
     dependencies:
       array.prototype.flatmap: 1.3.3
@@ -5060,6 +5285,11 @@ snapshots:
       semver: 6.3.1
 
   node-fetch-native@1.6.7: {}
+
+  node-gyp-build-optional-packages@5.2.2:
+    dependencies:
+      detect-libc: 2.1.2
+    optional: true
 
   npm-run-path@5.3.0:
     dependencies:
@@ -5297,6 +5527,16 @@ snapshots:
 
   readdirp@4.1.2: {}
 
+  redis-errors@1.2.0: {}
+
+  redis-info@3.1.0:
+    dependencies:
+      lodash: 4.18.1
+
+  redis-parser@3.0.0:
+    dependencies:
+      redis-errors: 1.2.0
+
   redis@4.7.1:
     dependencies:
       '@redis/bloom': 1.2.0(@redis/client@1.6.1)
@@ -5517,6 +5757,8 @@ snapshots:
   stable-hash@0.0.5: {}
 
   stackback@0.0.2: {}
+
+  standard-as-callback@2.1.0: {}
 
   std-env@3.10.0: {}
 
@@ -5750,6 +5992,8 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  uuid@11.1.0: {}
 
   vite-node@3.2.4(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:

--- a/prisma/extensions/encrypted-fields.ts
+++ b/prisma/extensions/encrypted-fields.ts
@@ -17,7 +17,11 @@ const ENCRYPTED_MODELS: Record<string, string[]> = {
 /**
  * 暗号化対象フィールドを Buffer（pgcrypto バイト列）に変換する
  */
-function encryptFields(modelName: string, data: Record<string, unknown>, encryptionKey: string): Record<string, unknown> {
+function encryptFields(
+  modelName: string,
+  data: Record<string, unknown>,
+  _encryptionKey: string,
+): Record<string, unknown> {
   const fields = ENCRYPTED_MODELS[modelName.toLowerCase()] ?? []
   const result = { ...data }
   for (const field of fields) {
@@ -62,13 +66,21 @@ export function createEncryptedExtension(encryptionKey: string) {
     query: {
       user: {
         async create({ args, query }) {
-          args.data = encryptFields('user', args.data as Record<string, unknown>, encryptionKey) as typeof args.data
+          args.data = encryptFields(
+            'user',
+            args.data as Record<string, unknown>,
+            encryptionKey,
+          ) as typeof args.data
           const result = await query(args)
           return decryptFields('user', result as Record<string, unknown>) as typeof result
         },
         async update({ args, query }) {
           if (args.data) {
-            args.data = encryptFields('user', args.data as Record<string, unknown>, encryptionKey) as typeof args.data
+            args.data = encryptFields(
+              'user',
+              args.data as Record<string, unknown>,
+              encryptionKey,
+            ) as typeof args.data
           }
           const result = await query(args)
           return decryptFields('user', result as Record<string, unknown>) as typeof result
@@ -85,18 +97,28 @@ export function createEncryptedExtension(encryptionKey: string) {
         },
         async findMany({ args, query }) {
           const results = await query(args)
-          return (results as Record<string, unknown>[]).map((r) => decryptFields('user', r)) as typeof results
+          return (results as Record<string, unknown>[]).map((r) =>
+            decryptFields('user', r),
+          ) as typeof results
         },
       },
       profile: {
         async create({ args, query }) {
-          args.data = encryptFields('profile', args.data as Record<string, unknown>, encryptionKey) as typeof args.data
+          args.data = encryptFields(
+            'profile',
+            args.data as Record<string, unknown>,
+            encryptionKey,
+          ) as typeof args.data
           const result = await query(args)
           return decryptFields('profile', result as Record<string, unknown>) as typeof result
         },
         async update({ args, query }) {
           if (args.data) {
-            args.data = encryptFields('profile', args.data as Record<string, unknown>, encryptionKey) as typeof args.data
+            args.data = encryptFields(
+              'profile',
+              args.data as Record<string, unknown>,
+              encryptionKey,
+            ) as typeof args.data
           }
           const result = await query(args)
           return decryptFields('profile', result as Record<string, unknown>) as typeof result
@@ -113,7 +135,9 @@ export function createEncryptedExtension(encryptionKey: string) {
         },
         async findMany({ args, query }) {
           const results = await query(args)
-          return (results as Record<string, unknown>[]).map((r) => decryptFields('profile', r)) as typeof results
+          return (results as Record<string, unknown>[]).map((r) =>
+            decryptFields('profile', r),
+          ) as typeof results
         },
       },
     },

--- a/src/lib/access-log/access-log-middleware.ts
+++ b/src/lib/access-log/access-log-middleware.ts
@@ -9,7 +9,7 @@ export interface AccessLogMiddleware {
 }
 
 function extractIp(req: NextRequest): string {
-  return req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ?? req.ip ?? 'unknown'
+  return req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ?? 'unknown'
 }
 
 function extractRequestId(req: NextRequest): string {

--- a/src/lib/access-log/access-log-middleware.ts
+++ b/src/lib/access-log/access-log-middleware.ts
@@ -9,7 +9,11 @@ export interface AccessLogMiddleware {
 }
 
 function extractIp(req: NextRequest): string {
-  return req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ?? 'unknown'
+  return (
+    req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ??
+    req.headers.get('x-real-ip') ??
+    'unknown'
+  )
 }
 
 function extractRequestId(req: NextRequest): string {

--- a/src/lib/audit/audit-log-emitter.ts
+++ b/src/lib/audit/audit-log-emitter.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from '@prisma/client'
+import { Prisma, PrismaClient } from '@prisma/client'
 import type { AuditLogEntry } from './audit-log-types'
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -35,8 +35,8 @@ class PrismaAuditLogEmitter implements AuditLogEmitter {
           resourceId: entry.resourceId,
           ipAddress: entry.ipAddress,
           userAgent: entry.userAgent,
-          before: entry.before,
-          after: entry.after,
+          before: entry.before != null ? (entry.before as Prisma.InputJsonValue) : undefined,
+          after: entry.after != null ? (entry.after as Prisma.InputJsonValue) : undefined,
         },
       })
     } catch {

--- a/src/lib/jobs/base-worker.ts
+++ b/src/lib/jobs/base-worker.ts
@@ -1,0 +1,47 @@
+import { Worker, type Processor } from 'bullmq'
+import { createRedisConnection } from './redis-connection'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 定数
+// ─────────────────────────────────────────────────────────────────────────────
+
+const DEFAULT_CONCURRENCY = 5
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Factory
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * BullMQ Worker の共通基盤。
+ * - 指定されたキュー名でワーカーを起動
+ * - completed / failed / error イベントハンドラを自動登録
+ * - 各ドメインワーカーはこの関数でラップして独自 Processor を渡す
+ */
+export function createBaseWorker(
+  queueName: string,
+  processor: Processor,
+  concurrency: number = DEFAULT_CONCURRENCY,
+): Worker {
+  const worker = new Worker(queueName, processor, {
+    connection: createRedisConnection(),
+    concurrency,
+  })
+
+  worker.on('completed', (job) => {
+    // 本番では構造化ロガーに転送する
+    void job
+  })
+
+  worker.on('failed', (job, err) => {
+    // DLQ 監視: 最大リトライ後も失敗した場合のフック
+    void job
+    void err
+  })
+
+  worker.on('error', (err) => {
+    // Redis 接続断など Worker レベルのエラー
+    void err
+  })
+
+  return worker
+}

--- a/src/lib/jobs/job-queue.ts
+++ b/src/lib/jobs/job-queue.ts
@@ -1,7 +1,7 @@
 import { Queue } from 'bullmq'
 import { createRedisConnection } from './redis-connection'
-import type { JobName, JobPayloadMap, JobStatus, JobState } from './job-types'
-import { isJobName } from './job-types'
+import type { JobName, JobPayloadMap, JobStatus } from './job-types'
+import { jobPayloadSchema } from './job-types'
 
 // ─────────────────────────────────────────────────────────────────────────────
 // 定数
@@ -42,6 +42,8 @@ class BullMQJobQueue implements JobQueue {
   }
 
   async enqueue<N extends JobName>(name: N, payload: JobPayloadMap[N]): Promise<string> {
+    // 境界バリデーション: 不正ペイロードがキューに投入されないよう実行時に検証する
+    jobPayloadSchema[name].parse(payload)
     const job = await this.queue.add(name, payload, DEFAULT_JOB_OPTIONS)
     if (!job.id) throw new Error(`BullMQ did not return a job id for "${name}"`)
     return job.id
@@ -51,10 +53,10 @@ class BullMQJobQueue implements JobQueue {
     const job = await this.queue.getJob(jobId)
     if (!job) return null
 
-    const state = (await job.getState()) as JobState
+    const state = await job.getState()
     return {
       jobId: job.id ?? jobId,
-      name: isJobName(job.name) ? job.name : 'send-email',
+      name: job.name,
       state,
       returnValue: job.returnvalue,
       failedReason: job.failedReason ?? null,

--- a/src/lib/jobs/job-queue.ts
+++ b/src/lib/jobs/job-queue.ts
@@ -1,0 +1,80 @@
+import { Queue } from 'bullmq'
+import { createRedisConnection } from './redis-connection'
+import type { JobName, JobPayloadMap, JobStatus, JobState } from './job-types'
+import { isJobName } from './job-types'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 定数
+// ─────────────────────────────────────────────────────────────────────────────
+
+const QUEUE_NAME = 'hr-main'
+
+/** 指数バックオフリトライ設定（Requirement 20.4） */
+const DEFAULT_JOB_OPTIONS = {
+  attempts: 3,
+  backoff: {
+    type: 'exponential' as const,
+    delay: 1_000, // 初回: 1s, 2回目: 2s, 3回目: 4s
+  },
+  removeOnComplete: { count: 1_000 },
+  removeOnFail: { count: 5_000 },
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Interface
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface JobQueue {
+  enqueue<N extends JobName>(name: N, payload: JobPayloadMap[N]): Promise<string>
+  getJobStatus(jobId: string): Promise<JobStatus | null>
+  close(): Promise<void>
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Implementation
+// ─────────────────────────────────────────────────────────────────────────────
+
+class BullMQJobQueue implements JobQueue {
+  private readonly queue: Queue
+
+  constructor(queue: Queue) {
+    this.queue = queue
+  }
+
+  async enqueue<N extends JobName>(name: N, payload: JobPayloadMap[N]): Promise<string> {
+    const job = await this.queue.add(name, payload, DEFAULT_JOB_OPTIONS)
+    if (!job.id) throw new Error(`BullMQ did not return a job id for "${name}"`)
+    return job.id
+  }
+
+  async getJobStatus(jobId: string): Promise<JobStatus | null> {
+    const job = await this.queue.getJob(jobId)
+    if (!job) return null
+
+    const state = (await job.getState()) as JobState
+    return {
+      jobId: job.id ?? jobId,
+      name: isJobName(job.name) ? job.name : 'send-email',
+      state,
+      returnValue: job.returnvalue,
+      failedReason: job.failedReason ?? null,
+    }
+  }
+
+  async close(): Promise<void> {
+    await this.queue.close()
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Factory
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function createJobQueue(queue?: Queue): JobQueue {
+  return new BullMQJobQueue(
+    queue ??
+      new Queue(QUEUE_NAME, {
+        connection: createRedisConnection(),
+      }),
+  )
+}

--- a/src/lib/jobs/job-types.ts
+++ b/src/lib/jobs/job-types.ts
@@ -1,0 +1,74 @@
+import { z } from 'zod'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Job 名一覧
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const JOB_NAMES = [
+  'send-email',
+  'export-csv',
+  'import-csv',
+  'anonymize-user',
+  'ai-feedback-generation',
+] as const
+
+export type JobName = (typeof JOB_NAMES)[number]
+
+export function isJobName(value: unknown): value is JobName {
+  return typeof value === 'string' && (JOB_NAMES as readonly string[]).includes(value)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Job ペイロードスキーマ（ジョブ名ごとに型安全なスキーマ）
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const jobPayloadSchema = {
+  'send-email': z.object({
+    to: z.string().email(),
+    subject: z.string().min(1),
+    body: z.string().min(1),
+    templateId: z.string().optional(),
+    variables: z.record(z.string()).optional(),
+  }),
+
+  'export-csv': z.object({
+    resourceType: z.string().min(1),
+    requestedBy: z.string().min(1),
+    filters: z.record(z.unknown()).optional(),
+  }),
+
+  'import-csv': z.object({
+    resourceType: z.string().min(1),
+    fileUrl: z.string().url(),
+    requestedBy: z.string().min(1),
+  }),
+
+  'anonymize-user': z.object({
+    userId: z.string().min(1),
+    requestedBy: z.string().min(1),
+  }),
+
+  'ai-feedback-generation': z.object({
+    evaluationId: z.string().min(1),
+    prompt: z.string().min(1),
+    requestedBy: z.string().min(1),
+  }),
+} satisfies Record<JobName, z.ZodTypeAny>
+
+export type JobPayloadMap = {
+  [K in JobName]: z.infer<(typeof jobPayloadSchema)[K]>
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Job ステータス
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type JobState = 'waiting' | 'active' | 'completed' | 'failed' | 'delayed' | 'unknown'
+
+export interface JobStatus {
+  jobId: string
+  name: JobName
+  state: JobState
+  returnValue: unknown
+  failedReason: string | null
+}

--- a/src/lib/jobs/job-types.ts
+++ b/src/lib/jobs/job-types.ts
@@ -63,11 +63,20 @@ export type JobPayloadMap = {
 // Job ステータス
 // ─────────────────────────────────────────────────────────────────────────────
 
-export type JobState = 'waiting' | 'active' | 'completed' | 'failed' | 'delayed' | 'unknown'
+export type JobState =
+  | 'waiting'
+  | 'active'
+  | 'completed'
+  | 'failed'
+  | 'delayed'
+  | 'unknown'
+  | 'waiting-children'
+  | 'prioritized'
 
 export interface JobStatus {
   jobId: string
-  name: JobName
+  /** ジョブ名。未知の名前も含む可能性があるため string。呼び出し側で isJobName() により絞り込むこと */
+  name: string
   state: JobState
   returnValue: unknown
   failedReason: string | null

--- a/src/lib/jobs/redis-connection.ts
+++ b/src/lib/jobs/redis-connection.ts
@@ -1,0 +1,12 @@
+import { Redis } from 'ioredis'
+
+/**
+ * BullMQ 専用の Redis 接続を生成する。
+ * BullMQ は ioredis インスタンスを直接受け取る。
+ */
+export function createRedisConnection(): Redis {
+  const url = process.env.REDIS_URL ?? 'redis://localhost:6379'
+  return new Redis(url, {
+    maxRetriesPerRequest: null, // BullMQ 推奨設定
+  })
+}

--- a/src/lib/shared/error-mapper.ts
+++ b/src/lib/shared/error-mapper.ts
@@ -58,7 +58,7 @@ export function domainErrorToHttpStatus(error: DomainError): number {
 
     default: {
       // 網羅性チェック: すべての DomainError タグを処理済みであることを確認
-      const _exhaustive: never = error
+      void (error satisfies never)
       return 500
     }
   }
@@ -105,7 +105,7 @@ export function domainErrorToApiCode(error: DomainError): ApiErrorCode {
       return 'INTERNAL_ERROR'
 
     default: {
-      const _exhaustive: never = error
+      void (error satisfies never)
       return 'INTERNAL_ERROR'
     }
   }
@@ -151,7 +151,7 @@ export function domainErrorToMessage(error: DomainError): string {
     case 'RateLimited':
       return `レート制限に達しました。${error.retryAfterSec}秒後に再試行してください`
     default: {
-      const _exhaustive: never = error
+      void (error satisfies never)
       return '予期せぬエラーが発生しました'
     }
   }

--- a/src/tests/access-log/access-log-middleware.test.ts
+++ b/src/tests/access-log/access-log-middleware.test.ts
@@ -103,7 +103,7 @@ describe('createAccessLogMiddleware', () => {
         durationMs: expect.any(Number),
       }),
     )
-    const recorded = mockEmit.mock.calls[0][0]
+    const recorded = mockEmit.mock.calls[0]![0]
     expect(recorded.durationMs).toBeGreaterThanOrEqual(0)
   })
 

--- a/src/tests/audit/audit-log-emitter.test.ts
+++ b/src/tests/audit/audit-log-emitter.test.ts
@@ -53,8 +53,8 @@ describe('AuditLogEmitter', () => {
           resourceId: 'user-1',
           ipAddress: '127.0.0.1',
           userAgent: 'Mozilla/5.0',
-          before: null,
-          after: null,
+          before: undefined,
+          after: undefined,
         }),
       })
     })

--- a/src/tests/jobs/base-worker.test.ts
+++ b/src/tests/jobs/base-worker.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Worker } from 'bullmq'
+import { createBaseWorker } from '@/lib/jobs/base-worker'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// BullMQ Worker をモック
+// ─────────────────────────────────────────────────────────────────────────────
+
+const mockOn = vi.fn()
+const mockClose = vi.fn()
+
+vi.mock('bullmq', () => ({
+  Worker: vi.fn().mockImplementation((_name: string, _processor: unknown, _opts: unknown) => ({
+    on: mockOn,
+    close: mockClose,
+  })),
+}))
+
+vi.mock('@/lib/jobs/redis-connection', () => ({
+  createRedisConnection: vi.fn(() => ({})),
+}))
+
+const MockedWorker = vi.mocked(Worker)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('createBaseWorker', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockOn.mockReturnValue({ on: mockOn, close: mockClose })
+  })
+
+  it('should create a worker with the given queue name', () => {
+    const processor = vi.fn()
+    createBaseWorker('send-email', processor)
+    expect(MockedWorker).toHaveBeenCalledWith('send-email', processor, expect.any(Object))
+  })
+
+  it('should register failed and error event handlers', () => {
+    const processor = vi.fn()
+    createBaseWorker('send-email', processor)
+    const eventNames = mockOn.mock.calls.map((c) => c[0])
+    expect(eventNames).toContain('failed')
+    expect(eventNames).toContain('error')
+  })
+
+  it('should register completed event handler', () => {
+    const processor = vi.fn()
+    createBaseWorker('send-email', processor)
+    const eventNames = mockOn.mock.calls.map((c) => c[0])
+    expect(eventNames).toContain('completed')
+  })
+
+  it('should apply concurrency options', () => {
+    const processor = vi.fn()
+    createBaseWorker('send-email', processor)
+    const opts = MockedWorker.mock.calls[0]![2]
+    expect(opts).toMatchObject({
+      concurrency: expect.any(Number),
+    })
+  })
+})

--- a/src/tests/jobs/job-queue.test.ts
+++ b/src/tests/jobs/job-queue.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { createJobQueue, type JobQueue } from '@/lib/jobs/job-queue'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// BullMQ をモック
+// ─────────────────────────────────────────────────────────────────────────────
+
+const mockAdd = vi.fn()
+const mockGetJob = vi.fn()
+
+vi.mock('bullmq', () => ({
+  Queue: vi.fn().mockImplementation(() => ({
+    add: mockAdd,
+    getJob: mockGetJob,
+    close: vi.fn(),
+  })),
+}))
+
+vi.mock('@/lib/jobs/redis-connection', () => ({
+  createRedisConnection: vi.fn(() => ({})),
+}))
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('JobQueue', () => {
+  let queue: JobQueue
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAdd.mockResolvedValue({ id: 'job-1' })
+    mockGetJob.mockResolvedValue(null)
+    queue = createJobQueue()
+  })
+
+  describe('enqueue()', () => {
+    it('should enqueue a job and return a jobId', async () => {
+      const jobId = await queue.enqueue('send-email', {
+        to: 'user@example.com',
+        subject: 'Test',
+        body: 'Hello',
+      })
+      expect(jobId).toBe('job-1')
+      expect(mockAdd).toHaveBeenCalledOnce()
+    })
+
+    it('should pass the job name and payload to BullMQ', async () => {
+      await queue.enqueue('export-csv', { resourceType: 'USER', requestedBy: 'user-1' })
+      expect(mockAdd).toHaveBeenCalledWith(
+        'export-csv',
+        expect.objectContaining({ resourceType: 'USER', requestedBy: 'user-1' }),
+        expect.any(Object),
+      )
+    })
+
+    it('should apply exponential backoff retry options', async () => {
+      await queue.enqueue('send-email', { to: 'a@b.com', subject: 'S', body: 'B' })
+      const options = mockAdd.mock.calls[0]![2]
+      expect(options).toMatchObject({
+        attempts: expect.any(Number),
+        backoff: expect.objectContaining({ type: 'exponential' }),
+      })
+      expect(options.attempts).toBeGreaterThanOrEqual(3)
+    })
+  })
+
+  describe('getJobStatus()', () => {
+    it('should return null when job does not exist', async () => {
+      mockGetJob.mockResolvedValue(null)
+      const status = await queue.getJobStatus('nonexistent')
+      expect(status).toBeNull()
+    })
+
+    it('should return job status when job exists', async () => {
+      mockGetJob.mockResolvedValue({
+        id: 'job-1',
+        name: 'send-email',
+        data: {},
+        getState: vi.fn().mockResolvedValue('completed'),
+        returnvalue: { success: true },
+        failedReason: null,
+      })
+      const status = await queue.getJobStatus('job-1')
+      expect(status).not.toBeNull()
+      expect(status?.state).toBe('completed')
+      expect(status?.jobId).toBe('job-1')
+    })
+  })
+})

--- a/src/tests/jobs/job-types.test.ts
+++ b/src/tests/jobs/job-types.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest'
+import { JOB_NAMES, isJobName, jobPayloadSchema } from '@/lib/jobs/job-types'
+
+describe('JOB_NAMES', () => {
+  it('should include email sending job', () => {
+    expect(JOB_NAMES).toContain('send-email')
+  })
+
+  it('should include csv export job', () => {
+    expect(JOB_NAMES).toContain('export-csv')
+  })
+
+  it('should include csv import job', () => {
+    expect(JOB_NAMES).toContain('import-csv')
+  })
+})
+
+describe('isJobName()', () => {
+  it('should return true for valid job names', () => {
+    expect(isJobName('send-email')).toBe(true)
+    expect(isJobName('export-csv')).toBe(true)
+  })
+
+  it('should return false for unknown names', () => {
+    expect(isJobName('unknown-job')).toBe(false)
+    expect(isJobName('')).toBe(false)
+    expect(isJobName(null)).toBe(false)
+  })
+})
+
+describe('jobPayloadSchema', () => {
+  it('should validate send-email payload', () => {
+    const result = jobPayloadSchema['send-email'].safeParse({
+      to: 'user@example.com',
+      subject: 'Hello',
+      body: 'World',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('should reject send-email payload with invalid email', () => {
+    const result = jobPayloadSchema['send-email'].safeParse({
+      to: 'not-an-email',
+      subject: 'Hello',
+      body: 'World',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('should validate export-csv payload', () => {
+    const result = jobPayloadSchema['export-csv'].safeParse({
+      resourceType: 'USER',
+      requestedBy: 'user-1',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('should validate import-csv payload', () => {
+    const result = jobPayloadSchema['import-csv'].safeParse({
+      resourceType: 'USER',
+      fileUrl: 'https://storage.example.com/upload.csv',
+      requestedBy: 'user-1',
+    })
+    expect(result.success).toBe(true)
+  })
+})

--- a/src/tests/shared/domain-error.test.ts
+++ b/src/tests/shared/domain-error.test.ts
@@ -5,7 +5,7 @@ import { describe, it, expect } from 'vitest'
 
 describe('DomainError 型', () => {
   it('ValidationError が正しく生成できる', async () => {
-    const { ok, err } = await import('@/lib/shared/domain-error')
+    const { err } = await import('@/lib/shared/domain-error')
     const error = err({ _tag: 'ValidationError', field: 'email', message: 'メールが不正です' })
     expect(error.isOk()).toBe(false)
     if (error.isErr()) {


### PR DESCRIPTION
## Summary

- `bullmq` / `ioredis` / `@bull-board/api` / `@bull-board/hono` を追加
- `src/lib/jobs/job-types.ts`: `JobName` 一覧・型安全なペイロードスキーマ（`send-email` / `export-csv` / `import-csv` 等）・`JobStatus` 型を定義
- `src/lib/jobs/redis-connection.ts`: BullMQ 推奨設定（`maxRetriesPerRequest: null`）で Redis 接続を生成
- `src/lib/jobs/job-queue.ts`: `enqueue()`（指数バックオフ 3 回リトライ）/ `getJobStatus()` を実装（Req 20.4）
- `src/lib/jobs/base-worker.ts`: `completed` / `failed` / `error` イベントハンドラ付き共通 Worker ファクトリ（各ドメインワーカーが継承）

## Test plan

- [x] `job-types.test.ts` — JOB_NAMES・isJobName・jobPayloadSchema の検証（9 tests）
- [x] `job-queue.test.ts` — enqueue / 指数バックオフオプション / getJobStatus（5 tests）
- [x] `base-worker.test.ts` — Worker 生成・イベントハンドラ登録・concurrency 設定（4 tests）
- [x] 171 tests passing / `npm run type-check` エラー 0

Closes #8