### PR TITLE
feat: Task 3.3 — 共通 ImportJob の実装

### DIFF
--- a/src/lib/import/import-job.ts
+++ b/src/lib/import/import-job.ts
@@ -1,0 +1,81 @@
+import type { JobQueue } from '@/lib/jobs/job-queue'
+import { createJobQueue } from '@/lib/jobs/job-queue'
+import type { ImportJobId, ImportJobStatus, ImportRequest, ImportResult } from './import-types'
+import { importResultSchema } from './import-types'
+import type { JobState } from '@/lib/jobs/job-types'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// BullMQ JobState → ImportJobStatus マッピング
+// ─────────────────────────────────────────────────────────────────────────────
+
+function toImportStatus(state: JobState): ImportJobStatus {
+  switch (state) {
+    case 'waiting':
+    case 'waiting-children':
+    case 'delayed':
+    case 'prioritized':
+      return 'queued'
+    case 'active':
+      return 'processing'
+    case 'completed':
+      return 'ready'
+    case 'failed':
+    case 'unknown':
+      return 'failed'
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Interface
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface ImportJob {
+  /** インポートジョブをキューに投入し、jobId を返す */
+  enqueue(request: ImportRequest): Promise<{ jobId: ImportJobId }>
+
+  /** ジョブのステータスを返す（存在しない場合は null） */
+  getStatus(jobId: ImportJobId): Promise<ImportJobStatus | null>
+
+  /**
+   * 完了済みジョブの結果を返す
+   * ジョブが存在しない・未完了・結果が不正な場合は null
+   */
+  getResult(jobId: ImportJobId): Promise<ImportResult | null>
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Implementation
+// ─────────────────────────────────────────────────────────────────────────────
+
+class BullMQImportJob implements ImportJob {
+  constructor(private readonly queue: JobQueue) {}
+
+  async enqueue(request: ImportRequest): Promise<{ jobId: ImportJobId }> {
+    const jobId = await this.queue.enqueue('import-csv', request)
+    return { jobId: jobId as ImportJobId }
+  }
+
+  async getStatus(jobId: ImportJobId): Promise<ImportJobStatus | null> {
+    const status = await this.queue.getJobStatus(jobId)
+    if (!status) return null
+    return toImportStatus(status.state)
+  }
+
+  async getResult(jobId: ImportJobId): Promise<ImportResult | null> {
+    const status = await this.queue.getJobStatus(jobId)
+    if (!status || status.state !== 'completed') return null
+
+    const parsed = importResultSchema.safeParse(status.returnValue)
+    if (!parsed.success) return null
+
+    return parsed.data
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Factory
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function createImportJob(queue?: JobQueue): ImportJob {
+  return new BullMQImportJob(queue ?? createJobQueue())
+}

--- a/src/lib/import/import-types.ts
+++ b/src/lib/import/import-types.ts
@@ -1,0 +1,77 @@
+import { z } from 'zod'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ImportJobId（ブランド型）
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** インポートジョブID（BullMQ が発行する文字列 jobId のエイリアス） */
+export type ImportJobId = string
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ImportJobStatus
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const IMPORT_JOB_STATUSES = ['queued', 'processing', 'ready', 'failed'] as const
+export type ImportJobStatus = (typeof IMPORT_JOB_STATUSES)[number]
+
+export function isImportJobStatus(value: unknown): value is ImportJobStatus {
+  return typeof value === 'string' && (IMPORT_JOB_STATUSES as readonly string[]).includes(value)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ImportRequest スキーマ（各ドメインのバリアント）
+// ─────────────────────────────────────────────────────────────────────────────
+
+const masterCsvSchema = z.object({
+  type: z.literal('MasterCsv'),
+  resource: z.string().min(1),
+})
+
+const employeeCsvSchema = z.object({
+  type: z.literal('EmployeeCsv'),
+})
+
+export const importRequestSchema = z.discriminatedUnion('type', [
+  masterCsvSchema,
+  employeeCsvSchema,
+])
+
+export type ImportRequest = z.infer<typeof importRequestSchema>
+
+export function isImportRequest(value: unknown): value is ImportRequest {
+  return importRequestSchema.safeParse(value).success
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ImportRowError（エラー行詳細）
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface ImportRowError {
+  rowNumber: number
+  field: string
+  message: string
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ImportResult（ワーカーの戻り値）
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface ImportResult {
+  totalRows: number
+  successCount: number
+  failureCount: number
+  errors: ImportRowError[]
+}
+
+export const importRowErrorSchema = z.object({
+  rowNumber: z.number().int().min(1),
+  field: z.string().min(1),
+  message: z.string().min(1),
+})
+
+export const importResultSchema = z.object({
+  totalRows: z.number().int().min(0),
+  successCount: z.number().int().min(0),
+  failureCount: z.number().int().min(0),
+  errors: z.array(importRowErrorSchema),
+})

--- a/src/lib/import/import-worker.ts
+++ b/src/lib/import/import-worker.ts
@@ -1,0 +1,44 @@
+import { type Job } from 'bullmq'
+import { isImportRequest } from './import-types'
+import type { ImportResult } from './import-types'
+import { createBaseWorker } from '@/lib/jobs/base-worker'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ジョブプロセッサ（テスト可能な純粋関数として分離）
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * import-csv ジョブを処理し、ImportResult を返す。
+ * 実際の CSV パースと DB 書き込みは各ドメインサービスが担当する予定。
+ */
+export async function processImportJob(job: Job): Promise<ImportResult> {
+  const payload = job.data as unknown
+
+  if (!isImportRequest(payload)) {
+    throw new Error(`ImportWorker: invalid payload for job "${job.id ?? 'unknown'}"`)
+  }
+
+  return processVariant(payload.type)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// バリアント別処理（スタブ実装）
+// 実際のデータ取得・バリデーションは各ドメインサービスが担当する予定
+// ─────────────────────────────────────────────────────────────────────────────
+
+function processVariant(type: 'MasterCsv' | 'EmployeeCsv'): ImportResult {
+  switch (type) {
+    case 'MasterCsv':
+      return { totalRows: 0, successCount: 0, failureCount: 0, errors: [] }
+    case 'EmployeeCsv':
+      return { totalRows: 0, successCount: 0, failureCount: 0, errors: [] }
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ワーカー起動ファクトリ
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function createImportWorker() {
+  return createBaseWorker('import-csv', (job: Job) => processImportJob(job))
+}

--- a/src/lib/jobs/job-types.ts
+++ b/src/lib/jobs/job-types.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod'
 import { exportRequestSchema } from '@/lib/export/export-types'
+import { importRequestSchema } from '@/lib/import/import-types'
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Job 名一覧
@@ -33,17 +34,8 @@ export const jobPayloadSchema = {
   }),
 
   'export-csv': exportRequestSchema,
-  'export-csv': z.object({
-    resourceType: z.string().min(1),
-    requestedBy: z.string().min(1),
-    filters: z.record(z.unknown()).optional(),
-  }),
 
-  'import-csv': z.object({
-    resourceType: z.string().min(1),
-    fileUrl: z.string().url(),
-    requestedBy: z.string().min(1),
-  }),
+  'import-csv': importRequestSchema,
 
   'anonymize-user': z.object({
     userId: z.string().min(1),

--- a/src/tests/import/import-job.test.ts
+++ b/src/tests/import/import-job.test.ts
@@ -1,0 +1,261 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { createImportJob } from '@/lib/import/import-job'
+import type { JobQueue } from '@/lib/jobs/job-queue'
+
+vi.mock('@/lib/jobs/redis-connection', () => ({
+  createRedisConnection: vi.fn(() => ({})),
+}))
+vi.mock('bullmq', () => ({
+  Queue: vi.fn().mockImplementation(() => ({
+    add: vi.fn().mockResolvedValue({ id: 'job-123' }),
+    getJob: vi.fn().mockResolvedValue(null),
+    close: vi.fn(),
+  })),
+  Worker: vi.fn().mockImplementation(() => ({ on: vi.fn(), close: vi.fn() })),
+}))
+
+// ─────────────────────────────────────────────────────────────────────────────
+// モック
+// ─────────────────────────────────────────────────────────────────────────────
+
+type QueueMock = {
+  enqueue: ReturnType<typeof vi.fn>
+  getJobStatus: ReturnType<typeof vi.fn>
+  close: ReturnType<typeof vi.fn>
+}
+
+function makeQueueMock(): QueueMock & JobQueue {
+  return {
+    enqueue: vi.fn().mockResolvedValue('job-123'),
+    getJobStatus: vi.fn().mockResolvedValue(null),
+    close: vi.fn().mockResolvedValue(undefined),
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('ImportJob', () => {
+  let queueMock: QueueMock & JobQueue
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    queueMock = makeQueueMock()
+  })
+
+  describe('enqueue()', () => {
+    it('should enqueue an import-csv job and return jobId', async () => {
+      const importJob = createImportJob(queueMock)
+      const { jobId } = await importJob.enqueue({ type: 'EmployeeCsv' })
+      expect(jobId).toBe('job-123')
+      expect(queueMock.enqueue).toHaveBeenCalledOnce()
+    })
+
+    it('should pass MasterCsv request as part of payload', async () => {
+      const importJob = createImportJob(queueMock)
+      await importJob.enqueue({ type: 'MasterCsv', resource: 'DEPARTMENT' })
+      expect(queueMock.enqueue).toHaveBeenCalledWith(
+        'import-csv',
+        expect.objectContaining({ type: 'MasterCsv', resource: 'DEPARTMENT' }),
+      )
+    })
+
+    it('should pass EmployeeCsv request as part of payload', async () => {
+      const importJob = createImportJob(queueMock)
+      await importJob.enqueue({ type: 'EmployeeCsv' })
+      expect(queueMock.enqueue).toHaveBeenCalledWith(
+        'import-csv',
+        expect.objectContaining({ type: 'EmployeeCsv' }),
+      )
+    })
+  })
+
+  describe('getStatus()', () => {
+    it('should return null when job does not exist', async () => {
+      queueMock.getJobStatus.mockResolvedValue(null)
+      const importJob = createImportJob(queueMock)
+      const status = await importJob.getStatus('nonexistent')
+      expect(status).toBeNull()
+    })
+
+    it('should return "queued" when job state is waiting', async () => {
+      queueMock.getJobStatus.mockResolvedValue({
+        jobId: 'job-1',
+        name: 'import-csv',
+        state: 'waiting',
+        returnValue: null,
+        failedReason: null,
+      })
+      const importJob = createImportJob(queueMock)
+      expect(await importJob.getStatus('job-1')).toBe('queued')
+    })
+
+    it('should return "queued" when job state is waiting-children', async () => {
+      queueMock.getJobStatus.mockResolvedValue({
+        jobId: 'job-1',
+        name: 'import-csv',
+        state: 'waiting-children',
+        returnValue: null,
+        failedReason: null,
+      })
+      const importJob = createImportJob(queueMock)
+      expect(await importJob.getStatus('job-1')).toBe('queued')
+    })
+
+    it('should return "queued" when job state is delayed', async () => {
+      queueMock.getJobStatus.mockResolvedValue({
+        jobId: 'job-1',
+        name: 'import-csv',
+        state: 'delayed',
+        returnValue: null,
+        failedReason: null,
+      })
+      const importJob = createImportJob(queueMock)
+      expect(await importJob.getStatus('job-1')).toBe('queued')
+    })
+
+    it('should return "queued" when job state is prioritized', async () => {
+      queueMock.getJobStatus.mockResolvedValue({
+        jobId: 'job-1',
+        name: 'import-csv',
+        state: 'prioritized',
+        returnValue: null,
+        failedReason: null,
+      })
+      const importJob = createImportJob(queueMock)
+      expect(await importJob.getStatus('job-1')).toBe('queued')
+    })
+
+    it('should return "processing" when job state is active', async () => {
+      queueMock.getJobStatus.mockResolvedValue({
+        jobId: 'job-1',
+        name: 'import-csv',
+        state: 'active',
+        returnValue: null,
+        failedReason: null,
+      })
+      const importJob = createImportJob(queueMock)
+      expect(await importJob.getStatus('job-1')).toBe('processing')
+    })
+
+    it('should return "ready" when job state is completed', async () => {
+      queueMock.getJobStatus.mockResolvedValue({
+        jobId: 'job-1',
+        name: 'import-csv',
+        state: 'completed',
+        returnValue: { totalRows: 10, successCount: 10, failureCount: 0, errors: [] },
+        failedReason: null,
+      })
+      const importJob = createImportJob(queueMock)
+      expect(await importJob.getStatus('job-1')).toBe('ready')
+    })
+
+    it('should return "failed" when job state is failed', async () => {
+      queueMock.getJobStatus.mockResolvedValue({
+        jobId: 'job-1',
+        name: 'import-csv',
+        state: 'failed',
+        returnValue: null,
+        failedReason: 'something went wrong',
+      })
+      const importJob = createImportJob(queueMock)
+      expect(await importJob.getStatus('job-1')).toBe('failed')
+    })
+
+    it('should return "failed" when job state is unknown', async () => {
+      queueMock.getJobStatus.mockResolvedValue({
+        jobId: 'job-1',
+        name: 'import-csv',
+        state: 'unknown',
+        returnValue: null,
+        failedReason: null,
+      })
+      const importJob = createImportJob(queueMock)
+      expect(await importJob.getStatus('job-1')).toBe('failed')
+    })
+  })
+
+  describe('getResult()', () => {
+    it('should return null when job does not exist', async () => {
+      queueMock.getJobStatus.mockResolvedValue(null)
+      const importJob = createImportJob(queueMock)
+      expect(await importJob.getResult('nonexistent')).toBeNull()
+    })
+
+    it('should return null when job is not completed', async () => {
+      queueMock.getJobStatus.mockResolvedValue({
+        jobId: 'job-1',
+        name: 'import-csv',
+        state: 'active',
+        returnValue: null,
+        failedReason: null,
+      })
+      const importJob = createImportJob(queueMock)
+      expect(await importJob.getResult('job-1')).toBeNull()
+    })
+
+    it('should return null when returnValue is null', async () => {
+      queueMock.getJobStatus.mockResolvedValue({
+        jobId: 'job-1',
+        name: 'import-csv',
+        state: 'completed',
+        returnValue: null,
+        failedReason: null,
+      })
+      const importJob = createImportJob(queueMock)
+      expect(await importJob.getResult('job-1')).toBeNull()
+    })
+
+    it('should return null when returnValue has no required fields', async () => {
+      queueMock.getJobStatus.mockResolvedValue({
+        jobId: 'job-1',
+        name: 'import-csv',
+        state: 'completed',
+        returnValue: { someOtherField: 'value' },
+        failedReason: null,
+      })
+      const importJob = createImportJob(queueMock)
+      expect(await importJob.getResult('job-1')).toBeNull()
+    })
+
+    it('should return ImportResult when job completed with no errors', async () => {
+      const result = { totalRows: 5, successCount: 5, failureCount: 0, errors: [] }
+      queueMock.getJobStatus.mockResolvedValue({
+        jobId: 'job-1',
+        name: 'import-csv',
+        state: 'completed',
+        returnValue: result,
+        failedReason: null,
+      })
+      const importJob = createImportJob(queueMock)
+      const importResult = await importJob.getResult('job-1')
+      expect(importResult).not.toBeNull()
+      expect(importResult?.totalRows).toBe(5)
+      expect(importResult?.successCount).toBe(5)
+      expect(importResult?.failureCount).toBe(0)
+      expect(importResult?.errors).toHaveLength(0)
+    })
+
+    it('should return ImportResult with error details', async () => {
+      const result = {
+        totalRows: 3,
+        successCount: 2,
+        failureCount: 1,
+        errors: [{ rowNumber: 2, field: 'email', message: 'Invalid email format' }],
+      }
+      queueMock.getJobStatus.mockResolvedValue({
+        jobId: 'job-1',
+        name: 'import-csv',
+        state: 'completed',
+        returnValue: result,
+        failedReason: null,
+      })
+      const importJob = createImportJob(queueMock)
+      const importResult = await importJob.getResult('job-1')
+      expect(importResult?.failureCount).toBe(1)
+      expect(importResult?.errors[0]?.rowNumber).toBe(2)
+      expect(importResult?.errors[0]?.field).toBe('email')
+    })
+  })
+})

--- a/src/tests/import/import-types.test.ts
+++ b/src/tests/import/import-types.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest'
+import {
+  importRequestSchema,
+  isImportRequest,
+  IMPORT_JOB_STATUSES,
+  isImportJobStatus,
+} from '@/lib/import/import-types'
+
+describe('importRequestSchema', () => {
+  describe('MasterCsv バリアント', () => {
+    it('should accept valid MasterCsv payload', () => {
+      const result = importRequestSchema.safeParse({ type: 'MasterCsv', resource: 'DEPARTMENT' })
+      expect(result.success).toBe(true)
+    })
+
+    it('should reject MasterCsv without resource', () => {
+      const result = importRequestSchema.safeParse({ type: 'MasterCsv' })
+      expect(result.success).toBe(false)
+    })
+
+    it('should reject MasterCsv with empty resource', () => {
+      const result = importRequestSchema.safeParse({ type: 'MasterCsv', resource: '' })
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('EmployeeCsv バリアント', () => {
+    it('should accept valid EmployeeCsv payload', () => {
+      const result = importRequestSchema.safeParse({ type: 'EmployeeCsv' })
+      expect(result.success).toBe(true)
+    })
+  })
+
+  it('should reject unknown type', () => {
+    const result = importRequestSchema.safeParse({ type: 'UnknownType' })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('isImportRequest()', () => {
+  it('should return true for valid MasterCsv', () => {
+    expect(isImportRequest({ type: 'MasterCsv', resource: 'POSITION' })).toBe(true)
+  })
+
+  it('should return true for valid EmployeeCsv', () => {
+    expect(isImportRequest({ type: 'EmployeeCsv' })).toBe(true)
+  })
+
+  it('should return false for null', () => {
+    expect(isImportRequest(null)).toBe(false)
+  })
+
+  it('should return false for unknown type', () => {
+    expect(isImportRequest({ type: 'Unknown' })).toBe(false)
+  })
+})
+
+describe('IMPORT_JOB_STATUSES', () => {
+  it('should contain the four expected statuses', () => {
+    expect(IMPORT_JOB_STATUSES).toContain('queued')
+    expect(IMPORT_JOB_STATUSES).toContain('processing')
+    expect(IMPORT_JOB_STATUSES).toContain('ready')
+    expect(IMPORT_JOB_STATUSES).toContain('failed')
+  })
+})
+
+describe('isImportJobStatus()', () => {
+  it('should return true for valid statuses', () => {
+    expect(isImportJobStatus('queued')).toBe(true)
+    expect(isImportJobStatus('processing')).toBe(true)
+    expect(isImportJobStatus('ready')).toBe(true)
+    expect(isImportJobStatus('failed')).toBe(true)
+  })
+
+  it('should return false for invalid status', () => {
+    expect(isImportJobStatus('unknown-status')).toBe(false)
+  })
+
+  it('should return false for non-string', () => {
+    expect(isImportJobStatus(42)).toBe(false)
+  })
+})

--- a/src/tests/import/import-worker.test.ts
+++ b/src/tests/import/import-worker.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { processImportJob } from '@/lib/import/import-worker'
+
+vi.mock('@/lib/jobs/redis-connection', () => ({
+  createRedisConnection: vi.fn(() => ({})),
+}))
+vi.mock('bullmq', () => ({
+  Queue: vi.fn().mockImplementation(() => ({
+    add: vi.fn().mockResolvedValue({ id: 'job-abc' }),
+    getJob: vi.fn().mockResolvedValue(null),
+    close: vi.fn(),
+  })),
+  Worker: vi.fn().mockImplementation(() => ({ on: vi.fn(), close: vi.fn() })),
+}))
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ヘルパー
+// ─────────────────────────────────────────────────────────────────────────────
+
+function makeJob(data: Record<string, unknown>, id = 'job-abc') {
+  return { id, data } as unknown as Parameters<typeof processImportJob>[0]
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('processImportJob()', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should process MasterCsv and return ImportResult', async () => {
+    const job = makeJob({ type: 'MasterCsv', resource: 'DEPARTMENT' })
+    const result = await processImportJob(job)
+    expect(result.totalRows).toBeGreaterThanOrEqual(0)
+    expect(result.successCount).toBeGreaterThanOrEqual(0)
+    expect(result.failureCount).toBeGreaterThanOrEqual(0)
+    expect(Array.isArray(result.errors)).toBe(true)
+  })
+
+  it('should process EmployeeCsv and return ImportResult', async () => {
+    const job = makeJob({ type: 'EmployeeCsv' })
+    const result = await processImportJob(job)
+    expect(result.totalRows).toBeGreaterThanOrEqual(0)
+    expect(Array.isArray(result.errors)).toBe(true)
+  })
+
+  it('should throw for unknown import type', async () => {
+    const job = makeJob({ type: 'UnknownType' })
+    await expect(processImportJob(job)).rejects.toThrow()
+  })
+
+  it('should satisfy totalRows = successCount + failureCount invariant for MasterCsv', async () => {
+    const job = makeJob({ type: 'MasterCsv', resource: 'POSITION' })
+    const result = await processImportJob(job)
+    expect(result.successCount + result.failureCount).toBe(result.totalRows)
+  })
+
+  it('should satisfy totalRows = successCount + failureCount invariant for EmployeeCsv', async () => {
+    const job = makeJob({ type: 'EmployeeCsv' })
+    const result = await processImportJob(job)
+    expect(result.successCount + result.failureCount).toBe(result.totalRows)
+  })
+
+  it('should satisfy errors.length equals failureCount', async () => {
+    const job = makeJob({ type: 'MasterCsv', resource: 'DEPARTMENT' })
+    const result = await processImportJob(job)
+    expect(result.errors).toHaveLength(result.failureCount)
+  })
+
+  it('should use "unknown" as fallback when job.id is undefined', async () => {
+    const job = { id: undefined, data: { type: 'EmployeeCsv' } } as unknown as Parameters<
+      typeof processImportJob
+    >[0]
+    const result = await processImportJob(job)
+    expect(result.totalRows).toBeGreaterThanOrEqual(0)
+  })
+})

--- a/src/tests/jobs/job-queue.test.ts
+++ b/src/tests/jobs/job-queue.test.ts
@@ -46,10 +46,10 @@ describe('JobQueue', () => {
     })
 
     it('should pass the job name and payload to BullMQ', async () => {
-      await queue.enqueue('export-csv', { resourceType: 'USER', requestedBy: 'user-1' })
+      await queue.enqueue('export-csv', { type: 'OrganizationCsv' })
       expect(mockAdd).toHaveBeenCalledWith(
         'export-csv',
-        expect.objectContaining({ resourceType: 'USER', requestedBy: 'user-1' }),
+        expect.objectContaining({ type: 'OrganizationCsv' }),
         expect.any(Object),
       )
     })

--- a/src/tests/jobs/job-types.test.ts
+++ b/src/tests/jobs/job-types.test.ts
@@ -49,17 +49,22 @@ describe('jobPayloadSchema', () => {
 
   it('should validate export-csv payload', () => {
     const result = jobPayloadSchema['export-csv'].safeParse({
-      resourceType: 'USER',
-      requestedBy: 'user-1',
+      type: 'OrganizationCsv',
     })
     expect(result.success).toBe(true)
   })
 
-  it('should validate import-csv payload', () => {
+  it('should validate import-csv payload (MasterCsv)', () => {
     const result = jobPayloadSchema['import-csv'].safeParse({
-      resourceType: 'USER',
-      fileUrl: 'https://storage.example.com/upload.csv',
-      requestedBy: 'user-1',
+      type: 'MasterCsv',
+      resource: 'DEPARTMENT',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('should validate import-csv payload (EmployeeCsv)', () => {
+    const result = jobPayloadSchema['import-csv'].safeParse({
+      type: 'EmployeeCsv',
     })
     expect(result.success).toBe(true)
   })


### PR DESCRIPTION
## Summary

- `ImportRequest`（MasterCsv / EmployeeCsv 判別ユニオン）と `ImportResult`（エラー行詳細付き）を Zod スキーマで型安全に定義
- `BullMQImportJob`: `enqueue()` / `getStatus()` / `getResult()` を実装。JobState → ImportJobStatus マッピングは ExportJob と対称設計
- `processImportJob()` をスタブ純粋関数として分離（将来のドメインサービスと依存性注入で接続予定）
- `job-types.ts` の重複 `export-csv` キーを修正し、`import-csv` を `importRequestSchema` に置き換え

## Test plan

- [ ] `src/tests/import/import-types.test.ts` — importRequestSchema / isImportRequest / IMPORT_JOB_STATUSES / isImportJobStatus (13テスト)
- [ ] `src/tests/import/import-job.test.ts` — enqueue / getStatus (全8 JobState) / getResult (6テスト)
- [ ] `src/tests/import/import-worker.test.ts` — processImportJob / invariant検証 (7テスト)
- [ ] 全254テストパス確認済み
- [ ] _Requirements: 2.7, 14.1_