### PR TITLE
feat(notification): Task 4.4 — カスタムブロードキャスト送信機能

### DIFF
--- a/src/lib/audit/audit-log-types.ts
+++ b/src/lib/audit/audit-log-types.ts
@@ -27,6 +27,8 @@ export const AUDIT_ACTIONS = [
   'EVALUATION_FINALIZED',
   // Export events (Requirement 17.2)
   'DATA_EXPORT',
+  // Custom broadcast notification events (Requirement 15.8)
+  'CUSTOM_BROADCAST_SENT',
 ] as const
 
 export type AuditAction = (typeof AUDIT_ACTIONS)[number]
@@ -52,6 +54,7 @@ export const AUDIT_RESOURCE_TYPES = [
   'MASTER_DATA',
   'EXPORT_JOB',
   'SYSTEM_CONFIG',
+  'NOTIFICATION',
 ] as const
 
 export type AuditResourceType = (typeof AUDIT_RESOURCE_TYPES)[number]

--- a/src/lib/notification/broadcast-target-resolver.ts
+++ b/src/lib/notification/broadcast-target-resolver.ts
@@ -1,0 +1,62 @@
+import type { BroadcastTarget } from './notification-types'
+import { BroadcastGroupNotFoundError } from './custom-broadcast-service'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** 通知の配信対象となる単一のユーザー（メールアドレス付き） */
+export interface BroadcastRecipient {
+  readonly userId: string
+  readonly email: string
+}
+
+/**
+ * 送信対象ユーザーを解決する。
+ * 将来的には UserRepository / GroupRepository が実装を提供する想定。
+ */
+export interface BroadcastTargetResolver {
+  resolve(target: BroadcastTarget): Promise<readonly BroadcastRecipient[]>
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// InMemory 実装（テスト用）
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface InMemorySeed {
+  readonly allUsers: readonly BroadcastRecipient[]
+  readonly groups: ReadonlyMap<string, readonly BroadcastRecipient[]>
+}
+
+class InMemoryBroadcastTargetResolver implements BroadcastTargetResolver {
+  private readonly allUsers: readonly BroadcastRecipient[]
+  private readonly groups: ReadonlyMap<string, readonly BroadcastRecipient[]>
+
+  constructor(seed: InMemorySeed) {
+    // 外部からの変更を遮断するため防御的コピーで保持する
+    this.allUsers = [...seed.allUsers]
+    const cloned = new Map<string, readonly BroadcastRecipient[]>()
+    for (const [groupId, members] of seed.groups) {
+      cloned.set(groupId, [...members])
+    }
+    this.groups = cloned
+  }
+
+  async resolve(target: BroadcastTarget): Promise<readonly BroadcastRecipient[]> {
+    if (target.type === 'ALL') {
+      // 毎回新しい配列を返し、呼び出し側に内部参照を露出させない
+      return [...this.allUsers]
+    }
+
+    const members = this.groups.get(target.groupId)
+    if (!members) {
+      throw new BroadcastGroupNotFoundError(target.groupId)
+    }
+    return [...members]
+  }
+}
+
+/** テスト用 InMemory 実装を生成する */
+export function createInMemoryBroadcastTargetResolver(seed: InMemorySeed): BroadcastTargetResolver {
+  return new InMemoryBroadcastTargetResolver(seed)
+}

--- a/src/lib/notification/custom-broadcast-service.ts
+++ b/src/lib/notification/custom-broadcast-service.ts
@@ -1,0 +1,197 @@
+import type { AuditLogEmitter } from '@/lib/audit/audit-log-emitter'
+import type { BroadcastRecipient, BroadcastTargetResolver } from './broadcast-target-resolver'
+import type { NotificationEmitter } from './notification-emitter'
+import type {
+  NotificationPreferenceRepository,
+  NotificationRepository,
+} from './notification-repository'
+import {
+  broadcastInputSchema,
+  type BroadcastInput,
+  type BroadcastTarget,
+  type NotificationPreferences,
+  type UserRole,
+} from './notification-types'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ドメイン例外
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** 実行ロールが HR_MANAGER / ADMIN のいずれでもない場合 */
+export class BroadcastForbiddenError extends Error {
+  constructor(role: UserRole) {
+    super(`Broadcast forbidden for role: ${role}`)
+    this.name = 'BroadcastForbiddenError'
+  }
+}
+
+/** target=GROUP で groupId に該当するグループが存在しない場合 */
+export class BroadcastGroupNotFoundError extends Error {
+  constructor(groupId: string) {
+    super(`Broadcast group not found: ${groupId}`)
+    this.name = 'BroadcastGroupNotFoundError'
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Public types
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** カスタムブロードキャスト送信者のコンテキスト */
+export interface BroadcastSender {
+  readonly userId: string
+  readonly role: UserRole
+}
+
+/** 監査ログに記録する HTTP リクエスト情報 */
+export interface BroadcastRequestContext {
+  readonly ipAddress: string
+  readonly userAgent: string
+}
+
+export interface BroadcastResult {
+  readonly deliveredCount: number
+}
+
+/**
+ * CustomBroadcastService — 手動カスタム通知（Req 15.8）
+ *
+ * - HR_MANAGER / ADMIN のみが呼び出し可能（最初にロール判定、それ以外の副作用を起こさない）
+ * - 対象ユーザーごとに、アプリ内通知を作成 + preferences に従ってメール emit
+ * - 成功後、1 回だけ CUSTOM_BROADCAST_SENT の監査ログを emit
+ */
+export interface CustomBroadcastService {
+  sendCustomBroadcast(
+    sender: BroadcastSender,
+    input: BroadcastInput,
+    context: BroadcastRequestContext,
+  ): Promise<BroadcastResult>
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 定数
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** ブロードキャスト実行を許可するロール */
+const ALLOWED_ROLES = new Set<UserRole>(['HR_MANAGER', 'ADMIN'])
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 内部ヘルパ
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * 指定ユーザーの CUSTOM カテゴリで email を送るべきか判定する。
+ * 保存された preferences が見つからない場合は emailEnabled=true がデフォルト（Req 15.3）。
+ */
+function shouldSendEmail(prefs: NotificationPreferences): boolean {
+  const custom = prefs.find((p) => p.category === 'CUSTOM')
+  if (!custom) {
+    return true
+  }
+  return custom.emailEnabled
+}
+
+interface Dependencies {
+  readonly emitter: NotificationEmitter
+  readonly notifications: NotificationRepository
+  readonly preferences: NotificationPreferenceRepository
+  readonly audit: AuditLogEmitter
+  readonly resolver: BroadcastTargetResolver
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Implementation
+// ─────────────────────────────────────────────────────────────────────────────
+
+class CustomBroadcastServiceImpl implements CustomBroadcastService {
+  constructor(private readonly deps: Dependencies) {}
+
+  async sendCustomBroadcast(
+    sender: BroadcastSender,
+    input: BroadcastInput,
+    context: BroadcastRequestContext,
+  ): Promise<BroadcastResult> {
+    // 1) ロール判定を最初に行い、それ以外の副作用を一切起こさない
+    if (!ALLOWED_ROLES.has(sender.role)) {
+      throw new BroadcastForbiddenError(sender.role)
+    }
+
+    // 2) Zod による入力検証
+    const validated = broadcastInputSchema.parse(input)
+
+    // 3) 対象ユーザーを解決（不明 groupId は BroadcastGroupNotFoundError）
+    const recipients = await this.deps.resolver.resolve(validated.target)
+
+    // 4) 各対象ユーザーに通知を配信
+    const deliveredCount = await this.deliverToRecipients({
+      recipients,
+      title: validated.title,
+      body: validated.body,
+      target: validated.target,
+      senderUserId: sender.userId,
+    })
+
+    // 5) 監査ログを 1 件だけ emit
+    await this.deps.audit.emit({
+      userId: sender.userId,
+      action: 'CUSTOM_BROADCAST_SENT',
+      resourceType: 'NOTIFICATION',
+      resourceId: null,
+      ipAddress: context.ipAddress,
+      userAgent: context.userAgent,
+      before: null,
+      after: {
+        title: validated.title,
+        body: validated.body,
+        target: validated.target,
+        deliveredCount,
+      },
+    })
+
+    return { deliveredCount }
+  }
+
+  private async deliverToRecipients(args: {
+    readonly recipients: readonly BroadcastRecipient[]
+    readonly title: string
+    readonly body: string
+    readonly target: BroadcastTarget
+    readonly senderUserId: string
+  }): Promise<number> {
+    const { recipients, title, body, target, senderUserId } = args
+    const payload = { broadcastBy: senderUserId, target }
+
+    let delivered = 0
+    for (const recipient of recipients) {
+      await this.deps.notifications.create({
+        userId: recipient.userId,
+        category: 'CUSTOM',
+        title,
+        body,
+        payload,
+      })
+
+      const prefs = await this.deps.preferences.listByUser(recipient.userId)
+      if (shouldSendEmail(prefs)) {
+        await this.deps.emitter.emit({
+          userId: recipient.userId,
+          category: 'CUSTOM',
+          title,
+          body,
+          payload,
+        })
+      }
+
+      delivered += 1
+    }
+    return delivered
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Factory
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function createCustomBroadcastService(deps: Dependencies): CustomBroadcastService {
+  return new CustomBroadcastServiceImpl(deps)
+}

--- a/src/lib/notification/notification-types.ts
+++ b/src/lib/notification/notification-types.ts
@@ -99,3 +99,35 @@ export function isNotificationChannel(value: unknown): value is NotificationChan
 export function isNotificationEvent(value: unknown): value is NotificationEvent {
   return notificationEventSchema.safeParse(value).success
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// User roles（Requirement 1.7 準拠、4 ロール）
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const USER_ROLES = ['ADMIN', 'HR_MANAGER', 'MANAGER', 'EMPLOYEE'] as const
+export type UserRole = (typeof USER_ROLES)[number]
+
+export function isUserRole(value: unknown): value is UserRole {
+  return typeof value === 'string' && (USER_ROLES as readonly string[]).includes(value)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Broadcast types（Req 15.8: HR_MANAGER 以上が全社員または特定グループへ送信）
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** 送信対象指定（全社員 or 特定グループ） */
+export const broadcastTargetSchema = z.discriminatedUnion('type', [
+  z.object({ type: z.literal('ALL') }),
+  z.object({ type: z.literal('GROUP'), groupId: z.string().min(1) }),
+])
+
+export type BroadcastTarget = z.infer<typeof broadcastTargetSchema>
+
+/** カスタムブロードキャスト入力 */
+export const broadcastInputSchema = z.object({
+  title: z.string().min(1).max(200),
+  body: z.string().min(1),
+  target: broadcastTargetSchema,
+})
+
+export type BroadcastInput = z.infer<typeof broadcastInputSchema>

--- a/src/tests/audit/audit-log-types.test.ts
+++ b/src/tests/audit/audit-log-types.test.ts
@@ -33,6 +33,10 @@ describe('AuditAction', () => {
   it('should include evaluation finalization events', () => {
     expect(AUDIT_ACTIONS).toContain('EVALUATION_FINALIZED')
   })
+
+  it('should include custom broadcast notification events (Req 15.8)', () => {
+    expect(AUDIT_ACTIONS).toContain('CUSTOM_BROADCAST_SENT')
+  })
 })
 
 describe('AuditResourceType', () => {
@@ -42,6 +46,10 @@ describe('AuditResourceType', () => {
     expect(AUDIT_RESOURCE_TYPES).toContain('ORGANIZATION')
     expect(AUDIT_RESOURCE_TYPES).toContain('EVALUATION')
     expect(AUDIT_RESOURCE_TYPES).toContain('EXPORT_JOB')
+  })
+
+  it('should include NOTIFICATION resource type (Req 15.8)', () => {
+    expect(AUDIT_RESOURCE_TYPES).toContain('NOTIFICATION')
   })
 })
 

--- a/src/tests/notification/broadcast-target-resolver.test.ts
+++ b/src/tests/notification/broadcast-target-resolver.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest'
+import {
+  createInMemoryBroadcastTargetResolver,
+  type BroadcastRecipient,
+} from '@/lib/notification/broadcast-target-resolver'
+import { BroadcastGroupNotFoundError } from '@/lib/notification/custom-broadcast-service'
+
+const USERS: readonly BroadcastRecipient[] = [
+  { userId: 'u1', email: 'u1@example.com' },
+  { userId: 'u2', email: 'u2@example.com' },
+  { userId: 'u3', email: 'u3@example.com' },
+]
+
+const GROUP_A: readonly BroadcastRecipient[] = [
+  { userId: 'u1', email: 'u1@example.com' },
+  { userId: 'u2', email: 'u2@example.com' },
+]
+
+describe('InMemoryBroadcastTargetResolver', () => {
+  function seed() {
+    return {
+      allUsers: USERS,
+      groups: new Map<string, readonly BroadcastRecipient[]>([['group-a', GROUP_A]]),
+    }
+  }
+
+  it('returns all users when target.type = ALL', async () => {
+    const resolver = createInMemoryBroadcastTargetResolver(seed())
+    const result = await resolver.resolve({ type: 'ALL' })
+    expect(result).toHaveLength(3)
+    expect(result.map((r) => r.userId).sort()).toEqual(['u1', 'u2', 'u3'])
+  })
+
+  it('returns group members when target.type = GROUP with known groupId', async () => {
+    const resolver = createInMemoryBroadcastTargetResolver(seed())
+    const result = await resolver.resolve({ type: 'GROUP', groupId: 'group-a' })
+    expect(result.map((r) => r.userId).sort()).toEqual(['u1', 'u2'])
+  })
+
+  it('throws BroadcastGroupNotFoundError for unknown groupId', async () => {
+    const resolver = createInMemoryBroadcastTargetResolver(seed())
+    await expect(resolver.resolve({ type: 'GROUP', groupId: 'nope' })).rejects.toBeInstanceOf(
+      BroadcastGroupNotFoundError,
+    )
+  })
+
+  it('returns an empty array when allUsers seed is empty (ALL target)', async () => {
+    const resolver = createInMemoryBroadcastTargetResolver({
+      allUsers: [],
+      groups: new Map(),
+    })
+    const result = await resolver.resolve({ type: 'ALL' })
+    expect(result).toHaveLength(0)
+  })
+
+  it('returns a fresh array on each call (no shared reference)', async () => {
+    const resolver = createInMemoryBroadcastTargetResolver(seed())
+    const first = await resolver.resolve({ type: 'ALL' })
+    const second = await resolver.resolve({ type: 'ALL' })
+    expect(first).not.toBe(second)
+    expect(second).toHaveLength(3)
+  })
+})

--- a/src/tests/notification/custom-broadcast-service.test.ts
+++ b/src/tests/notification/custom-broadcast-service.test.ts
@@ -1,0 +1,305 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import type { AuditLogEmitter } from '@/lib/audit/audit-log-emitter'
+import type { AuditLogEntry } from '@/lib/audit/audit-log-types'
+import {
+  createInMemoryBroadcastTargetResolver,
+  type BroadcastRecipient,
+} from '@/lib/notification/broadcast-target-resolver'
+import {
+  BroadcastForbiddenError,
+  BroadcastGroupNotFoundError,
+  createCustomBroadcastService,
+  type BroadcastRequestContext,
+  type BroadcastSender,
+  type CustomBroadcastService,
+} from '@/lib/notification/custom-broadcast-service'
+import type { NotificationEmitter } from '@/lib/notification/notification-emitter'
+import {
+  createInMemoryNotificationRepository,
+  createInMemoryPreferenceRepository,
+} from '@/lib/notification/notification-repository'
+import type {
+  NotificationPreferenceRepository,
+  NotificationRepository,
+} from '@/lib/notification/notification-repository'
+import type {
+  BroadcastInput,
+  NotificationEvent,
+  UserRole,
+} from '@/lib/notification/notification-types'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test doubles
+// ─────────────────────────────────────────────────────────────────────────────
+
+type EmitterSpy = NotificationEmitter & { readonly calls: NotificationEvent[] }
+type AuditSpy = AuditLogEmitter & { readonly calls: AuditLogEntry[] }
+
+function makeEmitterSpy(): EmitterSpy {
+  const calls: NotificationEvent[] = []
+  const emitter: EmitterSpy = {
+    calls,
+    emit: vi.fn(async (event: NotificationEvent) => {
+      calls.push(event)
+    }),
+  }
+  return emitter
+}
+
+function makeAuditSpy(): AuditSpy {
+  const calls: AuditLogEntry[] = []
+  const audit: AuditSpy = {
+    calls,
+    emit: vi.fn(async (entry: AuditLogEntry) => {
+      calls.push(entry)
+    }),
+  }
+  return audit
+}
+
+const ALL_USERS: readonly BroadcastRecipient[] = [
+  { userId: 'u1', email: 'u1@example.com' },
+  { userId: 'u2', email: 'u2@example.com' },
+  { userId: 'u3', email: 'u3@example.com' },
+]
+
+const GROUP_A: readonly BroadcastRecipient[] = [
+  { userId: 'u1', email: 'u1@example.com' },
+  { userId: 'u2', email: 'u2@example.com' },
+]
+
+const VALID_INPUT: BroadcastInput = {
+  title: '全社お知らせ',
+  body: '本日18時から全社ミーティングを実施します。',
+  target: { type: 'ALL' },
+}
+
+const CONTEXT: BroadcastRequestContext = {
+  ipAddress: '10.0.0.1',
+  userAgent: 'TestAgent/1.0',
+}
+
+function makeSender(role: UserRole): BroadcastSender {
+  return { userId: 'sender-1', role }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test harness
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface Harness {
+  readonly service: CustomBroadcastService
+  readonly emitter: EmitterSpy
+  readonly audit: AuditSpy
+  readonly notifications: NotificationRepository
+  readonly preferences: NotificationPreferenceRepository
+}
+
+function setupHarness(): Harness {
+  const emitter = makeEmitterSpy()
+  const audit = makeAuditSpy()
+  const notifications = createInMemoryNotificationRepository()
+  const preferences = createInMemoryPreferenceRepository()
+  const resolver = createInMemoryBroadcastTargetResolver({
+    allUsers: ALL_USERS,
+    groups: new Map([['group-a', GROUP_A]]),
+  })
+
+  const service = createCustomBroadcastService({
+    emitter,
+    notifications,
+    preferences,
+    audit,
+    resolver,
+  })
+
+  return { service, emitter, audit, notifications, preferences }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('CustomBroadcastService', () => {
+  let h: Harness
+
+  beforeEach(() => {
+    h = setupHarness()
+  })
+
+  describe('authorization', () => {
+    it('rejects EMPLOYEE role with BroadcastForbiddenError and no side effects', async () => {
+      await expect(
+        h.service.sendCustomBroadcast(makeSender('EMPLOYEE'), VALID_INPUT, CONTEXT),
+      ).rejects.toBeInstanceOf(BroadcastForbiddenError)
+
+      expect(h.emitter.calls).toHaveLength(0)
+      expect(h.audit.calls).toHaveLength(0)
+      const listed = await h.notifications.listByUser('u1')
+      expect(listed).toHaveLength(0)
+    })
+
+    it('rejects MANAGER role with BroadcastForbiddenError', async () => {
+      await expect(
+        h.service.sendCustomBroadcast(makeSender('MANAGER'), VALID_INPUT, CONTEXT),
+      ).rejects.toBeInstanceOf(BroadcastForbiddenError)
+
+      expect(h.emitter.calls).toHaveLength(0)
+      expect(h.audit.calls).toHaveLength(0)
+    })
+
+    it('allows HR_MANAGER role', async () => {
+      const result = await h.service.sendCustomBroadcast(
+        makeSender('HR_MANAGER'),
+        VALID_INPUT,
+        CONTEXT,
+      )
+      expect(result.deliveredCount).toBe(ALL_USERS.length)
+    })
+
+    it('allows ADMIN role', async () => {
+      const result = await h.service.sendCustomBroadcast(makeSender('ADMIN'), VALID_INPUT, CONTEXT)
+      expect(result.deliveredCount).toBe(ALL_USERS.length)
+    })
+  })
+
+  describe('input validation', () => {
+    it('rejects empty title via Zod', async () => {
+      await expect(
+        h.service.sendCustomBroadcast(
+          makeSender('HR_MANAGER'),
+          { title: '', body: 'body', target: { type: 'ALL' } },
+          CONTEXT,
+        ),
+      ).rejects.toThrow()
+      expect(h.audit.calls).toHaveLength(0)
+    })
+
+    it('rejects empty body via Zod', async () => {
+      await expect(
+        h.service.sendCustomBroadcast(
+          makeSender('HR_MANAGER'),
+          { title: 'ok', body: '', target: { type: 'ALL' } },
+          CONTEXT,
+        ),
+      ).rejects.toThrow()
+    })
+
+    it('rejects unknown target.type via Zod', async () => {
+      await expect(
+        h.service.sendCustomBroadcast(
+          makeSender('HR_MANAGER'),
+          {
+            title: 'ok',
+            body: 'body',
+            target: { type: 'BAD' } as unknown as BroadcastInput['target'],
+          },
+          CONTEXT,
+        ),
+      ).rejects.toThrow()
+    })
+  })
+
+  describe('target resolution', () => {
+    it('delivers to all users when target = ALL', async () => {
+      const result = await h.service.sendCustomBroadcast(
+        makeSender('HR_MANAGER'),
+        { ...VALID_INPUT, target: { type: 'ALL' } },
+        CONTEXT,
+      )
+
+      expect(result.deliveredCount).toBe(3)
+      expect(h.emitter.calls).toHaveLength(3)
+      for (const userId of ['u1', 'u2', 'u3']) {
+        const list = await h.notifications.listByUser(userId)
+        expect(list).toHaveLength(1)
+        const first = list[0]
+        if (!first) throw new Error('expected notification to exist')
+        expect(first.category).toBe('CUSTOM')
+      }
+    })
+
+    it('delivers only to group members when target = GROUP', async () => {
+      const result = await h.service.sendCustomBroadcast(
+        makeSender('HR_MANAGER'),
+        { ...VALID_INPUT, target: { type: 'GROUP', groupId: 'group-a' } },
+        CONTEXT,
+      )
+
+      expect(result.deliveredCount).toBe(2)
+      const u3List = await h.notifications.listByUser('u3')
+      expect(u3List).toHaveLength(0)
+    })
+
+    it('throws BroadcastGroupNotFoundError for unknown groupId', async () => {
+      await expect(
+        h.service.sendCustomBroadcast(
+          makeSender('HR_MANAGER'),
+          { ...VALID_INPUT, target: { type: 'GROUP', groupId: 'nope' } },
+          CONTEXT,
+        ),
+      ).rejects.toBeInstanceOf(BroadcastGroupNotFoundError)
+    })
+  })
+
+  describe('preferences-aware email delivery', () => {
+    it('creates in-app notification but skips email when CUSTOM emailEnabled=false', async () => {
+      // u1 は CUSTOM カテゴリのメールを無効化
+      await h.preferences.upsertMany('u1', [{ category: 'CUSTOM', emailEnabled: false }])
+
+      const result = await h.service.sendCustomBroadcast(
+        makeSender('HR_MANAGER'),
+        VALID_INPUT,
+        CONTEXT,
+      )
+
+      expect(result.deliveredCount).toBe(3)
+      // u1 宛のメール emit は行われない
+      const emailedUserIds = h.emitter.calls.map((e) => e.userId)
+      expect(emailedUserIds).not.toContain('u1')
+      expect(emailedUserIds.sort()).toEqual(['u2', 'u3'])
+
+      // アプリ内通知は全員分作成される
+      const u1List = await h.notifications.listByUser('u1')
+      expect(u1List).toHaveLength(1)
+    })
+
+    it('sends email when CUSTOM emailEnabled is true or unset (default true)', async () => {
+      await h.preferences.upsertMany('u2', [{ category: 'CUSTOM', emailEnabled: true }])
+      await h.service.sendCustomBroadcast(makeSender('ADMIN'), VALID_INPUT, CONTEXT)
+
+      const emailedUserIds = h.emitter.calls.map((e) => e.userId).sort()
+      expect(emailedUserIds).toEqual(['u1', 'u2', 'u3'])
+    })
+  })
+
+  describe('audit logging', () => {
+    it('emits exactly one audit log with CUSTOM_BROADCAST_SENT / NOTIFICATION', async () => {
+      await h.service.sendCustomBroadcast(makeSender('HR_MANAGER'), VALID_INPUT, CONTEXT)
+
+      expect(h.audit.calls).toHaveLength(1)
+      const entry = h.audit.calls[0]
+      if (!entry) throw new Error('expected audit entry to be emitted')
+      expect(entry.action).toBe('CUSTOM_BROADCAST_SENT')
+      expect(entry.resourceType).toBe('NOTIFICATION')
+      expect(entry.resourceId).toBeNull()
+      expect(entry.userId).toBe('sender-1')
+      expect(entry.ipAddress).toBe('10.0.0.1')
+      expect(entry.userAgent).toBe('TestAgent/1.0')
+      expect(entry.before).toBeNull()
+      expect(entry.after).toEqual({
+        title: VALID_INPUT.title,
+        body: VALID_INPUT.body,
+        target: VALID_INPUT.target,
+        deliveredCount: 3,
+      })
+    })
+
+    it('does not emit an audit log when authorization fails', async () => {
+      await expect(
+        h.service.sendCustomBroadcast(makeSender('EMPLOYEE'), VALID_INPUT, CONTEXT),
+      ).rejects.toBeInstanceOf(BroadcastForbiddenError)
+      expect(h.audit.calls).toHaveLength(0)
+    })
+  })
+})

--- a/src/tests/notification/notification-types.test.ts
+++ b/src/tests/notification/notification-types.test.ts
@@ -11,6 +11,10 @@ import {
   isNotification,
   notificationPreferenceSchema,
   notificationPreferencesSchema,
+  USER_ROLES,
+  isUserRole,
+  broadcastInputSchema,
+  broadcastTargetSchema,
 } from '@/lib/notification/notification-types'
 
 describe('NOTIFICATION_CATEGORIES', () => {
@@ -269,6 +273,116 @@ describe('notificationPreferencesSchema', () => {
 
   it('should reject a non-array value', () => {
     const result = notificationPreferencesSchema.safeParse({ category: 'SYSTEM' })
+    expect(result.success).toBe(false)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// User roles（Req 1.7 / Req 15.8）
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('USER_ROLES', () => {
+  it('should contain the four required roles', () => {
+    expect(USER_ROLES).toContain('ADMIN')
+    expect(USER_ROLES).toContain('HR_MANAGER')
+    expect(USER_ROLES).toContain('MANAGER')
+    expect(USER_ROLES).toContain('EMPLOYEE')
+    expect(USER_ROLES).toHaveLength(4)
+  })
+})
+
+describe('isUserRole()', () => {
+  it('should return true for valid roles', () => {
+    expect(isUserRole('ADMIN')).toBe(true)
+    expect(isUserRole('HR_MANAGER')).toBe(true)
+    expect(isUserRole('MANAGER')).toBe(true)
+    expect(isUserRole('EMPLOYEE')).toBe(true)
+  })
+
+  it('should return false for invalid roles', () => {
+    expect(isUserRole('admin')).toBe(false)
+    expect(isUserRole('SUPER_ADMIN')).toBe(false)
+    expect(isUserRole('')).toBe(false)
+    expect(isUserRole(null)).toBe(false)
+    expect(isUserRole(42)).toBe(false)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Broadcast schemas（Req 15.8）
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('broadcastTargetSchema', () => {
+  it('accepts target ALL', () => {
+    expect(broadcastTargetSchema.safeParse({ type: 'ALL' }).success).toBe(true)
+  })
+
+  it('accepts target GROUP with non-empty groupId', () => {
+    expect(broadcastTargetSchema.safeParse({ type: 'GROUP', groupId: 'group-1' }).success).toBe(
+      true,
+    )
+  })
+
+  it('rejects target GROUP with empty groupId', () => {
+    expect(broadcastTargetSchema.safeParse({ type: 'GROUP', groupId: '' }).success).toBe(false)
+  })
+
+  it('rejects unknown type', () => {
+    expect(broadcastTargetSchema.safeParse({ type: 'EVERYONE' }).success).toBe(false)
+  })
+})
+
+describe('broadcastInputSchema', () => {
+  it('accepts a valid broadcast input with target=ALL', () => {
+    const result = broadcastInputSchema.safeParse({
+      title: 'お知らせ',
+      body: '本文',
+      target: { type: 'ALL' },
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts a valid broadcast input with target=GROUP', () => {
+    const result = broadcastInputSchema.safeParse({
+      title: 'お知らせ',
+      body: '本文',
+      target: { type: 'GROUP', groupId: 'group-1' },
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects empty title', () => {
+    const result = broadcastInputSchema.safeParse({
+      title: '',
+      body: '本文',
+      target: { type: 'ALL' },
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects empty body', () => {
+    const result = broadcastInputSchema.safeParse({
+      title: 'お知らせ',
+      body: '',
+      target: { type: 'ALL' },
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects title longer than 200 characters', () => {
+    const result = broadcastInputSchema.safeParse({
+      title: 'a'.repeat(201),
+      body: '本文',
+      target: { type: 'ALL' },
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects missing target', () => {
+    const result = broadcastInputSchema.safeParse({
+      title: 'お知らせ',
+      body: '本文',
+    })
     expect(result.success).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary

- HR_MANAGER / ADMIN のみが呼び出せる `CustomBroadcastService` を新設し、全社員または特定グループへのカスタム通知配信を実装（Req 15.8）。
- 対象ユーザーごとにアプリ内通知を作成し、`CUSTOM` カテゴリの `emailEnabled` 設定に従ってメールを emit。送信後に 1 件だけ `CUSTOM_BROADCAST_SENT` の監査ログを emit。
- 役割判定を最初に行い、未許可ロールは副作用なしで `BroadcastForbiddenError` を throw。

Closes #14

## 実装内容

- `src/lib/notification/notification-types.ts`
  - `USER_ROLES` (ADMIN / HR_MANAGER / MANAGER / EMPLOYEE) と `isUserRole`
  - `broadcastTargetSchema`（`ALL` / `GROUP` の discriminated union）
  - `broadcastInputSchema`（title 1–200、body 非空、target 必須）
- `src/lib/audit/audit-log-types.ts`
  - `AUDIT_ACTIONS` に `CUSTOM_BROADCAST_SENT` を追加
  - `AUDIT_RESOURCE_TYPES` に `NOTIFICATION` を追加（末尾追加、既存順序は不変）
- `src/lib/notification/broadcast-target-resolver.ts`
  - `BroadcastRecipient` と `BroadcastTargetResolver` インターフェース
  - テスト用インメモリ実装（ALL / GROUP、不明 groupId で `BroadcastGroupNotFoundError`）
- `src/lib/notification/custom-broadcast-service.ts`
  - `CustomBroadcastService` インターフェースと `createCustomBroadcastService` ファクトリ
  - `BroadcastForbiddenError` / `BroadcastGroupNotFoundError` ドメイン例外
  - ロール判定 → Zod 入力検証 → 対象解決 → 各ユーザーへアプリ内通知 + preferences-aware なメール emit → 監査ログ 1 件 emit

## 認可設計

- HR_MANAGER / ADMIN のみが `sendCustomBroadcast` を許可される（Req 15.8）
- ロール判定は **メソッド入口の最初** に実施し、未許可の場合は `BroadcastForbiddenError` を throw。監査ログ・通知作成・メール emit など、他の副作用は一切起こさない
- 既定 preference: ユーザーが CUSTOM カテゴリを明示設定していない場合、`emailEnabled=true` がデフォルト（Req 15.3）
- 監査ログは成功時に 1 件のみ emit。`after` スナップショットに `{ title, body, target, deliveredCount }` を含む

### 設計上のメモ

設計書 design.md では `NotificationService.sendCustomBroadcast` として記述されていますが、既存 `NotificationService`（listForUser / markAsRead / updatePreferences / getPreferences）と依存関係が大きく異なるため、**単一責任原則を優先して別サービス `CustomBroadcastService` として分離**しました（`notification-service.ts` 33 行目のコメントも同方針）。

## テスト結果

- `pnpm test`: 35 file / **382 tests all pass**
  - `custom-broadcast-service.test.ts` — 14 tests（認可・Zod 検証・target 解決・preferences・監査）
  - `broadcast-target-resolver.test.ts` — 5 tests（ALL / GROUP / unknown groupId / empty seed / fresh array）
  - 既存 `notification-types.test.ts` に 11 tests 追加（USER_ROLES / isUserRole / broadcastTargetSchema / broadcastInputSchema）
  - 既存 `audit-log-types.test.ts` に 2 tests 追加（CUSTOM_BROADCAST_SENT / NOTIFICATION）
- 新規ファイルのカバレッジ:
  - `custom-broadcast-service.ts`: 100% stmts / 100% branches / 100% funcs / 100% lines
  - `broadcast-target-resolver.ts`: 100% stmts / 100% branches / 100% funcs / 100% lines
- `pnpm lint`: ✔ No ESLint warnings or errors
- `pnpm type-check`: 本 PR 由来の新規エラーは 0（既存の `prisma/extensions/encrypted-fields.ts`, `access-log-repository.ts`, および `audit-log-emitter.ts` 1–2 行目の duplicate import は別タスクで対応予定の pre-existing issue、設計書に従い本 PR では触らず）

## Requirements

- Req 15.8: HR_MANAGER 以上が手動で全社員または特定グループへカスタム通知を送信できる
- Req 15.1 / 15.6（アプリ内通知作成）、Req 15.3（CUSTOM カテゴリ emailEnabled 反映）も同時に満たす
- 監査ログ（Req 17.2 系）: `CUSTOM_BROADCAST_SENT` / `NOTIFICATION` を新設

## スコープ外

- **HTTP middleware / Next.js API Route ハンドラ層**: 本 PR はサービス層でのロール判定・副作用抑制を実装。実 Route ハンドラ（`BroadcastSender` を認証セッションから構築し、`BroadcastRequestContext` を HTTP ヘッダから抽出）は別タスク（Route 実装タスク）で対応
- `BroadcastTargetResolver` のプロダクション実装（UserRepository / GroupRepository バック）: 本 PR はインメモリ実装のみ。実装の差し替えはインターフェース経由で可能

## Test plan

- [x] Unit tests (Vitest) pass for new modules and updated type/audit tests
- [x] Lint passes
- [x] Type-check introduces no new errors
- [x] Coverage ≥ 80% on new files (actually 100%)
- [ ] E2E / integration (route-level) — 別タスクで実装