### PR TITLE
feat(notification): Task 4.3 — アプリ内通知 API と既読管理

### DIFF
--- a/src/lib/notification/notification-repository.ts
+++ b/src/lib/notification/notification-repository.ts
@@ -1,0 +1,143 @@
+import { randomUUID } from 'node:crypto'
+import type { Notification, NotificationId, NotificationPreferences } from './notification-types'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Interfaces
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Notification（アプリ内通知）の永続化インターフェース */
+export interface NotificationRepository {
+  /** 指定ユーザーの通知を createdAt 降順で返す */
+  listByUser(userId: string): Promise<readonly Notification[]>
+
+  /** 単一の通知を取得する。存在しない場合は null */
+  findById(id: NotificationId): Promise<Notification | null>
+
+  /**
+   * 通知を既読にする。
+   * - 存在しない場合は null
+   * - 既に既読の場合は readAt を上書きせず現状を返す（冪等）
+   */
+  markAsRead(id: NotificationId, readAt: Date): Promise<Notification | null>
+
+  /** 通知を作成する。id/createdAt/readAt は内部で割り当てる */
+  create(input: Omit<Notification, 'id' | 'createdAt' | 'readAt'>): Promise<Notification>
+}
+
+/** NotificationPreference（種別別 email ON/OFF）の永続化インターフェース */
+export interface NotificationPreferenceRepository {
+  /** 指定ユーザーの保存済み設定を返す（未保存のカテゴリは含まれない） */
+  listByUser(userId: string): Promise<NotificationPreferences>
+
+  /**
+   * 指定ユーザーの設定をまとめて保存する。
+   * 既存レコードは全てこの内容で置き換える（単純化のため）。
+   */
+  upsertMany(userId: string, prefs: NotificationPreferences): Promise<void>
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 内部ヘルパ
+// ─────────────────────────────────────────────────────────────────────────────
+
+function cloneNotification(n: Notification): Notification {
+  return { ...n }
+}
+
+function sortByCreatedAtDesc(list: readonly Notification[]): Notification[] {
+  return [...list].sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// InMemory NotificationRepository
+// ─────────────────────────────────────────────────────────────────────────────
+
+class InMemoryNotificationRepository implements NotificationRepository {
+  private readonly store: Map<string, Notification>
+
+  constructor(seed?: readonly Notification[]) {
+    this.store = new Map()
+    if (seed) {
+      for (const n of seed) {
+        // 防御的コピーで外部から保持している参照の変更を遮断する
+        this.store.set(n.id, cloneNotification(n))
+      }
+    }
+  }
+
+  async listByUser(userId: string): Promise<readonly Notification[]> {
+    const filtered: Notification[] = []
+    for (const n of this.store.values()) {
+      if (n.userId === userId) {
+        filtered.push(cloneNotification(n))
+      }
+    }
+    return sortByCreatedAtDesc(filtered)
+  }
+
+  async findById(id: NotificationId): Promise<Notification | null> {
+    const found = this.store.get(id)
+    return found ? cloneNotification(found) : null
+  }
+
+  async markAsRead(id: NotificationId, readAt: Date): Promise<Notification | null> {
+    const current = this.store.get(id)
+    if (!current) return null
+    if (current.readAt) {
+      // 既読済みは冪等に現状を返す
+      return cloneNotification(current)
+    }
+    const updated: Notification = { ...current, readAt }
+    this.store.set(id, updated)
+    return cloneNotification(updated)
+  }
+
+  async create(input: Omit<Notification, 'id' | 'createdAt' | 'readAt'>): Promise<Notification> {
+    const created: Notification = {
+      ...input,
+      id: randomUUID(),
+      createdAt: new Date(),
+      readAt: null,
+    }
+    this.store.set(created.id, created)
+    return cloneNotification(created)
+  }
+}
+
+export function createInMemoryNotificationRepository(
+  seed?: readonly Notification[],
+): NotificationRepository {
+  return new InMemoryNotificationRepository(seed)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// InMemory PreferenceRepository
+// ─────────────────────────────────────────────────────────────────────────────
+
+class InMemoryPreferenceRepository implements NotificationPreferenceRepository {
+  private readonly store: Map<string, NotificationPreferences>
+
+  constructor(seed?: ReadonlyMap<string, NotificationPreferences>) {
+    this.store = new Map()
+    if (seed) {
+      for (const [userId, prefs] of seed) {
+        this.store.set(userId, [...prefs])
+      }
+    }
+  }
+
+  async listByUser(userId: string): Promise<NotificationPreferences> {
+    const stored = this.store.get(userId)
+    return stored ? [...stored] : []
+  }
+
+  async upsertMany(userId: string, prefs: NotificationPreferences): Promise<void> {
+    this.store.set(userId, [...prefs])
+  }
+}
+
+export function createInMemoryPreferenceRepository(
+  seed?: ReadonlyMap<string, NotificationPreferences>,
+): NotificationPreferenceRepository {
+  return new InMemoryPreferenceRepository(seed)
+}

--- a/src/lib/notification/notification-service.ts
+++ b/src/lib/notification/notification-service.ts
@@ -1,0 +1,158 @@
+import { z } from 'zod'
+import type {
+  NotificationRepository,
+  NotificationPreferenceRepository,
+} from './notification-repository'
+import {
+  NOTIFICATION_CATEGORIES,
+  notificationPreferencesSchema,
+  type Notification,
+  type NotificationCategory,
+  type NotificationId,
+  type NotificationPreference,
+  type NotificationPreferences,
+} from './notification-types'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Public types
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** listForUser の戻り値（通知一覧 + 未読件数）。Req 15.6 の未読バッジ更新に利用。 */
+export interface NotificationListResult {
+  readonly notifications: readonly Notification[]
+  readonly unreadCount: number
+}
+
+/**
+ * NotificationService インターフェース。
+ * - listForUser: ユーザー別通知一覧 + 未読件数（Req 15.6）
+ * - markAsRead: 通知を既読化（Req 15.6）
+ * - updatePreferences / getPreferences: 種別別メール通知 ON/OFF（Req 15.3）
+ *
+ * Req 15.8 の sendCustomBroadcast は Task 4.4 で実装するため本 Service には含めない。
+ */
+export interface NotificationService {
+  listForUser(userId: string): Promise<NotificationListResult>
+  markAsRead(userId: string, notificationId: NotificationId): Promise<Notification>
+  updatePreferences(userId: string, preferences: NotificationPreferences): Promise<void>
+  getPreferences(userId: string): Promise<NotificationPreferences>
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 入力バリデーションスキーマ
+// ─────────────────────────────────────────────────────────────────────────────
+
+const userIdSchema = z.string().min(1, 'userId must not be empty')
+const notificationIdSchema = z.string().min(1, 'notificationId must not be empty')
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ドメイン例外
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** 指定 ID の通知が見つからない */
+export class NotificationNotFoundError extends Error {
+  constructor(notificationId: string) {
+    super(`Notification not found: ${notificationId}`)
+    this.name = 'NotificationNotFoundError'
+  }
+}
+
+/** 他ユーザーの通知を操作しようとした */
+export class NotificationAccessDeniedError extends Error {
+  constructor(notificationId: string) {
+    super(`Access denied for notification: ${notificationId}`)
+    this.name = 'NotificationAccessDeniedError'
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 内部ヘルパ
+// ─────────────────────────────────────────────────────────────────────────────
+
+function countUnread(list: readonly Notification[]): number {
+  let count = 0
+  for (const n of list) {
+    if (n.readAt === null) count += 1
+  }
+  return count
+}
+
+function buildDefaultPreferences(stored: NotificationPreferences): NotificationPreferences {
+  const storedByCategory = new Map<NotificationCategory, NotificationPreference>()
+  for (const p of stored) {
+    storedByCategory.set(p.category, p)
+  }
+
+  return NOTIFICATION_CATEGORIES.map((category) => {
+    const existing = storedByCategory.get(category)
+    // アプリ内通知は常時有効（Req 15.3）。保存されていないカテゴリは emailEnabled=true をデフォルトに。
+    return existing ?? { category, emailEnabled: true }
+  })
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Implementation
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface Dependencies {
+  readonly notifications: NotificationRepository
+  readonly preferences: NotificationPreferenceRepository
+}
+
+class NotificationServiceImpl implements NotificationService {
+  constructor(private readonly deps: Dependencies) {}
+
+  async listForUser(userId: string): Promise<NotificationListResult> {
+    const validUserId = userIdSchema.parse(userId)
+    const list = await this.deps.notifications.listByUser(validUserId)
+    return {
+      notifications: list,
+      unreadCount: countUnread(list),
+    }
+  }
+
+  async markAsRead(userId: string, notificationId: NotificationId): Promise<Notification> {
+    const validUserId = userIdSchema.parse(userId)
+    const validId = notificationIdSchema.parse(notificationId)
+
+    const existing = await this.deps.notifications.findById(validId)
+    if (!existing) {
+      throw new NotificationNotFoundError(validId)
+    }
+    if (existing.userId !== validUserId) {
+      // 他ユーザーの通知を既読化しようとした
+      throw new NotificationAccessDeniedError(validId)
+    }
+    if (existing.readAt) {
+      // 冪等: 既読済みは現状を返す
+      return existing
+    }
+
+    const updated = await this.deps.notifications.markAsRead(validId, new Date())
+    if (!updated) {
+      // 競合等で更新対象が消えた場合
+      throw new NotificationNotFoundError(validId)
+    }
+    return updated
+  }
+
+  async updatePreferences(userId: string, preferences: NotificationPreferences): Promise<void> {
+    const validUserId = userIdSchema.parse(userId)
+    const validPrefs = notificationPreferencesSchema.parse(preferences)
+    await this.deps.preferences.upsertMany(validUserId, validPrefs)
+  }
+
+  async getPreferences(userId: string): Promise<NotificationPreferences> {
+    const validUserId = userIdSchema.parse(userId)
+    const stored = await this.deps.preferences.listByUser(validUserId)
+    return buildDefaultPreferences(stored)
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Factory
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function createNotificationService(deps: Dependencies): NotificationService {
+  return new NotificationServiceImpl(deps)
+}

--- a/src/lib/notification/notification-types.ts
+++ b/src/lib/notification/notification-types.ts
@@ -42,21 +42,58 @@ export const notificationEventSchema = z.object({
 export type NotificationEvent = z.infer<typeof notificationEventSchema>
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Notification（アプリ内通知）
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** 通知ID（DB/ストア が発行する文字列 id のエイリアス） */
+export type NotificationId = string
+
+export const notificationSchema = z.object({
+  id: z.string().min(1),
+  userId: z.string().min(1),
+  category: z.enum(NOTIFICATION_CATEGORIES),
+  title: z.string().min(1),
+  body: z.string(),
+  payload: z.record(z.unknown()).nullable().optional(),
+  readAt: z.date().nullable(),
+  createdAt: z.date(),
+})
+
+export type Notification = z.infer<typeof notificationSchema>
+
+export function isNotification(value: unknown): value is Notification {
+  return notificationSchema.safeParse(value).success
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// NotificationPreference（通知種別ごとのメール送信設定）
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const notificationPreferenceSchema = z.object({
+  category: z.enum(NOTIFICATION_CATEGORIES),
+  emailEnabled: z.boolean(),
+})
+
+export type NotificationPreference = z.infer<typeof notificationPreferenceSchema>
+
+export const notificationPreferencesSchema = z.array(notificationPreferenceSchema)
+
+/**
+ * 通知設定（アプリ内通知は常時有効、メール通知のみカテゴリ別 ON/OFF）。
+ * Req 15.3 参照。
+ */
+export type NotificationPreferences = readonly NotificationPreference[]
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Type guards
 // ─────────────────────────────────────────────────────────────────────────────
 
 export function isNotificationCategory(value: unknown): value is NotificationCategory {
-  return (
-    typeof value === 'string' &&
-    (NOTIFICATION_CATEGORIES as readonly string[]).includes(value)
-  )
+  return typeof value === 'string' && (NOTIFICATION_CATEGORIES as readonly string[]).includes(value)
 }
 
 export function isNotificationChannel(value: unknown): value is NotificationChannel {
-  return (
-    typeof value === 'string' &&
-    (NOTIFICATION_CHANNELS as readonly string[]).includes(value)
-  )
+  return typeof value === 'string' && (NOTIFICATION_CHANNELS as readonly string[]).includes(value)
 }
 
 export function isNotificationEvent(value: unknown): value is NotificationEvent {

--- a/src/tests/notification/notification-repository.test.ts
+++ b/src/tests/notification/notification-repository.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect } from 'vitest'
+import {
+  createInMemoryNotificationRepository,
+  createInMemoryPreferenceRepository,
+} from '@/lib/notification/notification-repository'
+import type { Notification } from '@/lib/notification/notification-types'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// テストフィクスチャ
+// ─────────────────────────────────────────────────────────────────────────────
+
+function makeNotification(overrides: Partial<Notification> = {}): Notification {
+  return {
+    id: overrides.id ?? 'notif-1',
+    userId: overrides.userId ?? 'user-1',
+    category: overrides.category ?? 'SYSTEM',
+    title: overrides.title ?? 'テスト通知',
+    body: overrides.body ?? '本文',
+    payload: overrides.payload ?? null,
+    readAt: overrides.readAt ?? null,
+    createdAt: overrides.createdAt ?? new Date('2026-04-17T12:00:00Z'),
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// InMemoryNotificationRepository
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('createInMemoryNotificationRepository', () => {
+  describe('listByUser()', () => {
+    it('should return empty array when no notifications exist', async () => {
+      const repo = createInMemoryNotificationRepository()
+      const result = await repo.listByUser('user-1')
+      expect(result).toEqual([])
+    })
+
+    it('should return only notifications belonging to the specified user', async () => {
+      const seed = [
+        makeNotification({ id: 'a', userId: 'user-1' }),
+        makeNotification({ id: 'b', userId: 'user-2' }),
+        makeNotification({ id: 'c', userId: 'user-1' }),
+      ]
+      const repo = createInMemoryNotificationRepository(seed)
+      const result = await repo.listByUser('user-1')
+      expect(result).toHaveLength(2)
+      expect(result.every((n) => n.userId === 'user-1')).toBe(true)
+    })
+
+    it('should return notifications sorted by createdAt descending', async () => {
+      const seed = [
+        makeNotification({ id: 'old', createdAt: new Date('2026-04-10T00:00:00Z') }),
+        makeNotification({ id: 'newest', createdAt: new Date('2026-04-17T00:00:00Z') }),
+        makeNotification({ id: 'middle', createdAt: new Date('2026-04-15T00:00:00Z') }),
+      ]
+      const repo = createInMemoryNotificationRepository(seed)
+      const result = await repo.listByUser('user-1')
+      expect(result.map((n) => n.id)).toEqual(['newest', 'middle', 'old'])
+    })
+  })
+
+  describe('findById()', () => {
+    it('should return the notification when it exists', async () => {
+      const seed = [makeNotification({ id: 'target' })]
+      const repo = createInMemoryNotificationRepository(seed)
+      const result = await repo.findById('target')
+      expect(result?.id).toBe('target')
+    })
+
+    it('should return null when notification does not exist', async () => {
+      const repo = createInMemoryNotificationRepository()
+      const result = await repo.findById('missing')
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('markAsRead()', () => {
+    it('should set readAt and return the updated notification', async () => {
+      const seed = [makeNotification({ id: 'a', readAt: null })]
+      const repo = createInMemoryNotificationRepository(seed)
+      const readAt = new Date('2026-04-17T15:00:00Z')
+      const updated = await repo.markAsRead('a', readAt)
+      expect(updated?.readAt).toEqual(readAt)
+    })
+
+    it('should persist the readAt for subsequent reads', async () => {
+      const seed = [makeNotification({ id: 'a', readAt: null })]
+      const repo = createInMemoryNotificationRepository(seed)
+      const readAt = new Date('2026-04-17T15:00:00Z')
+      await repo.markAsRead('a', readAt)
+      const after = await repo.findById('a')
+      expect(after?.readAt).toEqual(readAt)
+    })
+
+    it('should return null when notification does not exist', async () => {
+      const repo = createInMemoryNotificationRepository()
+      const result = await repo.markAsRead('missing', new Date())
+      expect(result).toBeNull()
+    })
+
+    it('should not mutate the original seeded notification (immutability)', async () => {
+      const original = makeNotification({ id: 'a', readAt: null })
+      const seed = [original]
+      const repo = createInMemoryNotificationRepository(seed)
+      await repo.markAsRead('a', new Date('2026-04-17T15:00:00Z'))
+      expect(original.readAt).toBeNull()
+    })
+  })
+
+  describe('create()', () => {
+    it('should generate id and createdAt, default readAt to null', async () => {
+      const repo = createInMemoryNotificationRepository()
+      const created = await repo.create({
+        userId: 'user-1',
+        category: 'SYSTEM',
+        title: 'タイトル',
+        body: '本文',
+        payload: null,
+      })
+      expect(created.id).toBeTruthy()
+      expect(created.createdAt).toBeInstanceOf(Date)
+      expect(created.readAt).toBeNull()
+      expect(created.userId).toBe('user-1')
+    })
+
+    it('should make the created notification listable', async () => {
+      const repo = createInMemoryNotificationRepository()
+      const created = await repo.create({
+        userId: 'user-1',
+        category: 'SYSTEM',
+        title: 'タイトル',
+        body: '本文',
+        payload: null,
+      })
+      const list = await repo.listByUser('user-1')
+      expect(list.some((n) => n.id === created.id)).toBe(true)
+    })
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// InMemoryPreferenceRepository
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('createInMemoryPreferenceRepository', () => {
+  describe('listByUser()', () => {
+    it('should return empty array when no preferences are stored', async () => {
+      const repo = createInMemoryPreferenceRepository()
+      const result = await repo.listByUser('user-1')
+      expect(result).toEqual([])
+    })
+
+    it('should return seeded preferences for the user', async () => {
+      const seed = new Map([
+        [
+          'user-1',
+          [
+            { category: 'SYSTEM' as const, emailEnabled: false },
+            { category: 'EVAL_INVITATION' as const, emailEnabled: true },
+          ],
+        ],
+      ])
+      const repo = createInMemoryPreferenceRepository(seed)
+      const result = await repo.listByUser('user-1')
+      expect(result).toHaveLength(2)
+    })
+
+    it('should not leak preferences across users', async () => {
+      const seed = new Map([['user-1', [{ category: 'SYSTEM' as const, emailEnabled: false }]]])
+      const repo = createInMemoryPreferenceRepository(seed)
+      const result = await repo.listByUser('user-2')
+      expect(result).toEqual([])
+    })
+  })
+
+  describe('upsertMany()', () => {
+    it('should store preferences that can later be retrieved', async () => {
+      const repo = createInMemoryPreferenceRepository()
+      await repo.upsertMany('user-1', [{ category: 'SYSTEM', emailEnabled: false }])
+      const result = await repo.listByUser('user-1')
+      expect(result).toEqual([{ category: 'SYSTEM', emailEnabled: false }])
+    })
+
+    it('should replace existing preferences on subsequent upsert', async () => {
+      const repo = createInMemoryPreferenceRepository()
+      await repo.upsertMany('user-1', [
+        { category: 'SYSTEM', emailEnabled: true },
+        { category: 'EVAL_INVITATION', emailEnabled: true },
+      ])
+      await repo.upsertMany('user-1', [{ category: 'SYSTEM', emailEnabled: false }])
+      const result = await repo.listByUser('user-1')
+      expect(result).toEqual([{ category: 'SYSTEM', emailEnabled: false }])
+    })
+  })
+})

--- a/src/tests/notification/notification-service.test.ts
+++ b/src/tests/notification/notification-service.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  createInMemoryNotificationRepository,
+  createInMemoryPreferenceRepository,
+} from '@/lib/notification/notification-repository'
+import type {
+  NotificationRepository,
+  NotificationPreferenceRepository,
+} from '@/lib/notification/notification-repository'
+import { createNotificationService } from '@/lib/notification/notification-service'
+import type { NotificationService } from '@/lib/notification/notification-service'
+import { NOTIFICATION_CATEGORIES, type Notification } from '@/lib/notification/notification-types'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// テストフィクスチャ
+// ─────────────────────────────────────────────────────────────────────────────
+
+function makeNotification(overrides: Partial<Notification> = {}): Notification {
+  return {
+    id: overrides.id ?? 'notif-1',
+    userId: overrides.userId ?? 'user-1',
+    category: overrides.category ?? 'SYSTEM',
+    title: overrides.title ?? 'テスト通知',
+    body: overrides.body ?? '本文',
+    payload: overrides.payload ?? null,
+    readAt: overrides.readAt ?? null,
+    createdAt: overrides.createdAt ?? new Date('2026-04-17T12:00:00Z'),
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('NotificationService', () => {
+  let notifications: NotificationRepository
+  let preferences: NotificationPreferenceRepository
+  let service: NotificationService
+
+  beforeEach(() => {
+    notifications = createInMemoryNotificationRepository([
+      makeNotification({
+        id: 'n1',
+        userId: 'user-1',
+        readAt: null,
+        createdAt: new Date('2026-04-15T00:00:00Z'),
+      }),
+      makeNotification({
+        id: 'n2',
+        userId: 'user-1',
+        readAt: new Date('2026-04-16T09:00:00Z'),
+        createdAt: new Date('2026-04-16T00:00:00Z'),
+      }),
+      makeNotification({
+        id: 'n3',
+        userId: 'user-1',
+        readAt: null,
+        createdAt: new Date('2026-04-17T00:00:00Z'),
+      }),
+      makeNotification({ id: 'other-1', userId: 'user-2', readAt: null }),
+    ])
+    preferences = createInMemoryPreferenceRepository()
+    service = createNotificationService({ notifications, preferences })
+  })
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // listForUser
+  // ───────────────────────────────────────────────────────────────────────────
+
+  describe('listForUser()', () => {
+    it('should return notifications belonging to the user sorted desc', async () => {
+      const result = await service.listForUser('user-1')
+      expect(result.notifications.map((n) => n.id)).toEqual(['n3', 'n2', 'n1'])
+    })
+
+    it('should return unreadCount equal to number of readAt=null notifications', async () => {
+      const result = await service.listForUser('user-1')
+      expect(result.unreadCount).toBe(2)
+    })
+
+    it('should not include other users notifications', async () => {
+      const result = await service.listForUser('user-1')
+      expect(result.notifications.every((n) => n.userId === 'user-1')).toBe(true)
+    })
+
+    it('should return zero unreadCount when all notifications are read', async () => {
+      const repo = createInMemoryNotificationRepository([
+        makeNotification({ id: 'a', readAt: new Date() }),
+      ])
+      const s = createNotificationService({
+        notifications: repo,
+        preferences,
+      })
+      const result = await s.listForUser('user-1')
+      expect(result.unreadCount).toBe(0)
+    })
+  })
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // markAsRead
+  // ───────────────────────────────────────────────────────────────────────────
+
+  describe('markAsRead()', () => {
+    it('should set readAt on an unread notification', async () => {
+      const updated = await service.markAsRead('user-1', 'n1')
+      expect(updated.readAt).toBeInstanceOf(Date)
+    })
+
+    it('should decrement the unread count after marking as read', async () => {
+      await service.markAsRead('user-1', 'n1')
+      const after = await service.listForUser('user-1')
+      expect(after.unreadCount).toBe(1)
+    })
+
+    it('should be idempotent on an already-read notification', async () => {
+      const first = await service.markAsRead('user-1', 'n2')
+      const second = await service.markAsRead('user-1', 'n2')
+      expect(first.readAt).toEqual(second.readAt)
+    })
+
+    it('should throw when marking another user notification as read', async () => {
+      await expect(service.markAsRead('user-1', 'other-1')).rejects.toThrow()
+    })
+
+    it('should throw when notification does not exist', async () => {
+      await expect(service.markAsRead('user-1', 'missing')).rejects.toThrow()
+    })
+  })
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // updatePreferences
+  // ───────────────────────────────────────────────────────────────────────────
+
+  describe('updatePreferences()', () => {
+    it('should save valid preferences', async () => {
+      await service.updatePreferences('user-1', [
+        { category: 'SYSTEM', emailEnabled: false },
+        { category: 'EVAL_INVITATION', emailEnabled: true },
+      ])
+      const stored = await preferences.listByUser('user-1')
+      expect(stored).toHaveLength(2)
+    })
+
+    it('should reject invalid category via Zod validation', async () => {
+      await expect(
+        service.updatePreferences('user-1', [
+          // 意図的に不正なカテゴリを渡す
+          { category: 'UNKNOWN', emailEnabled: true } as unknown as {
+            category: 'SYSTEM'
+            emailEnabled: boolean
+          },
+        ]),
+      ).rejects.toThrow()
+    })
+
+    it('should reject non-boolean emailEnabled via Zod validation', async () => {
+      await expect(
+        service.updatePreferences('user-1', [
+          { category: 'SYSTEM', emailEnabled: 'yes' } as unknown as {
+            category: 'SYSTEM'
+            emailEnabled: boolean
+          },
+        ]),
+      ).rejects.toThrow()
+    })
+
+    it('should reject when userId is empty', async () => {
+      await expect(
+        service.updatePreferences('', [{ category: 'SYSTEM', emailEnabled: true }]),
+      ).rejects.toThrow()
+    })
+  })
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // getPreferences
+  // ───────────────────────────────────────────────────────────────────────────
+
+  describe('getPreferences()', () => {
+    it('should return default emailEnabled=true for all categories when none stored', async () => {
+      const result = await service.getPreferences('user-1')
+      expect(result).toHaveLength(NOTIFICATION_CATEGORIES.length)
+      expect(result.every((p) => p.emailEnabled === true)).toBe(true)
+    })
+
+    it('should merge stored preferences with defaults', async () => {
+      await service.updatePreferences('user-1', [{ category: 'SYSTEM', emailEnabled: false }])
+      const result = await service.getPreferences('user-1')
+      const systemPref = result.find((p) => p.category === 'SYSTEM')
+      const evalPref = result.find((p) => p.category === 'EVAL_INVITATION')
+      expect(systemPref?.emailEnabled).toBe(false)
+      expect(evalPref?.emailEnabled).toBe(true)
+    })
+
+    it('should cover every NotificationCategory exactly once', async () => {
+      const result = await service.getPreferences('user-1')
+      const categories = result.map((p) => p.category).sort()
+      const expected = [...NOTIFICATION_CATEGORIES].sort()
+      expect(categories).toEqual(expected)
+    })
+  })
+})

--- a/src/tests/notification/notification-types.test.ts
+++ b/src/tests/notification/notification-types.test.ts
@@ -7,6 +7,10 @@ import {
   isNotificationChannel,
   notificationEventSchema,
   isNotificationEvent,
+  notificationSchema,
+  isNotification,
+  notificationPreferenceSchema,
+  notificationPreferencesSchema,
 } from '@/lib/notification/notification-types'
 
 describe('NOTIFICATION_CATEGORIES', () => {
@@ -140,5 +144,131 @@ describe('isNotificationEvent()', () => {
         body: 'Body',
       }),
     ).toBe(false)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Notification（アプリ内通知）
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('notificationSchema', () => {
+  it('should accept a notification with readAt=null', () => {
+    const result = notificationSchema.safeParse({
+      id: 'notif-1',
+      userId: 'user-1',
+      category: 'SYSTEM',
+      title: 'テスト通知',
+      body: '本文',
+      payload: null,
+      readAt: null,
+      createdAt: new Date('2026-04-17T12:00:00Z'),
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('should accept a notification with readAt set', () => {
+    const result = notificationSchema.safeParse({
+      id: 'notif-2',
+      userId: 'user-1',
+      category: 'EVAL_INVITATION',
+      title: '評価依頼',
+      body: '評価を開始してください',
+      payload: { cycleId: 'cycle-1' },
+      readAt: new Date('2026-04-17T13:00:00Z'),
+      createdAt: new Date('2026-04-17T12:00:00Z'),
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('should reject when id is empty', () => {
+    const result = notificationSchema.safeParse({
+      id: '',
+      userId: 'user-1',
+      category: 'SYSTEM',
+      title: 'Test',
+      body: 'Body',
+      readAt: null,
+      createdAt: new Date(),
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('should reject when createdAt is not a Date', () => {
+    const result = notificationSchema.safeParse({
+      id: 'notif-3',
+      userId: 'user-1',
+      category: 'SYSTEM',
+      title: 'Test',
+      body: 'Body',
+      readAt: null,
+      createdAt: '2026-04-17',
+    })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('isNotification()', () => {
+  it('should return true for valid notification', () => {
+    expect(
+      isNotification({
+        id: 'notif-4',
+        userId: 'user-1',
+        category: 'SYSTEM',
+        title: 'Test',
+        body: 'Body',
+        readAt: null,
+        createdAt: new Date(),
+      }),
+    ).toBe(true)
+  })
+
+  it('should return false for null', () => {
+    expect(isNotification(null)).toBe(false)
+  })
+})
+
+describe('notificationPreferenceSchema', () => {
+  it('should accept valid preference', () => {
+    const result = notificationPreferenceSchema.safeParse({
+      category: 'SYSTEM',
+      emailEnabled: false,
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('should reject unknown category', () => {
+    const result = notificationPreferenceSchema.safeParse({
+      category: 'UNKNOWN',
+      emailEnabled: true,
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('should reject non-boolean emailEnabled', () => {
+    const result = notificationPreferenceSchema.safeParse({
+      category: 'SYSTEM',
+      emailEnabled: 'yes',
+    })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('notificationPreferencesSchema', () => {
+  it('should accept an array of preferences', () => {
+    const result = notificationPreferencesSchema.safeParse([
+      { category: 'SYSTEM', emailEnabled: true },
+      { category: 'EVAL_INVITATION', emailEnabled: false },
+    ])
+    expect(result.success).toBe(true)
+  })
+
+  it('should accept an empty array', () => {
+    const result = notificationPreferencesSchema.safeParse([])
+    expect(result.success).toBe(true)
+  })
+
+  it('should reject a non-array value', () => {
+    const result = notificationPreferencesSchema.safeParse({ category: 'SYSTEM' })
+    expect(result.success).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary
- アプリ内通知のユーザー別一覧 API、未読カウント、既読化をサービス層に実装
- カテゴリ別のメール通知 ON/OFF を管理する NotificationPreference サービスを追加（アプリ内通知は常時有効）
- DB 未整備のため InMemory リポジトリを同梱し、将来の Prisma 実装へ差し替え可能な構造にする

Closes #13

## 実装内容
- \`notification-types.ts\`: \`Notification\` / \`NotificationId\` / \`NotificationPreference\` / \`NotificationPreferences\` の Zod スキーマ・型を既存定義に追加（既存シンボル全て維持）
- \`notification-repository.ts\`: \`NotificationRepository\` / \`NotificationPreferenceRepository\` インターフェースと InMemory 実装（\`createInMemoryNotificationRepository\` / \`createInMemoryPreferenceRepository\`）。全メソッドを不変パターンで実装し、内部ストアへの外部参照リークを防ぐ防御的コピーを採用。\`listByUser\` は \`createdAt\` 降順。
- \`notification-service.ts\`: \`NotificationService\` と factory (\`createNotificationService\`)
  - \`listForUser\`: 通知一覧 + 未読件数 (\`readAt === null\`) を返す (Req 15.6)
  - \`markAsRead\`: 他ユーザーの通知は \`NotificationAccessDeniedError\`、存在しない ID は \`NotificationNotFoundError\`。既読済みは冪等に現状を返す (Req 15.6)
  - \`updatePreferences\`: Zod で \`notificationPreferencesSchema\` 検証後に upsert (Req 15.3)
  - \`getPreferences\`: 保存されていないカテゴリは \`emailEnabled: true\` をデフォルトとして全カテゴリを返却 (Req 15.3)
- テスト: types に追加検証 (12 ケース)、repository の CRUD とイミュータブル検証 (16 ケース)、service の正常系・他ユーザー拒否・Zod バリデーション失敗・未読カウント・デフォルト preference 等 (16 ケース)

## テスト結果
- \`pnpm test\`: 全 320 テスト green（通知関連は 66/66 green）
- \`pnpm lint\`: ESLint 警告・エラーゼロ
- \`pnpm test:coverage\` の \`src/lib/notification/\` カバレッジ:
  - \`notification-types.ts\`: 100%
  - \`notification-repository.ts\`: 97.53%
  - \`notification-service.ts\`: 97.61%
  - いずれも 80% 閾値を十分に上回る
- \`pnpm type-check\` は本 PR 範囲で追加の型エラーなし（残存する \`audit-log-emitter.ts\` の重複 import は Task 4.3 とは無関係の既存 issue）

## Requirements
- **15.3**: 通知設定画面で通知種別ごとのメール通知 ON/OFF 選択。アプリ内通知は常時有効
- **15.6**: アプリ内通知を開いた際の既読マーク + 未読バッジ更新

## スコープ外（本 PR では触れない）
- \`sendCustomBroadcast\` (Req 15.8) — **Task 4.4** で実装
- HTTP API ルート (\`src/app/api/notifications/**\`) — 別タスク
- Prisma ベースの永続化実装 — DB スキーマ整備後に InMemory を差し替え
- Task 4.2 (Issue #12) と並列作業のため \`email-*.ts\` / \`notification-log-recorder.ts\` / \`email-templates/\` / \`notification-emitter.ts\` には一切変更を加えていない

## Test plan
- [x] \`pnpm test\` 全 green
- [x] \`pnpm lint\` 0 warnings
- [x] 通知モジュールのカバレッジ 80%+ を確認
- [ ] レビュー後、Task 4.4 で HTTP API ルート + Broadcast を追加する際に本サービスを注入して E2E で確認