### PR TITLE
feat(notification): Task 4.2 — EmailWorker 実装

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "@bull-board/api": "^7.0.0",
     "@bull-board/hono": "^7.0.0",
     "@prisma/client": "^6.0.0",
+    "@react-email/components": "^1.0.12",
+    "@react-email/render": "^2.0.7",
     "bullmq": "^5.74.1",
     "ioredis": "^5.10.1",
     "neverthrow": "^8.0.0",
@@ -36,6 +38,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "redis": "^4.7.0",
+    "resend": "^6.12.0",
     "zod": "^3.0.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,12 @@ importers:
       '@prisma/client':
         specifier: ^6.0.0
         version: 6.19.3(prisma@6.19.3(magicast@0.3.5)(typescript@5.9.3))(typescript@5.9.3)
+      '@react-email/components':
+        specifier: ^1.0.12
+        version: 1.0.12(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@react-email/render':
+        specifier: ^2.0.7
+        version: 2.0.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       bullmq:
         specifier: ^5.74.1
         version: 5.74.1
@@ -44,6 +50,9 @@ importers:
       redis:
         specifier: ^4.7.0
         version: 4.7.1
+      resend:
+        specifier: ^6.12.0
+        version: 6.12.0(@react-email/render@2.0.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
       zod:
         specifier: ^3.0.0
         version: 3.25.76
@@ -684,6 +693,172 @@ packages:
   '@prisma/get-platform@6.19.3':
     resolution: {integrity: sha512-xFj1VcJ1N3MKooOQAGO0W5tsd0W2QzIvW7DD7c/8H14Zmp4jseeWAITm+w2LLoLrlhoHdPPh0NMZ8mfL6puoHA==}
 
+  '@react-email/body@0.3.0':
+    resolution: {integrity: sha512-uGo0BOOzjbMUo3lu+BIDWayvn5o6Xyfmnlla5VGf05n8gHMvO1ll7U4FtzWe3hxMLwt53pmc4iE0M+B5slG+Ug==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/button@0.2.1':
+    resolution: {integrity: sha512-qXyj7RZLE7POy9BMKSoqQ00tOXThjOZSUnI2Yu9i29IHngPlmrNayIWBoVKtElES7OWwypUcpiajwi1mUWx6/A==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/code-block@0.2.1':
+    resolution: {integrity: sha512-M3B7JpVH4ytgn83/ujRR1k1DQHvTeABiDM61OvAbjLRPhC/5KLHU5KkzIbbuGIrjWwxAbL1kSQzU8MhLEtSxyw==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/code-inline@0.0.6':
+    resolution: {integrity: sha512-jfhebvv3dVsp3OdPgKXnk8+e2pBiDVZejDOBFzBa/IblrAJ9cQDkN6rBD5IyEg8hTOxwbw3iaI/yZFmDmIguIA==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/column@0.0.14':
+    resolution: {integrity: sha512-f+W+Bk2AjNO77zynE33rHuQhyqVICx4RYtGX9NKsGUg0wWjdGP0qAuIkhx9Rnmk4/hFMo1fUrtYNqca9fwJdHg==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/components@1.0.12':
+    resolution: {integrity: sha512-tH18JhPDWgE+3jnYkzyB6ZrZdfNnEsFe4PwmuXmlOw4NGIysP8wPY5aXZg++pTG9qUabXg1nzX/FGHGkObH8xQ==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/container@0.0.16':
+    resolution: {integrity: sha512-QWBB56RkkU0AJ9h+qy33gfT5iuZknPC7Un/IjZv9B0QmMIK+WWacc0cH6y2SV5Cv/b99hU94fjEMOOO4enpkbQ==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/font@0.0.10':
+    resolution: {integrity: sha512-0urVSgCmQIfx5r7Xc586miBnQUVnGp3OTYUm8m5pwtQRdTRO5XrTtEfNJ3JhYhSOruV0nD8fd+dXtKXobum6tA==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/head@0.0.13':
+    resolution: {integrity: sha512-AJg6le/08Gz4tm+6MtKXqtNNyKHzmooOCdmtqmWxD7FxoAdU1eVcizhtQ0gcnVaY6ethEyE/hnEzQxt1zu5Kog==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/heading@0.0.16':
+    resolution: {integrity: sha512-jmsKnQm1ykpBzw4hCYHwBkt5pW2jScXffPeEH5ZRF5tZeF5b1pvlFTO9han7C0pCkZYo1kEvWiRtx69yfCIwuw==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/hr@0.0.12':
+    resolution: {integrity: sha512-TwmOmBDibavUQpXBxpmZYi2Iks/yeZOzFYh+di9EltMSnEabH8dMZXrl+pxNXzCgZ2XE8HY7VmUL65Lenfu5PA==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/html@0.0.12':
+    resolution: {integrity: sha512-KTShZesan+UsreU7PDUV90afrZwU5TLwYlALuCSU0OT+/U8lULNNbAUekg+tGwCnOfIKYtpDPKkAMRdYlqUznw==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/img@0.0.12':
+    resolution: {integrity: sha512-sRCpEARNVTf3FQhZOC+JTvu5r6ubiYWkT0ucYXg8ctkyi4G8QG+jgYPiNUqVeTLA2STOfmPM/nrk1nb84y6CPQ==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/link@0.0.13':
+    resolution: {integrity: sha512-lkWc/NjOcefRZMkQoSDDbuKBEBDES9aXnFEOuPH845wD3TxPwh+QTf0fStuzjoRLUZWpHnio4z7qGGRYusn/sw==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/markdown@0.0.18':
+    resolution: {integrity: sha512-gSuYK5fsMbGk87jDebqQ6fa2fKcWlkf2Dkva8kMONqLgGCq8/0d+ZQYMEJsdidIeBo3kmsnHZPrwdFB4HgjUXg==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/preview@0.0.14':
+    resolution: {integrity: sha512-aYK8q0IPkBXyMsbpMXgxazwHxYJxTrXrV95GFuu2HbEiIToMwSyUgb8HDFYwPqqfV03/jbwqlsXmFxsOd+VNaw==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/render@2.0.6':
+    resolution: {integrity: sha512-xOzaYkH3jLZKqN5MqrTXYnmqBYUnZSVbkxdb5PGGmDcK6sKDVMliaDiSwfXajRC9JtSHTcGc2tmGLHWuCgVpog==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/render@2.0.7':
+    resolution: {integrity: sha512-XCsqujKURb4egU8+z7RX1/yxRx1Qo89uGhy6UXyB5Oxq1SK+48t0AD/3qeuDGgDvyS+Ti+0oDT3nn5/dcG4Ttg==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/row@0.0.13':
+    resolution: {integrity: sha512-bYnOac40vIKCId7IkwuLAAsa3fKfSfqCvv6epJKmPE0JBuu5qI4FHFCl9o9dVpIIS08s/ub+Y/txoMt0dYziGw==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/section@0.0.17':
+    resolution: {integrity: sha512-qNl65ye3W0Rd5udhdORzTV9ezjb+GFqQQSae03NDzXtmJq6sqVXNWNiVolAjvJNypim+zGXmv6J9TcV5aNtE/w==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/tailwind@2.0.7':
+    resolution: {integrity: sha512-kGw80weVFXikcnCXbigTGXGWQ0MRCSYNCudcdkWxebkWYd0FG6/NPoN3V1p/u68/4+NxZwYPVi2fhnp0x23HdA==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@react-email/body': '>=0'
+      '@react-email/button': '>=0'
+      '@react-email/code-block': '>=0'
+      '@react-email/code-inline': '>=0'
+      '@react-email/container': '>=0'
+      '@react-email/heading': '>=0'
+      '@react-email/hr': '>=0'
+      '@react-email/img': '>=0'
+      '@react-email/link': '>=0'
+      '@react-email/preview': '>=0'
+      '@react-email/text': '>=0'
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@react-email/body':
+        optional: true
+      '@react-email/button':
+        optional: true
+      '@react-email/code-block':
+        optional: true
+      '@react-email/code-inline':
+        optional: true
+      '@react-email/container':
+        optional: true
+      '@react-email/heading':
+        optional: true
+      '@react-email/hr':
+        optional: true
+      '@react-email/img':
+        optional: true
+      '@react-email/link':
+        optional: true
+      '@react-email/preview':
+        optional: true
+
+  '@react-email/text@0.1.6':
+    resolution: {integrity: sha512-TYqkioRS45wTR5il3dYk/SbUjjEdhSwh9BtRNB99qNH1pXAwA45H7rAuxehiu8iJQJH0IyIr+6n62gBz9ezmsw==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
   '@redis/bloom@1.2.0':
     resolution: {integrity: sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==}
     peerDependencies:
@@ -843,6 +1018,12 @@ packages:
 
   '@rushstack/eslint-patch@1.16.1':
     resolution: {integrity: sha512-TvZbIpeKqGQQ7X0zSCvPH9riMSFQFSggnfBjFZ1mEoILW+UuXCKwOoPcgjMwiUtRqFZ8jWhPJc4um14vC6I4ag==}
+
+  '@selderee/plugin-htmlparser2@0.11.0':
+    resolution: {integrity: sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==}
+
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -1437,6 +1618,10 @@ packages:
     resolution: {integrity: sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==}
     engines: {node: '>=16.0.0'}
 
+  deepmerge@4.3.1:
+    resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
+    engines: {node: '>=0.10.0'}
+
   define-data-property@1.1.4:
     resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
     engines: {node: '>= 0.4'}
@@ -1462,6 +1647,19 @@ packages:
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
+
+  dom-serializer@2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+
+  domelementtype@2.3.0:
+    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
+  domhandler@5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
+    engines: {node: '>= 4'}
+
+  domutils@3.2.2:
+    resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
 
   dotenv@16.6.1:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
@@ -1498,6 +1696,10 @@ packages:
   enhanced-resolve@5.20.1:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
     engines: {node: '>=10.13.0'}
+
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
 
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
@@ -1701,6 +1903,9 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
+
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
@@ -1856,6 +2061,13 @@ packages:
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  html-to-text@9.0.5:
+    resolution: {integrity: sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==}
+    engines: {node: '>=14'}
+
+  htmlparser2@8.0.2:
+    resolution: {integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==}
 
   human-signals@5.0.0:
     resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
@@ -2082,6 +2294,9 @@ packages:
     resolution: {integrity: sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==}
     engines: {node: '>=0.10'}
 
+  leac@0.6.0:
+    resolution: {integrity: sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg==}
+
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
@@ -2212,6 +2427,11 @@ packages:
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
+
+  marked@15.0.12:
+    resolution: {integrity: sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==}
+    engines: {node: '>= 18'}
+    hasBin: true
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -2391,6 +2611,9 @@ packages:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
 
+  parseley@0.12.1:
+    resolution: {integrity: sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -2416,6 +2639,9 @@ packages:
   pathval@2.0.1:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
     engines: {node: '>= 14.16'}
+
+  peberminta@0.9.0:
+    resolution: {integrity: sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==}
 
   perfect-debounce@1.0.0:
     resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
@@ -2486,6 +2712,9 @@ packages:
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
+
+  postal-mime@2.7.4:
+    resolution: {integrity: sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==}
 
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
@@ -2591,6 +2820,10 @@ packages:
       typescript:
         optional: true
 
+  prismjs@1.30.0:
+    resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
+    engines: {node: '>=6'}
+
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
@@ -2645,6 +2878,15 @@ packages:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
 
+  resend@6.12.0:
+    resolution: {integrity: sha512-CaxEvX1z+/MGbgnhsM/bvmkbnZd1v1sEXELAjBNSDBQNMaB7MgqOyrBgI27CYikEgdaDnBrXghAXYWTBs/h5Bw==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@react-email/render': '*'
+    peerDependenciesMeta:
+      '@react-email/render':
+        optional: true
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -2690,6 +2932,9 @@ packages:
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  selderee@0.11.0:
+    resolution: {integrity: sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==}
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -2771,6 +3016,9 @@ packages:
 
   standard-as-callback@2.1.0:
     resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
+
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
@@ -2861,6 +3109,9 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  svix@1.90.0:
+    resolution: {integrity: sha512-ljkZuyy2+IBEoESkIpn8sLM+sxJHQcPxlZFxU+nVDhltNfUMisMBzWX/UR8SjEnzoI28ZjCzMbmYAPwSTucoMw==}
 
   tailwindcss@4.2.2:
     resolution: {integrity: sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==}
@@ -2957,6 +3208,10 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  uuid@10.0.0:
+    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    hasBin: true
 
   uuid@11.1.0:
     resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
@@ -3527,6 +3782,137 @@ snapshots:
     dependencies:
       '@prisma/debug': 6.19.3
 
+  '@react-email/body@0.3.0(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+
+  '@react-email/button@0.2.1(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+
+  '@react-email/code-block@0.2.1(react@19.2.5)':
+    dependencies:
+      prismjs: 1.30.0
+      react: 19.2.5
+
+  '@react-email/code-inline@0.0.6(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+
+  '@react-email/column@0.0.14(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+
+  '@react-email/components@1.0.12(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@react-email/body': 0.3.0(react@19.2.5)
+      '@react-email/button': 0.2.1(react@19.2.5)
+      '@react-email/code-block': 0.2.1(react@19.2.5)
+      '@react-email/code-inline': 0.0.6(react@19.2.5)
+      '@react-email/column': 0.0.14(react@19.2.5)
+      '@react-email/container': 0.0.16(react@19.2.5)
+      '@react-email/font': 0.0.10(react@19.2.5)
+      '@react-email/head': 0.0.13(react@19.2.5)
+      '@react-email/heading': 0.0.16(react@19.2.5)
+      '@react-email/hr': 0.0.12(react@19.2.5)
+      '@react-email/html': 0.0.12(react@19.2.5)
+      '@react-email/img': 0.0.12(react@19.2.5)
+      '@react-email/link': 0.0.13(react@19.2.5)
+      '@react-email/markdown': 0.0.18(react@19.2.5)
+      '@react-email/preview': 0.0.14(react@19.2.5)
+      '@react-email/render': 2.0.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@react-email/row': 0.0.13(react@19.2.5)
+      '@react-email/section': 0.0.17(react@19.2.5)
+      '@react-email/tailwind': 2.0.7(@react-email/body@0.3.0(react@19.2.5))(@react-email/button@0.2.1(react@19.2.5))(@react-email/code-block@0.2.1(react@19.2.5))(@react-email/code-inline@0.0.6(react@19.2.5))(@react-email/container@0.0.16(react@19.2.5))(@react-email/heading@0.0.16(react@19.2.5))(@react-email/hr@0.0.12(react@19.2.5))(@react-email/img@0.0.12(react@19.2.5))(@react-email/link@0.0.13(react@19.2.5))(@react-email/preview@0.0.14(react@19.2.5))(@react-email/text@0.1.6(react@19.2.5))(react@19.2.5)
+      '@react-email/text': 0.1.6(react@19.2.5)
+      react: 19.2.5
+    transitivePeerDependencies:
+      - react-dom
+
+  '@react-email/container@0.0.16(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+
+  '@react-email/font@0.0.10(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+
+  '@react-email/head@0.0.13(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+
+  '@react-email/heading@0.0.16(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+
+  '@react-email/hr@0.0.12(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+
+  '@react-email/html@0.0.12(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+
+  '@react-email/img@0.0.12(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+
+  '@react-email/link@0.0.13(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+
+  '@react-email/markdown@0.0.18(react@19.2.5)':
+    dependencies:
+      marked: 15.0.12
+      react: 19.2.5
+
+  '@react-email/preview@0.0.14(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+
+  '@react-email/render@2.0.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      html-to-text: 9.0.5
+      prettier: 3.8.3
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+
+  '@react-email/render@2.0.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      html-to-text: 9.0.5
+      prettier: 3.8.3
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+
+  '@react-email/row@0.0.13(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+
+  '@react-email/section@0.0.17(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+
+  '@react-email/tailwind@2.0.7(@react-email/body@0.3.0(react@19.2.5))(@react-email/button@0.2.1(react@19.2.5))(@react-email/code-block@0.2.1(react@19.2.5))(@react-email/code-inline@0.0.6(react@19.2.5))(@react-email/container@0.0.16(react@19.2.5))(@react-email/heading@0.0.16(react@19.2.5))(@react-email/hr@0.0.12(react@19.2.5))(@react-email/img@0.0.12(react@19.2.5))(@react-email/link@0.0.13(react@19.2.5))(@react-email/preview@0.0.14(react@19.2.5))(@react-email/text@0.1.6(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@react-email/text': 0.1.6(react@19.2.5)
+      react: 19.2.5
+      tailwindcss: 4.2.2
+    optionalDependencies:
+      '@react-email/body': 0.3.0(react@19.2.5)
+      '@react-email/button': 0.2.1(react@19.2.5)
+      '@react-email/code-block': 0.2.1(react@19.2.5)
+      '@react-email/code-inline': 0.0.6(react@19.2.5)
+      '@react-email/container': 0.0.16(react@19.2.5)
+      '@react-email/heading': 0.0.16(react@19.2.5)
+      '@react-email/hr': 0.0.12(react@19.2.5)
+      '@react-email/img': 0.0.12(react@19.2.5)
+      '@react-email/link': 0.0.13(react@19.2.5)
+      '@react-email/preview': 0.0.14(react@19.2.5)
+
+  '@react-email/text@0.1.6(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+
   '@redis/bloom@1.2.0(@redis/client@1.6.1)':
     dependencies:
       '@redis/client': 1.6.1
@@ -3631,6 +4017,13 @@ snapshots:
   '@rtsao/scc@1.1.0': {}
 
   '@rushstack/eslint-patch@1.16.1': {}
+
+  '@selderee/plugin-htmlparser2@0.11.0':
+    dependencies:
+      domhandler: 5.0.3
+      selderee: 0.11.0
+
+  '@stablelib/base64@1.0.1': {}
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -4249,6 +4642,8 @@ snapshots:
 
   deepmerge-ts@7.1.5: {}
 
+  deepmerge@4.3.1: {}
+
   define-data-property@1.1.4:
     dependencies:
       es-define-property: 1.0.1
@@ -4272,6 +4667,24 @@ snapshots:
   doctrine@2.1.0:
     dependencies:
       esutils: 2.0.3
+
+  dom-serializer@2.0.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+
+  domelementtype@2.3.0: {}
+
+  domhandler@5.0.3:
+    dependencies:
+      domelementtype: 2.3.0
+
+  domutils@3.2.2:
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
 
   dotenv@16.6.1: {}
 
@@ -4302,6 +4715,8 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.2
+
+  entities@4.5.0: {}
 
   environment@1.1.0: {}
 
@@ -4677,6 +5092,8 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-sha256@1.3.0: {}
+
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
@@ -4831,6 +5248,21 @@ snapshots:
   hono@4.12.14: {}
 
   html-escaper@2.0.2: {}
+
+  html-to-text@9.0.5:
+    dependencies:
+      '@selderee/plugin-htmlparser2': 0.11.0
+      deepmerge: 4.3.1
+      dom-serializer: 2.0.0
+      htmlparser2: 8.0.2
+      selderee: 0.11.0
+
+  htmlparser2@8.0.2:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 4.5.0
 
   human-signals@5.0.0: {}
 
@@ -5068,6 +5500,8 @@ snapshots:
     dependencies:
       language-subtag-registry: 0.3.23
 
+  leac@0.6.0: {}
+
   levn@0.4.1:
     dependencies:
       prelude-ls: 1.2.1
@@ -5191,6 +5625,8 @@ snapshots:
   make-dir@4.0.0:
     dependencies:
       semver: 7.7.4
+
+  marked@15.0.12: {}
 
   math-intrinsics@1.1.0: {}
 
@@ -5382,6 +5818,11 @@ snapshots:
     dependencies:
       callsites: 3.1.0
 
+  parseley@0.12.1:
+    dependencies:
+      leac: 0.6.0
+      peberminta: 0.9.0
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
@@ -5398,6 +5839,8 @@ snapshots:
   pathe@2.0.3: {}
 
   pathval@2.0.1: {}
+
+  peberminta@0.9.0: {}
 
   perfect-debounce@1.0.0: {}
 
@@ -5460,6 +5903,8 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
+  postal-mime@2.7.4: {}
+
   postcss@8.4.31:
     dependencies:
       nanoid: 3.3.11
@@ -5498,6 +5943,8 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - magicast
+
+  prismjs@1.30.0: {}
 
   prop-types@15.8.1:
     dependencies:
@@ -5565,6 +6012,13 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       set-function-name: 2.0.2
+
+  resend@6.12.0(@react-email/render@2.0.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)):
+    dependencies:
+      postal-mime: 2.7.4
+      svix: 1.90.0
+    optionalDependencies:
+      '@react-email/render': 2.0.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
 
   resolve-from@4.0.0: {}
 
@@ -5643,6 +6097,10 @@ snapshots:
       is-regex: 1.2.1
 
   scheduler@0.27.0: {}
+
+  selderee@0.11.0:
+    dependencies:
+      parseley: 0.12.1
 
   semver@6.3.1: {}
 
@@ -5760,6 +6218,11 @@ snapshots:
 
   standard-as-callback@2.1.0: {}
 
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
+
   std-env@3.10.0: {}
 
   stop-iteration-iterator@1.1.0:
@@ -5865,6 +6328,11 @@ snapshots:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  svix@1.90.0:
+    dependencies:
+      standardwebhooks: 1.0.0
+      uuid: 10.0.0
 
   tailwindcss@4.2.2: {}
 
@@ -5992,6 +6460,8 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  uuid@10.0.0: {}
 
   uuid@11.1.0: {}
 

--- a/src/lib/jobs/job-types.ts
+++ b/src/lib/jobs/job-types.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod'
 import { exportRequestSchema } from '@/lib/export/export-types'
 import { importRequestSchema } from '@/lib/import/import-types'
+import { NOTIFICATION_CATEGORIES } from '@/lib/notification/notification-types'
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Job 名一覧
@@ -31,6 +32,10 @@ export const jobPayloadSchema = {
     body: z.string().min(1),
     templateId: z.string().optional(),
     variables: z.record(z.string()).optional(),
+    // 任意メタデータ: 通知ログ記録時に userId / カテゴリを解決するために使用。
+    // NotificationService が emit 時に付与することを想定（後方互換のため optional）。
+    userId: z.string().min(1).optional(),
+    category: z.enum(NOTIFICATION_CATEGORIES).optional(),
   }),
 
   'export-csv': exportRequestSchema,

--- a/src/lib/notification/email-sender.ts
+++ b/src/lib/notification/email-sender.ts
@@ -1,0 +1,89 @@
+import { Resend } from 'resend'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Interface
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * メール送信抽象。
+ * 実装は Resend 等のベンダー固有 SDK を隠蔽する。
+ */
+export interface EmailSender {
+  send(input: SendEmailInput): Promise<void>
+}
+
+export interface SendEmailInput {
+  /** 宛先メールアドレス */
+  to: string
+  /** 差出人 (省略時は env FROM / ハードコードされたデフォルト) */
+  from?: string
+  /** メール件名 */
+  subject: string
+  /** メール本文 (レンダリング済み HTML) */
+  html: string
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 定数
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * 差出人フォールバック。環境変数 `EMAIL_FROM` で上書き可能。
+ * 本番では自社ドメインに差し替えること。
+ */
+const DEFAULT_FROM = 'HR Management System <noreply@example.com>'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Implementation
+// ─────────────────────────────────────────────────────────────────────────────
+
+class ResendEmailSender implements EmailSender {
+  private readonly client: Resend
+  private readonly defaultFrom: string
+
+  constructor(client: Resend, defaultFrom: string) {
+    this.client = client
+    this.defaultFrom = defaultFrom
+  }
+
+  async send(input: SendEmailInput): Promise<void> {
+    const response = await this.client.emails.send({
+      from: input.from ?? this.defaultFrom,
+      to: input.to,
+      subject: input.subject,
+      html: input.html,
+    })
+
+    // Resend SDK は { data, error } の Result 型を返す。
+    // エラー時は BullMQ のリトライ機構に委ねるため throw する。
+    if (response.error) {
+      throw new Error(
+        `Resend send failed: ${response.error.name} - ${response.error.message}`,
+      )
+    }
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Factory
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Resend クライアントをラップした EmailSender を生成する。
+ * API キーが空の場合はフェイルファストする（サイレントな送信失敗を防ぐ）。
+ *
+ * @param apiKey Resend API キー。通常 `process.env.RESEND_API_KEY` から渡す
+ * @param defaultFrom 差出人メールアドレス。省略時は env `EMAIL_FROM` → DEFAULT_FROM
+ */
+export function createResendEmailSender(
+  apiKey: string,
+  defaultFrom?: string,
+): EmailSender {
+  if (!apiKey || apiKey.trim().length === 0) {
+    throw new Error('RESEND_API_KEY is required to create an email sender')
+  }
+
+  const client = new Resend(apiKey)
+  const resolvedFrom = defaultFrom ?? process.env.EMAIL_FROM ?? DEFAULT_FROM
+  return new ResendEmailSender(client, resolvedFrom)
+}

--- a/src/lib/notification/email-templates/notification-email.tsx
+++ b/src/lib/notification/email-templates/notification-email.tsx
@@ -1,0 +1,146 @@
+import * as React from 'react'
+import {
+  Body,
+  Button,
+  Container,
+  Head,
+  Heading,
+  Hr,
+  Html,
+  Preview,
+  Section,
+  Text,
+} from '@react-email/components'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Props
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface NotificationEmailProps {
+  /** メール本文の見出し */
+  title: string
+  /** メール本文（改行は \n で区切る） */
+  body: string
+  /** 任意の CTA 導線。未指定ならボタン非表示 */
+  actionUrl?: string
+  /** CTA ボタンのラベル。actionUrl 指定時のみ使用。既定値は "詳細を確認" */
+  actionLabel?: string
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Styles（インライン: メールクライアントの CSS 対応バラつきを吸収）
+// ─────────────────────────────────────────────────────────────────────────────
+
+const COLOR_TEXT = '#1f2937'
+const COLOR_MUTED = '#6b7280'
+const COLOR_BORDER = '#e5e7eb'
+const COLOR_ACCENT = '#2563eb'
+const COLOR_ACCENT_TEXT = '#ffffff'
+
+const main: React.CSSProperties = {
+  backgroundColor: '#f9fafb',
+  fontFamily:
+    '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Hiragino Kaku Gothic ProN", "Hiragino Sans", "Yu Gothic", Meiryo, sans-serif',
+  padding: '24px 0',
+}
+
+const container: React.CSSProperties = {
+  backgroundColor: '#ffffff',
+  border: `1px solid ${COLOR_BORDER}`,
+  borderRadius: '8px',
+  margin: '0 auto',
+  maxWidth: '600px',
+  padding: '32px',
+}
+
+const heading: React.CSSProperties = {
+  color: COLOR_TEXT,
+  fontSize: '20px',
+  fontWeight: 600,
+  lineHeight: 1.4,
+  margin: '0 0 16px',
+}
+
+const paragraph: React.CSSProperties = {
+  color: COLOR_TEXT,
+  fontSize: '14px',
+  lineHeight: 1.7,
+  margin: '0 0 12px',
+  whiteSpace: 'pre-wrap',
+}
+
+const actionSection: React.CSSProperties = {
+  margin: '24px 0 8px',
+  textAlign: 'center',
+}
+
+const actionButton: React.CSSProperties = {
+  backgroundColor: COLOR_ACCENT,
+  borderRadius: '6px',
+  color: COLOR_ACCENT_TEXT,
+  display: 'inline-block',
+  fontSize: '14px',
+  fontWeight: 600,
+  padding: '12px 24px',
+  textDecoration: 'none',
+}
+
+const divider: React.CSSProperties = {
+  border: 'none',
+  borderTop: `1px solid ${COLOR_BORDER}`,
+  margin: '24px 0',
+}
+
+const footerText: React.CSSProperties = {
+  color: COLOR_MUTED,
+  fontSize: '12px',
+  lineHeight: 1.6,
+  margin: 0,
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Component
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * 汎用通知メールテンプレート。
+ * タイトル、本文、任意のアクション URL を受け取り、レスポンシブな
+ * HTML メールを生成する。
+ */
+export function NotificationEmail({
+  title,
+  body,
+  actionUrl,
+  actionLabel = '詳細を確認',
+}: NotificationEmailProps) {
+  return (
+    <Html lang="ja">
+      <Head />
+      <Preview>{title}</Preview>
+      <Body style={main}>
+        <Container style={container}>
+          <Heading as="h1" style={heading}>
+            {title}
+          </Heading>
+          <Section>
+            <Text style={paragraph}>{body}</Text>
+          </Section>
+          {actionUrl ? (
+            <Section style={actionSection}>
+              <Button href={actionUrl} style={actionButton}>
+                {actionLabel}
+              </Button>
+            </Section>
+          ) : null}
+          <Hr style={divider} />
+          <Text style={footerText}>
+            本メールは HR Management System から自動送信されています。
+            心当たりのない場合はお手数ですがシステム管理者までご連絡ください。
+          </Text>
+        </Container>
+      </Body>
+    </Html>
+  )
+}
+
+export default NotificationEmail

--- a/src/lib/notification/email-worker.ts
+++ b/src/lib/notification/email-worker.ts
@@ -1,0 +1,213 @@
+import type { Job, Worker } from 'bullmq'
+import { render } from '@react-email/render'
+import { createBaseWorker } from '@/lib/jobs/base-worker'
+import { jobPayloadSchema } from '@/lib/jobs/job-types'
+import type { JobPayloadMap } from '@/lib/jobs/job-types'
+import { NotificationEmail } from './email-templates/notification-email'
+import type { EmailSender } from './email-sender'
+import { createResendEmailSender } from './email-sender'
+import type {
+  NotificationLogEntry,
+  NotificationLogRecorder,
+} from './notification-log-recorder'
+import { createInMemoryLogRecorder } from './notification-log-recorder'
+import type { NotificationCategory } from './notification-types'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 定数
+// ─────────────────────────────────────────────────────────────────────────────
+
+const QUEUE_NAME = 'send-email'
+const CHANNEL_EMAIL = 'EMAIL' as const
+const DEFAULT_CATEGORY: NotificationCategory = 'SYSTEM'
+/** BullMQ のリトライ上限。job-queue.ts の DEFAULT_JOB_OPTIONS.attempts と一致させる */
+const MAX_ATTEMPTS = 3
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type SendEmailPayload = JobPayloadMap['send-email']
+
+export interface EmailWorkerDeps {
+  sender: EmailSender
+  recorder: NotificationLogRecorder
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ヘルパー
+// ─────────────────────────────────────────────────────────────────────────────
+
+function extractUserId(payload: SendEmailPayload): string {
+  // send-email ペイロードが userId を拡張フィールドで持つ可能性を許容する
+  const raw = (payload as Record<string, unknown>)['userId']
+  return typeof raw === 'string' && raw.length > 0 ? raw : payload.to
+}
+
+function extractCategory(payload: SendEmailPayload): NotificationCategory {
+  const raw = (payload as Record<string, unknown>)['category']
+  return typeof raw === 'string' && isNotificationCategoryString(raw)
+    ? raw
+    : DEFAULT_CATEGORY
+}
+
+function isNotificationCategoryString(value: string): value is NotificationCategory {
+  const categories: readonly NotificationCategory[] = [
+    'EVAL_INVITATION',
+    'EVAL_REMINDER',
+    'GOAL_APPROVAL_REQUEST',
+    'ONE_ON_ONE_REMINDER',
+    'DEADLINE_ALERT',
+    'FEEDBACK_PUBLISHED',
+    'SYSTEM',
+    'CUSTOM',
+  ]
+  return (categories as readonly string[]).includes(value)
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message
+  if (typeof error === 'string') return error
+  return 'Unknown error'
+}
+
+function buildLogEntry(args: {
+  payload: SendEmailPayload
+  attempts: number
+  status: NotificationLogEntry['status']
+  errorDetail: string | null
+}): NotificationLogEntry {
+  return {
+    userId: extractUserId(args.payload),
+    category: extractCategory(args.payload),
+    channel: CHANNEL_EMAIL,
+    subject: args.payload.subject,
+    status: args.status,
+    attempts: args.attempts,
+    errorDetail: args.errorDetail,
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ジョブプロセッサ（純粋に近い関数として切り出し: DI でテスタブル）
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * send-email ジョブを処理する。
+ * - ペイロードを jobPayloadSchema で境界バリデーション
+ * - React Email テンプレートから HTML をレンダリング
+ * - EmailSender.send で実送信
+ * - 成功時は NotificationLogRecorder に status='SENT' を記録
+ * - 失敗時はエラーを throw (BullMQ の attempts で自動リトライ)
+ */
+export async function processEmailJob(
+  job: Job,
+  deps: EmailWorkerDeps,
+): Promise<void> {
+  const parsed = jobPayloadSchema['send-email'].safeParse(job.data)
+  if (!parsed.success) {
+    throw new Error(
+      `EmailWorker: invalid payload for job "${job.id ?? 'unknown'}": ${parsed.error.message}`,
+    )
+  }
+
+  const payload = parsed.data
+  const attempts = typeof job.attemptsMade === 'number' ? job.attemptsMade + 1 : 1
+
+  const html = await render(
+    NotificationEmail({
+      title: payload.subject,
+      body: payload.body,
+    }),
+  )
+
+  try {
+    await deps.sender.send({
+      to: payload.to,
+      subject: payload.subject,
+      html,
+    })
+  } catch (error: unknown) {
+    // 途中失敗はリトライ継続 (RETRYING を記録)。最終失敗は worker 'failed' で FAILED を記録
+    if (attempts < MAX_ATTEMPTS) {
+      await deps.recorder.record(
+        buildLogEntry({
+          payload,
+          attempts,
+          status: 'RETRYING',
+          errorDetail: getErrorMessage(error),
+        }),
+      )
+    }
+    throw error
+  }
+
+  await deps.recorder.record(
+    buildLogEntry({
+      payload,
+      attempts,
+      status: 'SENT',
+      errorDetail: null,
+    }),
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 最終失敗フック (attemptsMade >= MAX_ATTEMPTS で FAILED を記録)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Worker の 'failed' イベントに FAILED ログ記録をフックする。
+ * テストから直接呼び出せるよう worker と recorder を引数で受け取る。
+ */
+export function attachFinalFailureLogging(
+  worker: Worker,
+  recorder: NotificationLogRecorder,
+): void {
+  worker.on('failed', (job, err) => {
+    if (!job) return
+    const attemptsMade = typeof job.attemptsMade === 'number' ? job.attemptsMade : 0
+    if (attemptsMade < MAX_ATTEMPTS) return
+
+    // 非同期 record は fire-and-forget (イベントハンドラは同期)。
+    // 失敗ログの記録自体が失敗した場合は console へフォールバック。
+    const parsed = jobPayloadSchema['send-email'].safeParse(job.data)
+    if (!parsed.success) return
+
+    void recorder
+      .record(
+        buildLogEntry({
+          payload: parsed.data,
+          attempts: attemptsMade,
+          status: 'FAILED',
+          errorDetail: getErrorMessage(err),
+        }),
+      )
+      .catch((recordError: unknown) => {
+        console.error('[EmailWorker] failed to record FAILED log', {
+          jobId: job.id,
+          error: getErrorMessage(recordError),
+        })
+      })
+  })
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ワーカー起動ファクトリ
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * EmailWorker を起動する。
+ * sender / recorder を省略した場合は env `RESEND_API_KEY` からクライアントを生成し、
+ * recorder はインメモリ実装を利用する (本番は Prisma 実装を DI すること)。
+ */
+export function createEmailWorker(deps?: Partial<EmailWorkerDeps>): Worker {
+  const sender = deps?.sender ?? createResendEmailSender(process.env.RESEND_API_KEY ?? '')
+  const recorder = deps?.recorder ?? createInMemoryLogRecorder()
+
+  const worker = createBaseWorker(QUEUE_NAME, (job: Job) =>
+    processEmailJob(job, { sender, recorder }),
+  )
+  attachFinalFailureLogging(worker, recorder)
+  return worker
+}

--- a/src/lib/notification/notification-log-recorder.ts
+++ b/src/lib/notification/notification-log-recorder.ts
@@ -1,0 +1,73 @@
+import type {
+  DeliveryStatus,
+  NotificationCategory,
+  NotificationChannel,
+} from './notification-types'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * 通知配信ログ 1 エントリ分。
+ * Requirement 15.7: 宛先・内容・送信結果・タイムスタンプを記録
+ */
+export interface NotificationLogEntry {
+  userId: string
+  category: NotificationCategory
+  channel: NotificationChannel
+  /** 件名。IN_APP など件名を持たないチャネルでは null */
+  subject: string | null
+  status: DeliveryStatus
+  /** 試行回数 (1 が初回) */
+  attempts: number
+  /** 失敗時のエラー詳細。成功時は null */
+  errorDetail: string | null
+  /** 記録時刻 (UTC ISO8601)。record 実装が自動付与するため外部入力不可 */
+  readonly recordedAt?: string
+}
+
+export interface NotificationLogRecorder {
+  record(entry: NotificationLogEntry): Promise<void>
+}
+
+/**
+ * テスト用: 記録された全エントリを参照できる InMemory 版。
+ */
+export interface InMemoryNotificationLogRecorder extends NotificationLogRecorder {
+  readonly entries: readonly NotificationLogEntry[]
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// In-memory 実装
+// ─────────────────────────────────────────────────────────────────────────────
+
+class InMemoryLogRecorder implements InMemoryNotificationLogRecorder {
+  private readonly store: NotificationLogEntry[] = []
+
+  async record(entry: NotificationLogEntry): Promise<void> {
+    // 不変性: 入力を直接参照せず、タイムスタンプ付きの新オブジェクトを push する
+    const stamped: NotificationLogEntry = {
+      ...entry,
+      recordedAt: entry.recordedAt ?? new Date().toISOString(),
+    }
+    this.store.push(stamped)
+  }
+
+  get entries(): readonly NotificationLogEntry[] {
+    // 外部からの破壊的変更を防ぐため防御コピーを返す
+    return this.store.slice()
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Factory
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * テスト用のインメモリ NotificationLogRecorder を生成する。
+ * 本番用の Prisma 実装は別タスク（Task 4.3 以降）で提供予定。
+ */
+export function createInMemoryLogRecorder(): InMemoryNotificationLogRecorder {
+  return new InMemoryLogRecorder()
+}

--- a/src/tests/notification/email-sender.test.ts
+++ b/src/tests/notification/email-sender.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { createResendEmailSender } from '@/lib/notification/email-sender'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Resend SDK をモック
+// ─────────────────────────────────────────────────────────────────────────────
+
+const mockResendSend = vi.fn()
+
+vi.mock('resend', () => ({
+  Resend: vi.fn().mockImplementation(() => ({
+    emails: {
+      send: mockResendSend,
+    },
+  })),
+}))
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('createResendEmailSender()', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockResendSend.mockReset()
+  })
+
+  it('should throw when apiKey is empty string', () => {
+    expect(() => createResendEmailSender('')).toThrow(/RESEND_API_KEY/)
+  })
+
+  it('should throw when apiKey is whitespace only', () => {
+    expect(() => createResendEmailSender('   ')).toThrow(/RESEND_API_KEY/)
+  })
+
+  it('should return a sender when apiKey is provided', () => {
+    const sender = createResendEmailSender('test-api-key')
+    expect(sender).toBeDefined()
+    expect(typeof sender.send).toBe('function')
+  })
+
+  it('should call Resend.emails.send with correct arguments', async () => {
+    mockResendSend.mockResolvedValue({ data: { id: 'msg-1' }, error: null })
+    const sender = createResendEmailSender('test-api-key', 'from@example.com')
+
+    await sender.send({
+      to: 'user@example.com',
+      subject: 'テスト件名',
+      html: '<p>Hello</p>',
+    })
+
+    expect(mockResendSend).toHaveBeenCalledOnce()
+    expect(mockResendSend).toHaveBeenCalledWith({
+      from: 'from@example.com',
+      to: 'user@example.com',
+      subject: 'テスト件名',
+      html: '<p>Hello</p>',
+    })
+  })
+
+  it('should allow per-call from override', async () => {
+    mockResendSend.mockResolvedValue({ data: { id: 'msg-2' }, error: null })
+    const sender = createResendEmailSender('test-api-key', 'default@example.com')
+
+    await sender.send({
+      from: 'override@example.com',
+      to: 'user@example.com',
+      subject: 'S',
+      html: '<p>H</p>',
+    })
+
+    expect(mockResendSend).toHaveBeenCalledWith(
+      expect.objectContaining({ from: 'override@example.com' }),
+    )
+  })
+
+  it('should throw when Resend returns an error result', async () => {
+    mockResendSend.mockResolvedValue({
+      data: null,
+      error: { name: 'validation_error', message: 'Invalid from address' },
+    })
+    const sender = createResendEmailSender('test-api-key', 'from@example.com')
+
+    await expect(
+      sender.send({ to: 'user@example.com', subject: 'S', html: '<p>H</p>' }),
+    ).rejects.toThrow(/Invalid from address/)
+  })
+
+  it('should propagate network errors from Resend client', async () => {
+    mockResendSend.mockRejectedValue(new Error('network down'))
+    const sender = createResendEmailSender('test-api-key', 'from@example.com')
+
+    await expect(
+      sender.send({ to: 'user@example.com', subject: 'S', html: '<p>H</p>' }),
+    ).rejects.toThrow(/network down/)
+  })
+})

--- a/src/tests/notification/email-worker.test.ts
+++ b/src/tests/notification/email-worker.test.ts
@@ -1,0 +1,254 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { Job, Worker } from 'bullmq'
+import {
+  processEmailJob,
+  attachFinalFailureLogging,
+} from '@/lib/notification/email-worker'
+import type { EmailWorkerDeps } from '@/lib/notification/email-worker'
+import type { EmailSender } from '@/lib/notification/email-sender'
+import { createInMemoryLogRecorder } from '@/lib/notification/notification-log-recorder'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 外部依存のモック
+// ─────────────────────────────────────────────────────────────────────────────
+
+vi.mock('@/lib/jobs/redis-connection', () => ({
+  createRedisConnection: vi.fn(() => ({})),
+}))
+vi.mock('bullmq', () => ({
+  Queue: vi.fn().mockImplementation(() => ({
+    add: vi.fn().mockResolvedValue({ id: 'job-abc' }),
+    getJob: vi.fn().mockResolvedValue(null),
+    close: vi.fn(),
+  })),
+  Worker: vi.fn().mockImplementation(() => ({ on: vi.fn(), close: vi.fn() })),
+}))
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ヘルパー
+// ─────────────────────────────────────────────────────────────────────────────
+
+function makeJob(data: Record<string, unknown>, overrides: Partial<Job> = {}): Job {
+  return {
+    id: 'job-1',
+    data,
+    attemptsMade: 0,
+    ...overrides,
+  } as unknown as Job
+}
+
+function makeDeps(sender?: EmailSender): EmailWorkerDeps & {
+  recorder: ReturnType<typeof createInMemoryLogRecorder>
+  sendMock: ReturnType<typeof vi.fn>
+} {
+  const sendMock = vi.fn().mockResolvedValue(undefined)
+  const resolvedSender: EmailSender = sender ?? { send: sendMock }
+  const recorder = createInMemoryLogRecorder()
+  return { sender: resolvedSender, recorder, sendMock }
+}
+
+function validPayload() {
+  return {
+    to: 'user@example.com',
+    subject: '評価依頼',
+    body: '評価を開始してください',
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests: processEmailJob
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('processEmailJob()', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should call EmailSender.send with rendered HTML on valid payload', async () => {
+    const deps = makeDeps()
+    const job = makeJob(validPayload())
+
+    await processEmailJob(job, deps)
+
+    expect(deps.sendMock).toHaveBeenCalledOnce()
+    const arg = deps.sendMock.mock.calls[0]?.[0] as {
+      to: string
+      subject: string
+      html: string
+    }
+    expect(arg.to).toBe('user@example.com')
+    expect(arg.subject).toBe('評価依頼')
+    expect(arg.html).toContain('<html')
+    expect(arg.html).toContain('評価依頼')
+  })
+
+  it('should record SENT log entry on success', async () => {
+    const deps = makeDeps()
+    const job = makeJob(validPayload())
+
+    await processEmailJob(job, deps)
+
+    expect(deps.recorder.entries).toHaveLength(1)
+    const entry = deps.recorder.entries[0]
+    expect(entry?.status).toBe('SENT')
+    expect(entry?.channel).toBe('EMAIL')
+    expect(entry?.subject).toBe('評価依頼')
+    expect(entry?.errorDetail).toBeNull()
+    expect(entry?.attempts).toBe(1)
+  })
+
+  it('should throw when EmailSender.send rejects', async () => {
+    const failingSender: EmailSender = {
+      send: vi.fn().mockRejectedValue(new Error('SMTP unreachable')),
+    }
+    const deps = makeDeps(failingSender)
+    const job = makeJob(validPayload())
+
+    await expect(processEmailJob(job, deps)).rejects.toThrow(/SMTP unreachable/)
+  })
+
+  it('should record RETRYING log entry on non-final failure', async () => {
+    const failingSender: EmailSender = {
+      send: vi.fn().mockRejectedValue(new Error('temporary glitch')),
+    }
+    const deps = makeDeps(failingSender)
+    // attemptsMade=0 -> attempts=1 < 3 (not final)
+    const job = makeJob(validPayload(), { attemptsMade: 0 } as Partial<Job>)
+
+    await expect(processEmailJob(job, deps)).rejects.toThrow(/temporary glitch/)
+
+    expect(deps.recorder.entries).toHaveLength(1)
+    const entry = deps.recorder.entries[0]
+    expect(entry?.status).toBe('RETRYING')
+    expect(entry?.errorDetail).toContain('temporary glitch')
+  })
+
+  it('should not record RETRYING on final attempt (defer FAILED to worker event)', async () => {
+    const failingSender: EmailSender = {
+      send: vi.fn().mockRejectedValue(new Error('final failure')),
+    }
+    const deps = makeDeps(failingSender)
+    // attemptsMade=2 -> attempts=3 which is MAX_ATTEMPTS
+    const job = makeJob(validPayload(), { attemptsMade: 2 } as Partial<Job>)
+
+    await expect(processEmailJob(job, deps)).rejects.toThrow(/final failure/)
+
+    expect(deps.recorder.entries).toHaveLength(0)
+  })
+
+  it('should throw validation error for invalid payload (missing subject)', async () => {
+    const deps = makeDeps()
+    const job = makeJob({ to: 'user@example.com', body: 'hello' })
+    await expect(processEmailJob(job, deps)).rejects.toThrow(/invalid payload/)
+    expect(deps.sendMock).not.toHaveBeenCalled()
+  })
+
+  it('should throw validation error for invalid email address', async () => {
+    const deps = makeDeps()
+    const job = makeJob({ to: 'not-an-email', subject: 'S', body: 'B' })
+    await expect(processEmailJob(job, deps)).rejects.toThrow(/invalid payload/)
+  })
+
+  it('should throw validation error for empty body', async () => {
+    const deps = makeDeps()
+    const job = makeJob({ to: 'user@example.com', subject: 'S', body: '' })
+    await expect(processEmailJob(job, deps)).rejects.toThrow(/invalid payload/)
+  })
+
+  it('should use extended userId/category fields when present in payload', async () => {
+    const deps = makeDeps()
+    const job = makeJob({
+      ...validPayload(),
+      userId: 'user-42',
+      category: 'EVAL_INVITATION',
+    })
+
+    await processEmailJob(job, deps)
+
+    const entry = deps.recorder.entries[0]
+    expect(entry?.userId).toBe('user-42')
+    expect(entry?.category).toBe('EVAL_INVITATION')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests: attachFinalFailureLogging (worker 'failed' イベントフック)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('attachFinalFailureLogging()', () => {
+  type FailedHandler = (job: Job | undefined, err: Error) => void
+
+  function makeWorkerStub(): {
+    worker: Worker
+    fire: (job: Job | undefined, err: Error) => void
+  } {
+    let handler: FailedHandler | null = null
+    const worker = {
+      on: vi.fn((event: string, h: FailedHandler) => {
+        if (event === 'failed') handler = h
+      }),
+    } as unknown as Worker
+    return {
+      worker,
+      fire: (job, err) => {
+        if (handler) handler(job, err)
+      },
+    }
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should record FAILED entry when attemptsMade >= MAX_ATTEMPTS', async () => {
+    const recorder = createInMemoryLogRecorder()
+    const { worker, fire } = makeWorkerStub()
+    attachFinalFailureLogging(worker, recorder)
+
+    const job = makeJob(validPayload(), { attemptsMade: 3 } as Partial<Job>)
+    fire(job, new Error('SMTP permanent failure'))
+
+    // record() は非同期のため Promise flush
+    await new Promise((r) => setImmediate(r))
+
+    expect(recorder.entries).toHaveLength(1)
+    const entry = recorder.entries[0]
+    expect(entry?.status).toBe('FAILED')
+    expect(entry?.errorDetail).toContain('SMTP permanent failure')
+    expect(entry?.attempts).toBe(3)
+  })
+
+  it('should not record when attemptsMade < MAX_ATTEMPTS', async () => {
+    const recorder = createInMemoryLogRecorder()
+    const { worker, fire } = makeWorkerStub()
+    attachFinalFailureLogging(worker, recorder)
+
+    const job = makeJob(validPayload(), { attemptsMade: 1 } as Partial<Job>)
+    fire(job, new Error('retry'))
+
+    await new Promise((r) => setImmediate(r))
+    expect(recorder.entries).toHaveLength(0)
+  })
+
+  it('should ignore undefined job', async () => {
+    const recorder = createInMemoryLogRecorder()
+    const { worker, fire } = makeWorkerStub()
+    attachFinalFailureLogging(worker, recorder)
+
+    fire(undefined, new Error('no job'))
+    await new Promise((r) => setImmediate(r))
+    expect(recorder.entries).toHaveLength(0)
+  })
+
+  it('should skip logging when payload is invalid', async () => {
+    const recorder = createInMemoryLogRecorder()
+    const { worker, fire } = makeWorkerStub()
+    attachFinalFailureLogging(worker, recorder)
+
+    const job = makeJob({ invalid: 'shape' }, { attemptsMade: 3 } as Partial<Job>)
+    fire(job, new Error('validation'))
+
+    await new Promise((r) => setImmediate(r))
+    expect(recorder.entries).toHaveLength(0)
+  })
+})

--- a/src/tests/notification/notification-log-recorder.test.ts
+++ b/src/tests/notification/notification-log-recorder.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { createInMemoryLogRecorder } from '@/lib/notification/notification-log-recorder'
+import type { NotificationLogEntry } from '@/lib/notification/notification-log-recorder'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ヘルパー
+// ─────────────────────────────────────────────────────────────────────────────
+
+function makeEntry(overrides: Partial<NotificationLogEntry> = {}): NotificationLogEntry {
+  return {
+    userId: 'user-1',
+    category: 'SYSTEM',
+    channel: 'EMAIL',
+    subject: 'テスト件名',
+    status: 'SENT',
+    attempts: 1,
+    errorDetail: null,
+    ...overrides,
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('createInMemoryLogRecorder()', () => {
+  let recorder: ReturnType<typeof createInMemoryLogRecorder>
+
+  beforeEach(() => {
+    recorder = createInMemoryLogRecorder()
+  })
+
+  it('should start with an empty entries list', () => {
+    expect(recorder.entries).toEqual([])
+  })
+
+  it('should record a SENT entry', async () => {
+    await recorder.record(makeEntry())
+    expect(recorder.entries).toHaveLength(1)
+    expect(recorder.entries[0]?.status).toBe('SENT')
+  })
+
+  it('should record multiple entries in order', async () => {
+    await recorder.record(makeEntry({ status: 'RETRYING', attempts: 1 }))
+    await recorder.record(makeEntry({ status: 'SENT', attempts: 2 }))
+    expect(recorder.entries).toHaveLength(2)
+    expect(recorder.entries[0]?.status).toBe('RETRYING')
+    expect(recorder.entries[1]?.status).toBe('SENT')
+  })
+
+  it('should stamp recordedAt automatically when omitted', async () => {
+    await recorder.record(makeEntry())
+    const entry = recorder.entries[0]
+    expect(entry?.recordedAt).toBeDefined()
+    // ISO8601 な形を確認
+    expect(entry?.recordedAt).toMatch(/\d{4}-\d{2}-\d{2}T/)
+  })
+
+  it('should preserve caller-provided recordedAt when present', async () => {
+    const fixed = '2026-04-17T00:00:00.000Z'
+    await recorder.record(makeEntry({ recordedAt: fixed }))
+    expect(recorder.entries[0]?.recordedAt).toBe(fixed)
+  })
+
+  it('should return a defensive copy from entries getter', async () => {
+    await recorder.record(makeEntry())
+    const snapshot = recorder.entries
+    // 参照を mutate しても内部 store に影響しないこと
+    ;(snapshot as NotificationLogEntry[]).pop()
+    expect(recorder.entries).toHaveLength(1)
+  })
+
+  it('should record FAILED entry with errorDetail', async () => {
+    await recorder.record(
+      makeEntry({ status: 'FAILED', attempts: 3, errorDetail: 'SMTP timeout' }),
+    )
+    const entry = recorder.entries[0]
+    expect(entry?.status).toBe('FAILED')
+    expect(entry?.errorDetail).toBe('SMTP timeout')
+    expect(entry?.attempts).toBe(3)
+  })
+
+  it('should record entries for each category independently', async () => {
+    await recorder.record(makeEntry({ category: 'EVAL_INVITATION' }))
+    await recorder.record(makeEntry({ category: 'FEEDBACK_PUBLISHED' }))
+    expect(recorder.entries.map((e) => e.category)).toEqual([
+      'EVAL_INVITATION',
+      'FEEDBACK_PUBLISHED',
+    ])
+  })
+})


### PR DESCRIPTION
## Summary

Resend + React Email を利用した汎用メール配信 Worker を実装。BullMQ の `attempts: 3` + 指数バックオフ (1s/2s/4s) に委譲し、成功/途中失敗/最終失敗を NotificationLog に記録する。Prisma 実装は後続タスクのため、今回は抽象 + インメモリ実装を提供。

Closes #12

## 実装内容

- **NotificationEmail** (`src/lib/notification/email-templates/notification-email.tsx`): title/body/actionUrl を受け取る React Email 汎用テンプレート
- **EmailSender** (`src/lib/notification/email-sender.ts`): Resend SDK ラッパー。API キー未設定時は fail-fast、Resend の `{data, error}` 結果を Error に変換
- **NotificationLogRecorder** (`src/lib/notification/notification-log-recorder.ts`): ログ記録抽象 + InMemory 実装。`recordedAt` 自動付与、防御コピー返却
- **EmailWorker** (`src/lib/notification/email-worker.ts`):
  - `jobPayloadSchema['send-email']` で境界バリデーション
  - React Email `render` で HTML 生成 → `EmailSender.send`
  - 成功: SENT / 途中失敗: RETRYING / 最終失敗: 'failed' イベントフックで FAILED を記録
  - BullMQ のリトライは `job-queue.ts` の DEFAULT_JOB_OPTIONS (attempts: 3, exponential delay 1s) を利用
- **job-types.ts**: `send-email` ペイロードに optional `userId` / `category` フィールドを追加 (NotificationService が通知ログ用メタデータを埋め込めるよう後方互換的に拡張)
- 依存追加: `resend`, `@react-email/components`, `@react-email/render`

## テスト結果

```
Test Files  31 passed (31)
     Tests  304 passed (304)
```

新規テスト合計 28 件:
- `notification-log-recorder.test.ts`: 8 件 (記録、順序、recordedAt、防御コピー)
- `email-sender.test.ts`: 7 件 (APIキー検証、送信、エラー伝播)
- `email-worker.test.ts`: 13 件 (正常送信、各種バリデーション失敗、リトライ、最終失敗フック)

カバレッジ: `src/lib/notification/` 全体で 93.5% (閾値 80% 超過)。`email-sender.ts` 100%、`email-worker.ts` 88.6%、`notification-email.tsx` 94.6%。

## Requirements

- **15.4**: システムイベント発生時、通知設定に基づいて配信チャネルを決定し、非同期ジョブで送信 ✅
- **15.5**: メール送信失敗時、最大3回まで指数バックオフでリトライする ✅ (`attempts: 3`, backoff 1s/2s/4s)
- **15.7**: 送信した全通知のログ (宛先・内容・送信結果・タイムスタンプ) を記録 ✅

## Test plan

- [x] 正常送信: EmailSender.send が rendered HTML 付きで呼ばれ SENT ログが記録される
- [x] 送信失敗: EmailSender.send が reject するとエラー throw、途中失敗時は RETRYING 記録
- [x] ペイロード不正: 境界バリデーションで早期 throw (メール形式、空文字列、欠損)
- [x] 最終失敗時に 'failed' イベント経由で FAILED ログ記録
- [x] APIキー空/空白は createResendEmailSender が throw
- [x] 既存テスト (304 件) すべて通過 — 後方互換を維持
- [x] `pnpm lint` / `pnpm type-check` いずれも新規エラーなし (pre-existing Prisma 型エラー 31 件は本 PR と無関係)