### PR TITLE
feat(ai-gateway): Task 5.1 — AIGateway と Provider 抽象化

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "prepare": "husky"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.90.0",
     "@bull-board/api": "^7.0.0",
     "@bull-board/hono": "^7.0.0",
     "@prisma/client": "^6.0.0",
@@ -33,6 +34,7 @@
     "ioredis": "^5.10.1",
     "neverthrow": "^8.0.0",
     "next": "^15.3.0",
+    "openai": "^6.34.0",
     "pg": "^8.13.0",
     "prisma": "^6.0.0",
     "react": "^19.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@anthropic-ai/sdk':
+        specifier: ^0.90.0
+        version: 0.90.0(zod@3.25.76)
       '@bull-board/api':
         specifier: ^7.0.0
         version: 7.0.0(@bull-board/ui@7.0.0)
@@ -35,6 +38,9 @@ importers:
       next:
         specifier: ^15.3.0
         version: 15.5.15(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      openai:
+        specifier: ^6.34.0
+        version: 6.34.0(zod@3.25.76)
       pg:
         specifier: ^8.13.0
         version: 8.20.0
@@ -134,6 +140,15 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
+  '@anthropic-ai/sdk@0.90.0':
+    resolution: {integrity: sha512-MzZtPabJF1b0FTDl6Z6H5ljphPwACLGP13lu8MTiB8jXaW/YXlpOp+Po2cVou3MPM5+f5toyLnul9whKCy7fBg==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
     engines: {node: '>=6.9.0'}
@@ -146,6 +161,10 @@ packages:
     resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  '@babel/runtime@7.29.2':
+    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
@@ -2270,6 +2289,10 @@ packages:
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
+
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
@@ -2587,6 +2610,18 @@ packages:
   onetime@7.0.0:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
+
+  openai@6.34.0:
+    resolution: {integrity: sha512-yEr2jdGf4tVFYG6ohmr3pF6VJuveP0EA/sS8TBx+4Eq5NT10alu5zg2dmxMXMgqpihRDQlFGpRt2XwsGj+Fyxw==}
+    hasBin: true
+    peerDependencies:
+      ws: ^8.18.0
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -3154,6 +3189,9 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
+
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
     engines: {node: '>=18.12'}
@@ -3360,6 +3398,12 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
+  '@anthropic-ai/sdk@0.90.0(zod@3.25.76)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+    optionalDependencies:
+      zod: 3.25.76
+
   '@babel/helper-string-parser@7.27.1': {}
 
   '@babel/helper-validator-identifier@7.28.5': {}
@@ -3367,6 +3411,8 @@ snapshots:
   '@babel/parser@7.29.2':
     dependencies:
       '@babel/types': 7.29.0
+
+  '@babel/runtime@7.29.2': {}
 
   '@babel/types@7.29.0':
     dependencies:
@@ -5475,6 +5521,11 @@ snapshots:
 
   json-buffer@3.0.1: {}
 
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.29.2
+      ts-algebra: 2.0.0
+
   json-schema-traverse@0.4.1: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
@@ -5788,6 +5839,10 @@ snapshots:
   onetime@7.0.0:
     dependencies:
       mimic-function: 5.0.1
+
+  openai@6.34.0(zod@3.25.76):
+    optionalDependencies:
+      zod: 3.25.76
 
   optionator@0.9.4:
     dependencies:
@@ -6364,6 +6419,8 @@ snapshots:
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  ts-algebra@2.0.0: {}
 
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:

--- a/src/lib/ai-gateway/ai-gateway-types.ts
+++ b/src/lib/ai-gateway/ai-gateway-types.ts
@@ -1,0 +1,123 @@
+/**
+ * AIGateway 型定義
+ *
+ * AI プロバイダ抽象化層の共通型とスキーマ。
+ * - AI プロバイダ名 / ドメイン enum
+ * - Chat リクエスト / レスポンス 型
+ * - ゲートウェイ固有の例外クラス (ドメインエラー判別共用体とは独立)
+ *
+ * 関連要件: Req 20.13, Req 19.8
+ */
+import { z } from 'zod'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Provider
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** サポート対象の AI プロバイダ名 */
+export const AI_PROVIDER_NAMES = ['claude', 'openai'] as const
+
+export type AIProviderName = (typeof AI_PROVIDER_NAMES)[number]
+
+/** 任意の値が AIProviderName か判定 */
+export function isAIProviderName(value: unknown): value is AIProviderName {
+  return typeof value === 'string' && (AI_PROVIDER_NAMES as readonly string[]).includes(value)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Domain
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * AI 機能ドメイン。
+ * - ai-coach: 評価コーチング (Req 9.x)
+ * - feedback: フィードバック変換 (Req 11.x)
+ */
+export const AI_DOMAINS = ['ai-coach', 'feedback'] as const
+
+export type AIDomain = (typeof AI_DOMAINS)[number]
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Chat Message / Request
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const chatMessageSchema = z.object({
+  role: z.enum(['system', 'user', 'assistant']),
+  content: z.string().min(1),
+})
+
+export type ChatMessage = z.infer<typeof chatMessageSchema>
+
+export const aiChatRequestSchema = z.object({
+  /** 機能ドメイン (キャッシュキー・ロギング識別) */
+  domain: z.enum(AI_DOMAINS),
+  /** 対話メッセージ (最低 1 件) */
+  messages: z.array(chatMessageSchema).min(1),
+  /** 応答の最大トークン数 */
+  maxOutputTokens: z.number().int().positive().optional(),
+  /** サンプリング温度 */
+  temperature: z.number().min(0).max(2).optional(),
+  /** Anthropic プロンプトキャッシュを有効化するか */
+  enablePromptCache: z.boolean().optional(),
+  /** このリクエスト個別のタイムアウト (ms) */
+  timeoutMs: z.number().int().positive().optional(),
+})
+
+export type AIChatRequest = z.infer<typeof aiChatRequestSchema>
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Chat Response
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface AIChatUsage {
+  readonly promptTokens: number
+  readonly completionTokens: number
+}
+
+export interface AIChatResponse {
+  readonly content: string
+  readonly provider: AIProviderName
+  readonly usage: AIChatUsage
+  readonly cached: boolean
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Errors
+//
+// 注: src/lib/shared/domain-error.ts には同名の _tag 付き型が存在するが、
+// それは Result<T, DomainError> 用の判別共用体。こちらは throw 可能な
+// Error サブクラスであり、責務と名前空間が異なる。ai-gateway モジュールの
+// 呼び出し側は本ファイルからクラスを import する。
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** AI プロバイダ呼び出しで発生した例外 */
+export class AIProviderError extends Error {
+  public readonly provider: AIProviderName
+  public readonly providerMessage: string
+
+  constructor(provider: AIProviderName, providerMessage: string, options?: ErrorOptions) {
+    super(`[${provider}] ${providerMessage}`, options)
+    this.name = 'AIProviderError'
+    this.provider = provider
+    this.providerMessage = providerMessage
+  }
+}
+
+/** AI 呼び出しがタイムアウトした */
+export class AITimeoutError extends Error {
+  public readonly elapsedMs: number
+
+  constructor(elapsedMs: number) {
+    super(`AI call timed out after ${elapsedMs}ms`)
+    this.name = 'AITimeoutError'
+    this.elapsedMs = elapsedMs
+  }
+}
+
+/** AI 設定不備 (API キー未設定・プロバイダ名不正 等) */
+export class AIConfigurationError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'AIConfigurationError'
+  }
+}

--- a/src/lib/ai-gateway/ai-gateway.ts
+++ b/src/lib/ai-gateway/ai-gateway.ts
@@ -1,0 +1,225 @@
+/**
+ * AIGateway
+ *
+ * AI プロバイダ呼び出しの統合エントリポイント。
+ *  - リクエスト Zod バリデーション
+ *  - 同一入力レスポンスの Redis キャッシュ (Req 19.8)
+ *  - タイムアウト付き実行 (デフォルト 5 秒)
+ *  - usage ログ用フック (Task 5.1 では optional、実装は別タスク)
+ *
+ * プロバイダ (Anthropic / OpenAI) は ChatProvider 抽象経由で DI される (Req 20.13)。
+ */
+import {
+  AIProviderError,
+  AITimeoutError,
+  AIConfigurationError,
+  aiChatRequestSchema,
+  isAIProviderName,
+  type AIChatRequest,
+  type AIChatResponse,
+  type AIDomain,
+  type AIProviderName,
+} from './ai-gateway-types'
+import type { ChatProvider } from './chat-provider'
+import {
+  createInMemoryAIResponseCache,
+  createRedisAIResponseCache,
+  type AIResponseCache,
+} from './ai-response-cache'
+import { createAnthropicProvider } from './providers/anthropic-provider'
+import { createOpenAIProvider } from './providers/openai-provider'
+import { createRedisConnection } from '../jobs/redis-connection'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 定数
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** ゲートウェイのデフォルトタイムアウト (5 秒) */
+export const DEFAULT_AI_GATEWAY_TIMEOUT_MS = 5000
+
+/** AI_PROVIDER 環境変数のデフォルト */
+const DEFAULT_PROVIDER_NAME: AIProviderName = 'claude'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 公開型
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface AIGateway {
+  chat(request: AIChatRequest): Promise<AIChatResponse>
+  getCurrentProvider(): AIProviderName
+}
+
+export interface AIUsageEntry {
+  readonly domain: AIDomain
+  readonly provider: AIProviderName
+  readonly promptTokens: number
+  readonly completionTokens: number
+  readonly cached: boolean
+}
+
+export interface AIGatewayDeps {
+  readonly provider: ChatProvider
+  readonly cache: AIResponseCache
+  /** トークン使用量ロギング用フック (本タスクでは optional、実装は別タスク) */
+  readonly onUsage?: (entry: AIUsageEntry) => void | Promise<void>
+  readonly defaultTimeoutMs?: number
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// キャッシュキー
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** provider + domain + messages からキャッシュキーの raw 文字列を生成 */
+function buildRawCacheKey(provider: AIProviderName, request: AIChatRequest): string {
+  return `${provider}|${request.domain}|${JSON.stringify(request.messages)}`
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// タイムアウト
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * 指定ミリ秒で resolve されなかった場合は AITimeoutError で reject する Promise を返す。
+ * 元の promise の reject は素通しする。
+ */
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined
+
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      reject(new AITimeoutError(timeoutMs))
+    }, timeoutMs)
+  })
+
+  return Promise.race([promise, timeoutPromise]).finally(() => {
+    if (timer) clearTimeout(timer)
+  })
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// onUsage 安全呼び出し
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function emitUsage(
+  onUsage: AIGatewayDeps['onUsage'],
+  entry: AIUsageEntry,
+): Promise<void> {
+  if (!onUsage) return
+  try {
+    await onUsage(entry)
+  } catch {
+    // ロギングの失敗でメイン処理を止めない (フェイルオープン)
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 実装
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * AIGateway を生成する。
+ */
+export function createAIGateway(deps: AIGatewayDeps): AIGateway {
+  const defaultTimeoutMs = deps.defaultTimeoutMs ?? DEFAULT_AI_GATEWAY_TIMEOUT_MS
+  const { provider, cache, onUsage } = deps
+
+  async function chat(request: AIChatRequest): Promise<AIChatResponse> {
+    // 1. Zod バリデーション
+    const parsed = aiChatRequestSchema.parse(request)
+
+    // 2. キャッシュ確認
+    const rawKey = buildRawCacheKey(provider.name, parsed)
+    const cached = await cache.get(rawKey)
+    if (cached) {
+      await emitUsage(onUsage, {
+        domain: parsed.domain,
+        provider: provider.name,
+        promptTokens: cached.usage.promptTokens,
+        completionTokens: cached.usage.completionTokens,
+        cached: true,
+      })
+      return cached
+    }
+
+    // 3. プロバイダ呼び出し (タイムアウト付き)
+    const timeoutMs = parsed.timeoutMs ?? defaultTimeoutMs
+    let response: AIChatResponse
+    try {
+      response = await withTimeout(provider.chat(parsed), timeoutMs)
+    } catch (error) {
+      if (error instanceof AITimeoutError) throw error
+      if (error instanceof AIProviderError) throw error
+      // 想定外の例外は AIProviderError に正規化
+      const message = error instanceof Error ? error.message : 'Unknown provider error'
+      throw new AIProviderError(provider.name, message, { cause: error })
+    }
+
+    // 4. キャッシュ保存 + usage 記録
+    await cache.set(rawKey, response)
+    await emitUsage(onUsage, {
+      domain: parsed.domain,
+      provider: provider.name,
+      promptTokens: response.usage.promptTokens,
+      completionTokens: response.usage.completionTokens,
+      cached: false,
+    })
+
+    return response
+  }
+
+  return {
+    chat,
+    getCurrentProvider: () => provider.name,
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Factory (env ベース)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * 環境変数からゲートウェイを組み立てる。
+ *  - AI_PROVIDER = 'claude' | 'openai' (default: 'claude')
+ *  - REDIS_URL 未設定時は InMemory キャッシュにフォールバック
+ *  - overrides で個別の依存を差し替え可能
+ */
+export function createAIGatewayFromEnv(
+  overrides: Partial<AIGatewayDeps> = {},
+): AIGateway {
+  const providerName = resolveProviderName()
+  const provider = overrides.provider ?? buildProviderForName(providerName)
+  const cache = overrides.cache ?? buildCacheFromEnv()
+
+  return createAIGateway({
+    provider,
+    cache,
+    onUsage: overrides.onUsage,
+    defaultTimeoutMs: overrides.defaultTimeoutMs,
+  })
+}
+
+function resolveProviderName(): AIProviderName {
+  const raw = process.env.AI_PROVIDER
+  if (!raw || raw.trim().length === 0) return DEFAULT_PROVIDER_NAME
+  if (!isAIProviderName(raw)) {
+    throw new AIConfigurationError(`Unknown AI_PROVIDER value: ${raw}`)
+  }
+  return raw
+}
+
+function buildProviderForName(name: AIProviderName): ChatProvider {
+  switch (name) {
+    case 'claude':
+      return createAnthropicProvider()
+    case 'openai':
+      return createOpenAIProvider()
+  }
+}
+
+function buildCacheFromEnv(): AIResponseCache {
+  const redisUrl = process.env.REDIS_URL
+  if (!redisUrl || redisUrl.trim().length === 0) {
+    return createInMemoryAIResponseCache()
+  }
+  return createRedisAIResponseCache(createRedisConnection())
+}

--- a/src/lib/ai-gateway/ai-response-cache.ts
+++ b/src/lib/ai-gateway/ai-response-cache.ts
@@ -1,0 +1,151 @@
+/**
+ * AIResponseCache
+ *
+ * AI プロバイダ呼び出しのレスポンスをキャッシュするモジュール。
+ * 同一入力 (provider|domain|messages) に対して Redis にキャッシュし、
+ * コスト削減と応答時間短縮を実現する (Req 19.8)。
+ *
+ * 実装:
+ *  - Redis 実装 (本番): ioredis クライアント + SETEX で TTL 付き保存
+ *  - InMemory 実装 (テスト用・Redis 未設定フォールバック): Map + ソフト TTL
+ *
+ * キャッシュキー:
+ *  - 呼び出し側 (ai-gateway) で `${provider}|${domain}|${messagesJson}` を生成し、
+ *    本モジュール内で sha256 ハッシュ化して `ai:cache:<hash>` の形に整形する。
+ */
+import { createHash } from 'node:crypto'
+import type { Redis } from 'ioredis'
+
+import type { AIChatResponse } from './ai-gateway-types'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 定数
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Redis キー名前空間プレフィックス */
+const CACHE_KEY_PREFIX = 'ai:cache:'
+
+/** デフォルト TTL (5 分) */
+export const DEFAULT_AI_CACHE_TTL_SECONDS = 300
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Interface
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface AIResponseCache {
+  /** キャッシュ取得。ヒット時は cached:true が注入されたレスポンスを返す */
+  get(key: string): Promise<AIChatResponse | null>
+  /** キャッシュ保存。TTL 省略時はデフォルト TTL を使用 */
+  set(key: string, response: AIChatResponse, ttlSeconds?: number): Promise<void>
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 共通ヘルパー
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** 入力文字列を sha256 ハッシュ化し、キャッシュキー形式に整形 */
+export function buildCacheKey(rawKey: string): string {
+  const hash = createHash('sha256').update(rawKey).digest('hex')
+  return `${CACHE_KEY_PREFIX}${hash}`
+}
+
+/** JSON シリアライズ時の失敗を吸収して null を返す */
+function tryParseResponse(raw: string): AIChatResponse | null {
+  try {
+    const parsed = JSON.parse(raw) as AIChatResponse
+    return { ...parsed, cached: true }
+  } catch {
+    return null
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Redis 実装
+// ─────────────────────────────────────────────────────────────────────────────
+
+class RedisAIResponseCache implements AIResponseCache {
+  private readonly redis: Redis
+  private readonly defaultTtl: number
+
+  constructor(redis: Redis, defaultTtl: number) {
+    this.redis = redis
+    this.defaultTtl = defaultTtl
+  }
+
+  async get(key: string): Promise<AIChatResponse | null> {
+    const redisKey = buildCacheKey(key)
+    const raw = await this.redis.get(redisKey)
+    if (raw === null) return null
+    return tryParseResponse(raw)
+  }
+
+  async set(
+    key: string,
+    response: AIChatResponse,
+    ttlSeconds: number = this.defaultTtl,
+  ): Promise<void> {
+    const redisKey = buildCacheKey(key)
+    // cached フラグはキャッシュ読込側で付与するため、保存時は false を正規化して保存
+    const payload = JSON.stringify({ ...response, cached: false })
+    await this.redis.setex(redisKey, ttlSeconds, payload)
+  }
+}
+
+/** Redis クライアントをラップしたキャッシュを生成する */
+export function createRedisAIResponseCache(
+  redis: Redis,
+  defaultTtlSeconds: number = DEFAULT_AI_CACHE_TTL_SECONDS,
+): AIResponseCache {
+  return new RedisAIResponseCache(redis, defaultTtlSeconds)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// InMemory 実装
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface InMemoryEntry {
+  readonly response: AIChatResponse
+  readonly expiresAt: number // epoch millis
+}
+
+class InMemoryAIResponseCache implements AIResponseCache {
+  private readonly store = new Map<string, InMemoryEntry>()
+  private readonly clock: () => number
+
+  constructor(clock: () => number) {
+    this.clock = clock
+  }
+
+  async get(key: string): Promise<AIChatResponse | null> {
+    const redisKey = buildCacheKey(key)
+    const entry = this.store.get(redisKey)
+    if (!entry) return null
+    if (entry.expiresAt <= this.clock()) {
+      this.store.delete(redisKey)
+      return null
+    }
+    return { ...entry.response, cached: true }
+  }
+
+  async set(
+    key: string,
+    response: AIChatResponse,
+    ttlSeconds: number = DEFAULT_AI_CACHE_TTL_SECONDS,
+  ): Promise<void> {
+    const redisKey = buildCacheKey(key)
+    this.store.set(redisKey, {
+      response: { ...response, cached: false },
+      expiresAt: this.clock() + ttlSeconds * 1000,
+    })
+  }
+}
+
+/**
+ * In-memory キャッシュを生成する (テスト・Redis 未設定時のフォールバック用)。
+ * clock() は現在時刻ミリ秒を返す関数。テストでは Date.now() 以外を差し込める。
+ */
+export function createInMemoryAIResponseCache(
+  clock: () => number = () => Date.now(),
+): AIResponseCache {
+  return new InMemoryAIResponseCache(clock)
+}

--- a/src/lib/ai-gateway/anonymizer.ts
+++ b/src/lib/ai-gateway/anonymizer.ts
@@ -1,0 +1,170 @@
+/**
+ * 個人識別情報 (PII) 匿名化ユーティリティ
+ *
+ * AI に送信するプロンプトから個人を特定できる情報を除外する (Req 9.8)。
+ *
+ * 処理対象:
+ *  1. 明示的に渡された employees の fullName / employeeCode / email を
+ *     連番トークン `emp_NNN` に置換する。同じ社員の各フィールドは同一トークンを共有する。
+ *  2. 汎用パターン (メール・電話番号・コード形式 E-数字) を
+ *     `[EMAIL_REDACTED]` / `[PHONE_REDACTED]` / `[CODE_REDACTED]` に置換する。
+ *
+ * 復元用のマップを返し、deanonymize でトークンから原文に戻せる。
+ * 正規表現ベースの REDACTED 置換は元に戻らない（意図的に情報を破棄）。
+ */
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 型定義
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface AnonymizationMap {
+  /** 原文 → トークン (emp_NNN 形式) への写像 */
+  readonly tokens: ReadonlyMap<string, string>
+}
+
+export interface AnonymizerEmployeeInput {
+  readonly id: string
+  readonly fullName?: string
+  readonly employeeCode?: string
+  readonly email?: string
+}
+
+export interface AnonymizerInput {
+  readonly text: string
+  readonly employees?: readonly AnonymizerEmployeeInput[]
+}
+
+export interface AnonymizerResult {
+  readonly text: string
+  readonly map: AnonymizationMap
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 定数
+// ─────────────────────────────────────────────────────────────────────────────
+
+const EMAIL_PATTERN = /[\w.+-]+@[\w.-]+\.\w+/g
+// 電話番号: 日本国内形式 0x-xxxx-xxxx / 0xxxxxxxxxx など
+const PHONE_PATTERN = /\b0\d{1,4}-?\d{1,4}-?\d{3,4}\b/g
+// 社員コード: E-1234 〜 E-123456 を想定
+const CODE_PATTERN = /\bE-\d{4,6}\b/g
+
+const TOKEN_PREFIX = 'emp_'
+
+const EMAIL_PLACEHOLDER = '[EMAIL_REDACTED]'
+const PHONE_PLACEHOLDER = '[PHONE_REDACTED]'
+const CODE_PLACEHOLDER = '[CODE_REDACTED]'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 内部ユーティリティ
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** 正規表現特殊文字をエスケープ */
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+/** 3 桁ゼロ埋めの連番トークンを生成 (emp_001) */
+function formatToken(index: number): string {
+  return `${TOKEN_PREFIX}${String(index).padStart(3, '0')}`
+}
+
+/**
+ * employees[] の各フィールド値を収集し、原文→トークンのマップを構築する。
+ * 空文字列・undefined はスキップ。同一社員の複数フィールドは同一トークンを共有する。
+ */
+function buildEmployeeTokenMap(
+  employees: readonly AnonymizerEmployeeInput[],
+): Map<string, string> {
+  const originalToToken = new Map<string, string>()
+  const tokenByEmployeeId = new Map<string, string>()
+  let nextIndex = 1
+
+  for (const emp of employees) {
+    let token = tokenByEmployeeId.get(emp.id)
+    if (!token) {
+      token = formatToken(nextIndex)
+      nextIndex += 1
+      tokenByEmployeeId.set(emp.id, token)
+    }
+
+    for (const value of [emp.fullName, emp.employeeCode, emp.email]) {
+      if (!value || value.length === 0) continue
+      if (!originalToToken.has(value)) {
+        originalToToken.set(value, token)
+      }
+    }
+  }
+
+  return originalToToken
+}
+
+/**
+ * 長い文字列から先に置換することでオーバーラップ事故を避ける
+ * (例: "田中太郎" の前に "田中" を置換してしまわない)。
+ */
+function replaceAllByMap(text: string, tokenMap: ReadonlyMap<string, string>): string {
+  const sortedEntries = Array.from(tokenMap.entries()).sort(
+    (a, b) => b[0].length - a[0].length,
+  )
+
+  let result = text
+  for (const [original, token] of sortedEntries) {
+    const pattern = new RegExp(escapeRegExp(original), 'g')
+    result = result.replace(pattern, token)
+  }
+  return result
+}
+
+/** 正規表現ベースの PII を REDACTED プレースホルダに置換 */
+function redactPatterns(text: string): string {
+  return text
+    .replace(EMAIL_PATTERN, EMAIL_PLACEHOLDER)
+    .replace(PHONE_PATTERN, PHONE_PLACEHOLDER)
+    .replace(CODE_PATTERN, CODE_PLACEHOLDER)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 公開 API
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * 入力テキストから PII を匿名化する。
+ *
+ * @param input 対象テキスト + employees 情報 (任意)
+ * @returns 匿名化済みテキストと復元用マップ
+ */
+export function anonymize(input: AnonymizerInput): AnonymizerResult {
+  const employees = input.employees ?? []
+  const tokenMap = buildEmployeeTokenMap(employees)
+
+  // 1. 明示的に渡された値をトークン置換
+  const afterTokens = replaceAllByMap(input.text, tokenMap)
+  // 2. 残った一般パターンを REDACTED に
+  const finalText = redactPatterns(afterTokens)
+
+  return {
+    text: finalText,
+    map: { tokens: tokenMap },
+  }
+}
+
+/**
+ * 匿名化されたテキストからトークンを原文に戻す。
+ * 復元対象は employees 由来のトークン (emp_NNN) のみ。
+ * REDACTED プレースホルダは復元不可 (意図的な情報破棄)。
+ */
+export function deanonymize(text: string, map: AnonymizationMap): string {
+  if (text.length === 0) return text
+
+  // token → 代表的な原文 の逆引きマップを作成
+  const reverseMap = new Map<string, string>()
+  for (const [original, token] of map.tokens.entries()) {
+    // 同一トークンに複数原文が紐づいた場合は最初の値を採用
+    if (!reverseMap.has(token)) {
+      reverseMap.set(token, original)
+    }
+  }
+
+  return replaceAllByMap(text, reverseMap)
+}

--- a/src/lib/ai-gateway/chat-provider.ts
+++ b/src/lib/ai-gateway/chat-provider.ts
@@ -1,0 +1,18 @@
+/**
+ * ChatProvider 抽象インターフェース
+ *
+ * AI プロバイダ SDK (Anthropic / OpenAI) を共通形状にラップする。
+ * AIGateway はこのインターフェースにのみ依存する (DI 対象)。
+ *
+ * 関連要件: Req 20.13 (設定変更のみでモデル切替可能なアーキテクチャ)
+ */
+import type {
+  AIChatRequest,
+  AIChatResponse,
+  AIProviderName,
+} from './ai-gateway-types'
+
+export interface ChatProvider {
+  readonly name: AIProviderName
+  chat(request: AIChatRequest): Promise<AIChatResponse>
+}

--- a/src/lib/ai-gateway/providers/anthropic-provider.ts
+++ b/src/lib/ai-gateway/providers/anthropic-provider.ts
@@ -1,0 +1,156 @@
+/**
+ * Anthropic Claude ChatProvider 実装
+ *
+ * - @anthropic-ai/sdk の Messages.create() を呼び出す
+ * - system プロンプトは request.messages から抽出し、SDK の top-level `system` に渡す
+ * - request.enablePromptCache=true の場合、system ブロックに
+ *   cache_control: { type: 'ephemeral' } を付与しプロンプトキャッシュを有効化
+ * - usage.input_tokens / output_tokens を promptTokens / completionTokens に写像
+ */
+import Anthropic from '@anthropic-ai/sdk'
+
+import {
+  AIConfigurationError,
+  AIProviderError,
+  type AIChatRequest,
+  type AIChatResponse,
+} from '../ai-gateway-types'
+import type { ChatProvider } from '../chat-provider'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 定数
+// ─────────────────────────────────────────────────────────────────────────────
+
+const DEFAULT_MODEL = 'claude-haiku-4-5-20251001'
+const DEFAULT_MAX_OUTPUT_TOKENS = 1024
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 型
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface AnthropicProviderOptions {
+  readonly apiKey?: string
+  readonly model?: string
+  /** テスト用: モック済み Anthropic クライアントを差し替え */
+  readonly client?: Anthropic
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 実装
+// ─────────────────────────────────────────────────────────────────────────────
+
+class AnthropicChatProvider implements ChatProvider {
+  public readonly name = 'claude' as const
+  private readonly client: Anthropic
+  private readonly model: string
+
+  constructor(client: Anthropic, model: string) {
+    this.client = client
+    this.model = model
+  }
+
+  async chat(request: AIChatRequest): Promise<AIChatResponse> {
+    const systemText = extractSystemText(request)
+    const userAssistantMessages = request.messages
+      .filter((m) => m.role !== 'system')
+      .map((m) => ({
+        role: m.role as 'user' | 'assistant',
+        content: m.content,
+      }))
+
+    const createParams: Parameters<Anthropic['messages']['create']>[0] = {
+      model: this.model,
+      max_tokens: request.maxOutputTokens ?? DEFAULT_MAX_OUTPUT_TOKENS,
+      messages: userAssistantMessages,
+    }
+
+    if (systemText) {
+      if (request.enablePromptCache) {
+        createParams.system = [
+          {
+            type: 'text',
+            text: systemText,
+            cache_control: { type: 'ephemeral' },
+          },
+        ]
+      } else {
+        createParams.system = systemText
+      }
+    }
+
+    if (typeof request.temperature === 'number') {
+      createParams.temperature = request.temperature
+    }
+
+    let result
+    try {
+      result = await this.client.messages.create(createParams)
+    } catch (error) {
+      throw new AIProviderError(this.name, getErrorMessage(error), { cause: error })
+    }
+
+    const message = result as Awaited<ReturnType<Anthropic['messages']['create']>> & {
+      content: Array<{ type: string; text?: string }>
+      usage?: { input_tokens?: number; output_tokens?: number }
+    }
+
+    const content = message.content
+      .filter((block) => block.type === 'text')
+      .map((block) => block.text ?? '')
+      .join('')
+
+    return {
+      content,
+      provider: this.name,
+      usage: {
+        promptTokens: message.usage?.input_tokens ?? 0,
+        completionTokens: message.usage?.output_tokens ?? 0,
+      },
+      cached: false,
+    }
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ヘルパー
+// ─────────────────────────────────────────────────────────────────────────────
+
+function extractSystemText(request: AIChatRequest): string {
+  const systemMessages = request.messages.filter((m) => m.role === 'system')
+  if (systemMessages.length === 0) return ''
+  return systemMessages.map((m) => m.content).join('\n\n')
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message
+  return 'Unknown Anthropic error'
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Factory
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * AnthropicChatProvider を生成する。
+ *
+ * 優先順位:
+ *  1. opts.client が渡されていればそれを使用 (DI)
+ *  2. opts.apiKey または env ANTHROPIC_API_KEY で新規クライアント生成
+ *
+ * API キー未設定時は AIConfigurationError を投げる。
+ */
+export function createAnthropicProvider(opts: AnthropicProviderOptions = {}): ChatProvider {
+  const model = opts.model ?? process.env.ANTHROPIC_MODEL ?? DEFAULT_MODEL
+
+  if (opts.client) {
+    return new AnthropicChatProvider(opts.client, model)
+  }
+
+  const apiKey = opts.apiKey ?? process.env.ANTHROPIC_API_KEY
+  if (!apiKey || apiKey.trim().length === 0) {
+    throw new AIConfigurationError('ANTHROPIC_API_KEY is required to create an Anthropic provider')
+  }
+
+  const client = new Anthropic({ apiKey })
+  return new AnthropicChatProvider(client, model)
+}

--- a/src/lib/ai-gateway/providers/openai-provider.ts
+++ b/src/lib/ai-gateway/providers/openai-provider.ts
@@ -1,0 +1,128 @@
+/**
+ * OpenAI ChatProvider 実装
+ *
+ * - openai SDK の chat.completions.create() を呼び出す
+ * - usage.prompt_tokens / completion_tokens を promptTokens / completionTokens に写像
+ */
+import OpenAI from 'openai'
+
+import {
+  AIConfigurationError,
+  AIProviderError,
+  type AIChatRequest,
+  type AIChatResponse,
+} from '../ai-gateway-types'
+import type { ChatProvider } from '../chat-provider'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 定数
+// ─────────────────────────────────────────────────────────────────────────────
+
+const DEFAULT_MODEL = 'gpt-4o-mini'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 型
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface OpenAIProviderOptions {
+  readonly apiKey?: string
+  readonly model?: string
+  /** テスト用: モック済み OpenAI クライアントを差し替え */
+  readonly client?: OpenAI
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 実装
+// ─────────────────────────────────────────────────────────────────────────────
+
+class OpenAIChatProvider implements ChatProvider {
+  public readonly name = 'openai' as const
+  private readonly client: OpenAI
+  private readonly model: string
+
+  constructor(client: OpenAI, model: string) {
+    this.client = client
+    this.model = model
+  }
+
+  async chat(request: AIChatRequest): Promise<AIChatResponse> {
+    const params: Parameters<OpenAI['chat']['completions']['create']>[0] = {
+      model: this.model,
+      messages: request.messages.map((m) => ({
+        role: m.role,
+        content: m.content,
+      })),
+    }
+
+    if (typeof request.maxOutputTokens === 'number') {
+      params.max_completion_tokens = request.maxOutputTokens
+    }
+    if (typeof request.temperature === 'number') {
+      params.temperature = request.temperature
+    }
+
+    let result
+    try {
+      result = await this.client.chat.completions.create(params)
+    } catch (error) {
+      throw new AIProviderError(this.name, getErrorMessage(error), { cause: error })
+    }
+
+    const completion = result as Awaited<
+      ReturnType<OpenAI['chat']['completions']['create']>
+    > & {
+      choices: Array<{ message: { content: string | null } }>
+      usage?: { prompt_tokens?: number; completion_tokens?: number }
+    }
+
+    const content = completion.choices[0]?.message?.content ?? ''
+
+    return {
+      content,
+      provider: this.name,
+      usage: {
+        promptTokens: completion.usage?.prompt_tokens ?? 0,
+        completionTokens: completion.usage?.completion_tokens ?? 0,
+      },
+      cached: false,
+    }
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ヘルパー
+// ─────────────────────────────────────────────────────────────────────────────
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message
+  return 'Unknown OpenAI error'
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Factory
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * OpenAIChatProvider を生成する。
+ *
+ * 優先順位:
+ *  1. opts.client が渡されていればそれを使用 (DI)
+ *  2. opts.apiKey または env OPENAI_API_KEY で新規クライアント生成
+ *
+ * API キー未設定時は AIConfigurationError を投げる。
+ */
+export function createOpenAIProvider(opts: OpenAIProviderOptions = {}): ChatProvider {
+  const model = opts.model ?? process.env.OPENAI_MODEL ?? DEFAULT_MODEL
+
+  if (opts.client) {
+    return new OpenAIChatProvider(opts.client, model)
+  }
+
+  const apiKey = opts.apiKey ?? process.env.OPENAI_API_KEY
+  if (!apiKey || apiKey.trim().length === 0) {
+    throw new AIConfigurationError('OPENAI_API_KEY is required to create an OpenAI provider')
+  }
+
+  const client = new OpenAI({ apiKey })
+  return new OpenAIChatProvider(client, model)
+}

--- a/src/tests/ai-gateway/ai-gateway-from-env.test.ts
+++ b/src/tests/ai-gateway/ai-gateway-from-env.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+import { createAIGatewayFromEnv } from '@/lib/ai-gateway/ai-gateway'
+import { AIConfigurationError } from '@/lib/ai-gateway/ai-gateway-types'
+
+// ioredis の Redis クラスを no-op にモックし、REDIS_URL が設定された場合でも
+// テスト実行時にネットワーク接続が発生しないようにする。
+vi.mock('ioredis', () => ({
+  Redis: vi.fn().mockImplementation(() => ({
+    get: vi.fn().mockResolvedValue(null),
+    setex: vi.fn().mockResolvedValue('OK'),
+  })),
+}))
+
+// ─────────────────────────────────────────────────────────────────────────────
+// env helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+const ENV_KEYS = [
+  'AI_PROVIDER',
+  'REDIS_URL',
+  'ANTHROPIC_API_KEY',
+  'ANTHROPIC_MODEL',
+  'OPENAI_API_KEY',
+  'OPENAI_MODEL',
+] as const
+
+function snapshotEnv(): Record<string, string | undefined> {
+  const snap: Record<string, string | undefined> = {}
+  for (const key of ENV_KEYS) snap[key] = process.env[key]
+  return snap
+}
+
+function restoreEnv(snap: Record<string, string | undefined>): void {
+  for (const key of ENV_KEYS) {
+    if (snap[key] === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = snap[key]
+    }
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('createAIGatewayFromEnv', () => {
+  let snap: Record<string, string | undefined>
+
+  beforeEach(() => {
+    snap = snapshotEnv()
+    for (const key of ENV_KEYS) delete process.env[key]
+  })
+
+  afterEach(() => {
+    restoreEnv(snap)
+  })
+
+  it('defaults to claude provider when AI_PROVIDER is unset', () => {
+    process.env.ANTHROPIC_API_KEY = 'sk-test'
+    const gateway = createAIGatewayFromEnv()
+    expect(gateway.getCurrentProvider()).toBe('claude')
+  })
+
+  it('uses claude when AI_PROVIDER=claude', () => {
+    process.env.AI_PROVIDER = 'claude'
+    process.env.ANTHROPIC_API_KEY = 'sk-test'
+    const gateway = createAIGatewayFromEnv()
+    expect(gateway.getCurrentProvider()).toBe('claude')
+  })
+
+  it('uses openai when AI_PROVIDER=openai', () => {
+    process.env.AI_PROVIDER = 'openai'
+    process.env.OPENAI_API_KEY = 'sk-test'
+    const gateway = createAIGatewayFromEnv()
+    expect(gateway.getCurrentProvider()).toBe('openai')
+  })
+
+  it('throws AIConfigurationError for unknown AI_PROVIDER', () => {
+    process.env.AI_PROVIDER = 'gemini'
+    expect(() => createAIGatewayFromEnv()).toThrow(AIConfigurationError)
+  })
+
+  it('throws AIConfigurationError when selected provider has no API key', () => {
+    process.env.AI_PROVIDER = 'openai'
+    // OPENAI_API_KEY intentionally unset
+    expect(() => createAIGatewayFromEnv()).toThrow(AIConfigurationError)
+  })
+
+  it('falls back to InMemory cache when REDIS_URL is not set', () => {
+    process.env.ANTHROPIC_API_KEY = 'sk-test'
+    // REDIS_URL unset → ゲートウェイ生成が成功すること (Redis 接続失敗しないこと)
+    expect(() => createAIGatewayFromEnv()).not.toThrow()
+  })
+
+  it('accepts overrides.provider and skips env-based provider construction', () => {
+    // env に API キーがない状態でも overrides.provider を渡せば作成できる
+    const gateway = createAIGatewayFromEnv({
+      provider: {
+        name: 'claude',
+        chat: vi.fn(),
+      },
+    })
+    expect(gateway.getCurrentProvider()).toBe('claude')
+  })
+})

--- a/src/tests/ai-gateway/ai-gateway-types.test.ts
+++ b/src/tests/ai-gateway/ai-gateway-types.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest'
+import {
+  AI_PROVIDER_NAMES,
+  AI_DOMAINS,
+  isAIProviderName,
+  chatMessageSchema,
+  aiChatRequestSchema,
+  AIProviderError,
+  AITimeoutError,
+  AIConfigurationError,
+} from '@/lib/ai-gateway/ai-gateway-types'
+
+describe('AI_PROVIDER_NAMES', () => {
+  it('contains claude and openai', () => {
+    expect(AI_PROVIDER_NAMES).toEqual(['claude', 'openai'])
+  })
+})
+
+describe('AI_DOMAINS', () => {
+  it('contains ai-coach and feedback', () => {
+    expect(AI_DOMAINS).toEqual(['ai-coach', 'feedback'])
+  })
+})
+
+describe('isAIProviderName', () => {
+  it('returns true for supported providers', () => {
+    expect(isAIProviderName('claude')).toBe(true)
+    expect(isAIProviderName('openai')).toBe(true)
+  })
+
+  it('returns false for unknown providers or non-string values', () => {
+    expect(isAIProviderName('gemini')).toBe(false)
+    expect(isAIProviderName('')).toBe(false)
+    expect(isAIProviderName(null)).toBe(false)
+    expect(isAIProviderName(123)).toBe(false)
+    expect(isAIProviderName(undefined)).toBe(false)
+  })
+})
+
+describe('chatMessageSchema', () => {
+  it('accepts a valid message', () => {
+    const result = chatMessageSchema.safeParse({ role: 'user', content: 'hello' })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects empty content', () => {
+    const result = chatMessageSchema.safeParse({ role: 'user', content: '' })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects unknown role', () => {
+    const result = chatMessageSchema.safeParse({ role: 'tool', content: 'x' })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('aiChatRequestSchema', () => {
+  it('accepts a minimal valid request', () => {
+    const result = aiChatRequestSchema.safeParse({
+      domain: 'ai-coach',
+      messages: [{ role: 'user', content: 'hi' }],
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects empty messages array', () => {
+    const result = aiChatRequestSchema.safeParse({
+      domain: 'feedback',
+      messages: [],
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects unknown domain', () => {
+    const result = aiChatRequestSchema.safeParse({
+      domain: 'unknown',
+      messages: [{ role: 'user', content: 'hi' }],
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects temperature out of range', () => {
+    const result = aiChatRequestSchema.safeParse({
+      domain: 'ai-coach',
+      messages: [{ role: 'user', content: 'x' }],
+      temperature: 3,
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects non-positive timeoutMs', () => {
+    const result = aiChatRequestSchema.safeParse({
+      domain: 'ai-coach',
+      messages: [{ role: 'user', content: 'x' }],
+      timeoutMs: 0,
+    })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('Error classes', () => {
+  it('AIProviderError captures provider and message', () => {
+    const err = new AIProviderError('claude', 'boom')
+    expect(err).toBeInstanceOf(Error)
+    expect(err.name).toBe('AIProviderError')
+    expect(err.provider).toBe('claude')
+    expect(err.providerMessage).toBe('boom')
+    expect(err.message).toContain('claude')
+    expect(err.message).toContain('boom')
+  })
+
+  it('AITimeoutError captures elapsed ms', () => {
+    const err = new AITimeoutError(5000)
+    expect(err).toBeInstanceOf(Error)
+    expect(err.name).toBe('AITimeoutError')
+    expect(err.elapsedMs).toBe(5000)
+  })
+
+  it('AIConfigurationError wraps a message', () => {
+    const err = new AIConfigurationError('API key missing')
+    expect(err).toBeInstanceOf(Error)
+    expect(err.name).toBe('AIConfigurationError')
+    expect(err.message).toBe('API key missing')
+  })
+})

--- a/src/tests/ai-gateway/ai-gateway.test.ts
+++ b/src/tests/ai-gateway/ai-gateway.test.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+import { createAIGateway } from '@/lib/ai-gateway/ai-gateway'
+import { createInMemoryAIResponseCache } from '@/lib/ai-gateway/ai-response-cache'
+import {
+  AIProviderError,
+  AITimeoutError,
+  type AIChatRequest,
+  type AIChatResponse,
+} from '@/lib/ai-gateway/ai-gateway-types'
+import type { ChatProvider } from '@/lib/ai-gateway/chat-provider'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test fixtures
+// ─────────────────────────────────────────────────────────────────────────────
+
+function buildProvider(
+  overrides: {
+    name?: 'claude' | 'openai'
+    chatFn?: ReturnType<typeof vi.fn>
+  } = {},
+): { provider: ChatProvider; chatFn: ReturnType<typeof vi.fn> } {
+  const chatFn =
+    overrides.chatFn ??
+    vi.fn().mockResolvedValue({
+      content: 'hi from fake',
+      provider: overrides.name ?? 'claude',
+      usage: { promptTokens: 5, completionTokens: 3 },
+      cached: false,
+    } satisfies AIChatResponse)
+
+  const provider: ChatProvider = {
+    name: overrides.name ?? 'claude',
+    chat: chatFn as unknown as ChatProvider['chat'],
+  }
+  return { provider, chatFn }
+}
+
+function buildRequest(overrides: Partial<AIChatRequest> = {}): AIChatRequest {
+  return {
+    domain: 'ai-coach',
+    messages: [{ role: 'user', content: 'hi' }],
+    ...overrides,
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// getCurrentProvider
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('AIGateway.getCurrentProvider', () => {
+  it('returns the provider name', () => {
+    const { provider } = buildProvider({ name: 'openai' })
+    const gateway = createAIGateway({
+      provider,
+      cache: createInMemoryAIResponseCache(() => 0),
+    })
+    expect(gateway.getCurrentProvider()).toBe('openai')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Validation
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('AIGateway.chat — validation', () => {
+  it('rejects requests that fail Zod validation', async () => {
+    const { provider } = buildProvider()
+    const gateway = createAIGateway({
+      provider,
+      cache: createInMemoryAIResponseCache(() => 0),
+    })
+
+    await expect(
+      gateway.chat({
+        // @ts-expect-error intentional invalid input
+        domain: 'unknown-domain',
+        messages: [{ role: 'user', content: 'hi' }],
+      }),
+    ).rejects.toThrow()
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Cache behaviour
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('AIGateway.chat — caching', () => {
+  it('calls provider on miss, stores the response, and emits onUsage', async () => {
+    const { provider, chatFn } = buildProvider()
+    const cache = createInMemoryAIResponseCache(() => 0)
+    const onUsage = vi.fn()
+
+    const gateway = createAIGateway({ provider, cache, onUsage })
+
+    const response = await gateway.chat(buildRequest())
+
+    expect(chatFn).toHaveBeenCalledOnce()
+    expect(response.content).toBe('hi from fake')
+    expect(response.cached).toBe(false)
+    expect(onUsage).toHaveBeenCalledOnce()
+    expect(onUsage.mock.calls[0]?.[0]).toMatchObject({
+      domain: 'ai-coach',
+      provider: 'claude',
+      cached: false,
+      promptTokens: 5,
+      completionTokens: 3,
+    })
+  })
+
+  it('returns cached response without calling provider on hit', async () => {
+    const { provider, chatFn } = buildProvider()
+    const cache = createInMemoryAIResponseCache(() => 0)
+    const onUsage = vi.fn()
+    const gateway = createAIGateway({ provider, cache, onUsage })
+
+    const req = buildRequest()
+    const first = await gateway.chat(req)
+    expect(first.cached).toBe(false)
+
+    const second = await gateway.chat(req)
+    expect(second.cached).toBe(true)
+    expect(second.content).toBe('hi from fake')
+    expect(chatFn).toHaveBeenCalledOnce() // only the first call hit the provider
+    expect(onUsage).toHaveBeenCalledTimes(2)
+    expect(onUsage.mock.calls[1]?.[0].cached).toBe(true)
+  })
+
+  it('treats different domains as different cache entries', async () => {
+    const { provider, chatFn } = buildProvider()
+    const cache = createInMemoryAIResponseCache(() => 0)
+    const gateway = createAIGateway({ provider, cache })
+
+    await gateway.chat(buildRequest({ domain: 'ai-coach' }))
+    await gateway.chat(buildRequest({ domain: 'feedback' }))
+
+    expect(chatFn).toHaveBeenCalledTimes(2)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Timeout
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('AIGateway.chat — timeout', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('rejects with AITimeoutError when provider exceeds defaultTimeoutMs', async () => {
+    // Provider never resolves; only the gateway's internal timer should fire
+    const chatFn = vi.fn().mockImplementation(() => new Promise<AIChatResponse>(() => {}))
+    const { provider } = buildProvider({ chatFn })
+    const cache = createInMemoryAIResponseCache(() => 0)
+    const gateway = createAIGateway({
+      provider,
+      cache,
+      defaultTimeoutMs: 1000,
+    })
+
+    const pending = gateway.chat(buildRequest())
+    // ハンドラを先に attach して未捕捉 rejection を防ぐ
+    const assertion = expect(pending).rejects.toBeInstanceOf(AITimeoutError)
+
+    await vi.advanceTimersByTimeAsync(1500)
+    await assertion
+  })
+
+  it('honours per-request timeoutMs', async () => {
+    const chatFn = vi.fn().mockImplementation(() => new Promise<AIChatResponse>(() => {}))
+    const { provider } = buildProvider({ chatFn })
+    const cache = createInMemoryAIResponseCache(() => 0)
+    const gateway = createAIGateway({
+      provider,
+      cache,
+      defaultTimeoutMs: 10_000,
+    })
+
+    const pending = gateway.chat(buildRequest({ timeoutMs: 500 }))
+    const assertion = expect(pending).rejects.toBeInstanceOf(AITimeoutError)
+
+    await vi.advanceTimersByTimeAsync(1000)
+    await assertion
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Error normalisation
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('AIGateway.chat — errors', () => {
+  it('propagates AIProviderError thrown by the provider', async () => {
+    const chatFn = vi.fn().mockRejectedValue(new AIProviderError('claude', 'boom'))
+    const { provider } = buildProvider({ chatFn })
+    const gateway = createAIGateway({
+      provider,
+      cache: createInMemoryAIResponseCache(() => 0),
+    })
+
+    await expect(gateway.chat(buildRequest())).rejects.toBeInstanceOf(AIProviderError)
+  })
+
+  it('normalises generic Errors into AIProviderError', async () => {
+    const chatFn = vi.fn().mockRejectedValue(new Error('unexpected'))
+    const { provider } = buildProvider({ chatFn })
+    const gateway = createAIGateway({
+      provider,
+      cache: createInMemoryAIResponseCache(() => 0),
+    })
+
+    const promise = gateway.chat(buildRequest())
+    await expect(promise).rejects.toBeInstanceOf(AIProviderError)
+    await expect(promise).rejects.toThrow(/unexpected/)
+  })
+
+  it('does not fail the call when onUsage itself throws', async () => {
+    const { provider } = buildProvider()
+    const cache = createInMemoryAIResponseCache(() => 0)
+    const onUsage = vi.fn().mockRejectedValue(new Error('logger down'))
+
+    const gateway = createAIGateway({ provider, cache, onUsage })
+
+    const response = await gateway.chat(buildRequest())
+    expect(response.content).toBe('hi from fake')
+    expect(onUsage).toHaveBeenCalled()
+  })
+})

--- a/src/tests/ai-gateway/ai-response-cache.test.ts
+++ b/src/tests/ai-gateway/ai-response-cache.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, vi } from 'vitest'
+import type { Redis } from 'ioredis'
+
+import {
+  createInMemoryAIResponseCache,
+  createRedisAIResponseCache,
+  buildCacheKey,
+  DEFAULT_AI_CACHE_TTL_SECONDS,
+} from '@/lib/ai-gateway/ai-response-cache'
+import type { AIChatResponse } from '@/lib/ai-gateway/ai-gateway-types'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+function buildResponse(overrides: Partial<AIChatResponse> = {}): AIChatResponse {
+  return {
+    content: 'hello',
+    provider: 'claude',
+    usage: { promptTokens: 10, completionTokens: 5 },
+    cached: false,
+    ...overrides,
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// buildCacheKey
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('buildCacheKey', () => {
+  it('produces a stable ai:cache:<sha256hex> key for identical input', () => {
+    const a = buildCacheKey('claude|ai-coach|[]')
+    const b = buildCacheKey('claude|ai-coach|[]')
+    expect(a).toBe(b)
+    expect(a.startsWith('ai:cache:')).toBe(true)
+    // sha256 hex = 64 chars
+    expect(a.length).toBe('ai:cache:'.length + 64)
+  })
+
+  it('produces different keys for different inputs', () => {
+    const a = buildCacheKey('claude|ai-coach|x')
+    const b = buildCacheKey('openai|ai-coach|x')
+    expect(a).not.toBe(b)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// InMemory cache
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('createInMemoryAIResponseCache', () => {
+  it('returns null when no entry exists', async () => {
+    const cache = createInMemoryAIResponseCache(() => 0)
+    const result = await cache.get('missing')
+    expect(result).toBeNull()
+  })
+
+  it('round-trips set and get, injecting cached:true', async () => {
+    const cache = createInMemoryAIResponseCache(() => 0)
+    const response = buildResponse({ cached: false })
+
+    await cache.set('key-1', response)
+    const hit = await cache.get('key-1')
+
+    expect(hit).not.toBeNull()
+    expect(hit?.cached).toBe(true)
+    expect(hit?.content).toBe('hello')
+    expect(hit?.usage.promptTokens).toBe(10)
+  })
+
+  it('expires entries after TTL elapses (clock-driven)', async () => {
+    let now = 0
+    const cache = createInMemoryAIResponseCache(() => now)
+    await cache.set('key-1', buildResponse(), 1) // 1 second TTL
+
+    now = 500 // 0.5s later → still valid
+    expect(await cache.get('key-1')).not.toBeNull()
+
+    now = 1500 // 1.5s later → expired
+    expect(await cache.get('key-1')).toBeNull()
+  })
+
+  it('applies DEFAULT_AI_CACHE_TTL_SECONDS when ttl is omitted', async () => {
+    let now = 0
+    const cache = createInMemoryAIResponseCache(() => now)
+    await cache.set('key-1', buildResponse())
+
+    now = (DEFAULT_AI_CACHE_TTL_SECONDS - 1) * 1000 // just before expiry
+    expect(await cache.get('key-1')).not.toBeNull()
+
+    now = (DEFAULT_AI_CACHE_TTL_SECONDS + 1) * 1000
+    expect(await cache.get('key-1')).toBeNull()
+  })
+
+  it('keeps entries for different keys independent', async () => {
+    const cache = createInMemoryAIResponseCache(() => 0)
+    await cache.set('a', buildResponse({ content: 'A' }))
+    await cache.set('b', buildResponse({ content: 'B' }))
+
+    const hitA = await cache.get('a')
+    const hitB = await cache.get('b')
+
+    expect(hitA?.content).toBe('A')
+    expect(hitB?.content).toBe('B')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Redis cache
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('createRedisAIResponseCache', () => {
+  function buildRedisMock(): {
+    client: Redis
+    get: ReturnType<typeof vi.fn>
+    setex: ReturnType<typeof vi.fn>
+  } {
+    const get = vi.fn()
+    const setex = vi.fn()
+    return {
+      client: { get, setex } as unknown as Redis,
+      get,
+      setex,
+    }
+  }
+
+  it('calls redis.get with the hashed key and returns null when missing', async () => {
+    const { client, get } = buildRedisMock()
+    get.mockResolvedValue(null)
+
+    const cache = createRedisAIResponseCache(client)
+    const result = await cache.get('k')
+
+    expect(result).toBeNull()
+    expect(get).toHaveBeenCalledOnce()
+    expect(get.mock.calls[0]?.[0]).toBe(buildCacheKey('k'))
+  })
+
+  it('parses JSON value and injects cached:true on hit', async () => {
+    const { client, get } = buildRedisMock()
+    const stored = { ...buildResponse(), cached: false }
+    get.mockResolvedValue(JSON.stringify(stored))
+
+    const cache = createRedisAIResponseCache(client)
+    const result = await cache.get('k')
+
+    expect(result).not.toBeNull()
+    expect(result?.cached).toBe(true)
+    expect(result?.content).toBe('hello')
+  })
+
+  it('returns null for malformed JSON without throwing', async () => {
+    const { client, get } = buildRedisMock()
+    get.mockResolvedValue('not-json')
+
+    const cache = createRedisAIResponseCache(client)
+    expect(await cache.get('k')).toBeNull()
+  })
+
+  it('calls redis.setex with default TTL when ttl is omitted', async () => {
+    const { client, setex } = buildRedisMock()
+    setex.mockResolvedValue('OK')
+
+    const cache = createRedisAIResponseCache(client)
+    await cache.set('k', buildResponse())
+
+    expect(setex).toHaveBeenCalledOnce()
+    const [key, ttl, payload] = setex.mock.calls[0] as [string, number, string]
+    expect(key).toBe(buildCacheKey('k'))
+    expect(ttl).toBe(DEFAULT_AI_CACHE_TTL_SECONDS)
+    expect(JSON.parse(payload).cached).toBe(false)
+    expect(JSON.parse(payload).content).toBe('hello')
+  })
+
+  it('respects a custom defaultTtl from the factory', async () => {
+    const { client, setex } = buildRedisMock()
+    setex.mockResolvedValue('OK')
+
+    const cache = createRedisAIResponseCache(client, 60)
+    await cache.set('k', buildResponse())
+
+    expect(setex.mock.calls[0]?.[1]).toBe(60)
+  })
+
+  it('accepts a per-call ttl override', async () => {
+    const { client, setex } = buildRedisMock()
+    setex.mockResolvedValue('OK')
+
+    const cache = createRedisAIResponseCache(client, 60)
+    await cache.set('k', buildResponse(), 10)
+
+    expect(setex.mock.calls[0]?.[1]).toBe(10)
+  })
+})

--- a/src/tests/ai-gateway/anonymizer.test.ts
+++ b/src/tests/ai-gateway/anonymizer.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from 'vitest'
+import { anonymize, deanonymize } from '@/lib/ai-gateway/anonymizer'
+
+describe('anonymize', () => {
+  it('replaces a single fullName with emp_001', () => {
+    const result = anonymize({
+      text: '田中太郎さんの評価を行います。',
+      employees: [{ id: 'u1', fullName: '田中太郎' }],
+    })
+
+    expect(result.text).toBe('emp_001さんの評価を行います。')
+    expect(result.map.tokens.get('田中太郎')).toBe('emp_001')
+  })
+
+  it('uses the same token for repeated occurrences of the same fullName', () => {
+    const result = anonymize({
+      text: '田中太郎。また田中太郎。',
+      employees: [{ id: 'u1', fullName: '田中太郎' }],
+    })
+
+    expect(result.text).toBe('emp_001。またemp_001。')
+  })
+
+  it('replaces employeeCode along with fullName using the same token per employee', () => {
+    const result = anonymize({
+      text: '田中太郎 (E-0001) の評価',
+      employees: [{ id: 'u1', fullName: '田中太郎', employeeCode: 'E-0001' }],
+    })
+
+    expect(result.text).toContain('emp_001')
+    expect(result.text).not.toContain('田中太郎')
+    expect(result.text).not.toContain('E-0001')
+    expect(result.map.tokens.get('E-0001')).toBe('emp_001')
+  })
+
+  it('replaces emails with [EMAIL_REDACTED] when no employee mapping provided', () => {
+    const result = anonymize({
+      text: 'Contact: tanaka@example.com please',
+    })
+
+    expect(result.text).toBe('Contact: [EMAIL_REDACTED] please')
+  })
+
+  it('replaces phone numbers with [PHONE_REDACTED]', () => {
+    const result = anonymize({
+      text: '電話番号は 03-1234-5678 です',
+    })
+
+    expect(result.text).toContain('[PHONE_REDACTED]')
+    expect(result.text).not.toContain('03-1234-5678')
+  })
+
+  it('replaces generic employee codes with [CODE_REDACTED] when not in the map', () => {
+    const result = anonymize({
+      text: '社員番号 E-9999 の件',
+    })
+
+    expect(result.text).toBe('社員番号 [CODE_REDACTED] の件')
+  })
+
+  it('assigns sequential tokens for multiple employees', () => {
+    const result = anonymize({
+      text: '田中太郎と山田花子のミーティング',
+      employees: [
+        { id: 'u1', fullName: '田中太郎' },
+        { id: 'u2', fullName: '山田花子' },
+      ],
+    })
+
+    expect(result.text).toBe('emp_001とemp_002のミーティング')
+    expect(result.map.tokens.get('田中太郎')).toBe('emp_001')
+    expect(result.map.tokens.get('山田花子')).toBe('emp_002')
+  })
+
+  it('prefers explicit employee email over the redaction pattern', () => {
+    const result = anonymize({
+      text: '連絡先: tanaka@example.com と yamada@example.com',
+      employees: [
+        { id: 'u1', fullName: '田中太郎', email: 'tanaka@example.com' },
+        { id: 'u2', fullName: '山田花子' },
+      ],
+    })
+
+    expect(result.text).toContain('emp_001')
+    expect(result.text).toContain('[EMAIL_REDACTED]')
+    expect(result.text).not.toContain('tanaka@example.com')
+  })
+
+  it('handles empty text safely', () => {
+    const result = anonymize({ text: '' })
+    expect(result.text).toBe('')
+    expect(result.map.tokens.size).toBe(0)
+  })
+
+  it('handles input without employees (returns only pattern redactions)', () => {
+    const result = anonymize({ text: '問い合わせは info@example.com まで' })
+    expect(result.text).toBe('問い合わせは [EMAIL_REDACTED] まで')
+    expect(result.map.tokens.size).toBe(0)
+  })
+
+  it('ignores employees with missing fields without producing stray tokens in the map', () => {
+    const result = anonymize({
+      text: '田中太郎の件',
+      employees: [
+        { id: 'u1', fullName: '田中太郎' },
+        { id: 'u2' }, // no identifying fields
+      ],
+    })
+
+    expect(result.text).toBe('emp_001の件')
+    // u2 は原文に一致する値を提供しないため、置換マップには現れない
+    expect(Array.from(result.map.tokens.values())).toEqual(['emp_001'])
+  })
+
+  it('does not over-replace: "田中" inside "田中一郎" stays intact when only full name is registered', () => {
+    const result = anonymize({
+      text: '田中太郎さんと田中一郎さんは別人です',
+      employees: [{ id: 'u1', fullName: '田中太郎' }],
+    })
+
+    expect(result.text).toBe('emp_001さんと田中一郎さんは別人です')
+  })
+})
+
+describe('deanonymize', () => {
+  it('restores tokens back to the original names', () => {
+    const { text, map } = anonymize({
+      text: '田中太郎と山田花子',
+      employees: [
+        { id: 'u1', fullName: '田中太郎' },
+        { id: 'u2', fullName: '山田花子' },
+      ],
+    })
+
+    expect(deanonymize(text, map)).toBe('田中太郎と山田花子')
+  })
+
+  it('returns empty string unchanged', () => {
+    expect(deanonymize('', { tokens: new Map() })).toBe('')
+  })
+
+  it('leaves REDACTED placeholders untouched (irreversible)', () => {
+    const { text, map } = anonymize({ text: '連絡先 info@example.com' })
+    expect(deanonymize(text, map)).toBe('連絡先 [EMAIL_REDACTED]')
+  })
+})

--- a/src/tests/ai-gateway/anthropic-provider.test.ts
+++ b/src/tests/ai-gateway/anthropic-provider.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type Anthropic from '@anthropic-ai/sdk'
+
+import { createAnthropicProvider } from '@/lib/ai-gateway/providers/anthropic-provider'
+import {
+  AIConfigurationError,
+  AIProviderError,
+  type AIChatRequest,
+} from '@/lib/ai-gateway/ai-gateway-types'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+function buildMockClient(overrides: {
+  createFn?: ReturnType<typeof vi.fn>
+} = {}): { client: Anthropic; createFn: ReturnType<typeof vi.fn> } {
+  const createFn =
+    overrides.createFn ??
+    vi.fn().mockResolvedValue({
+      content: [{ type: 'text', text: 'hello from claude' }],
+      usage: { input_tokens: 42, output_tokens: 17 },
+    })
+  return {
+    client: { messages: { create: createFn } } as unknown as Anthropic,
+    createFn,
+  }
+}
+
+function buildRequest(overrides: Partial<AIChatRequest> = {}): AIChatRequest {
+  return {
+    domain: 'ai-coach',
+    messages: [{ role: 'user', content: 'hi' }],
+    ...overrides,
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Factory behaviour
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('createAnthropicProvider', () => {
+  const originalEnv = { ...process.env }
+
+  beforeEach(() => {
+    // 各テストで API キー env をクリアして独立性を確保
+    delete process.env.ANTHROPIC_API_KEY
+    delete process.env.ANTHROPIC_MODEL
+  })
+
+  afterEach(() => {
+    process.env = { ...originalEnv }
+  })
+
+  it('throws AIConfigurationError when no API key and no client provided', () => {
+    expect(() => createAnthropicProvider()).toThrow(AIConfigurationError)
+  })
+
+  it('uses injected client when provided (no API key required)', async () => {
+    const { client, createFn } = buildMockClient()
+    const provider = createAnthropicProvider({ client })
+
+    expect(provider.name).toBe('claude')
+
+    await provider.chat(buildRequest())
+    expect(createFn).toHaveBeenCalledOnce()
+  })
+
+  it('accepts an apiKey option without throwing', () => {
+    expect(() => createAnthropicProvider({ apiKey: 'sk-test-key' })).not.toThrow()
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// chat() behaviour
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('AnthropicChatProvider.chat', () => {
+  it('passes a plain string system prompt by default', async () => {
+    const { client, createFn } = buildMockClient()
+    const provider = createAnthropicProvider({ client })
+
+    await provider.chat(
+      buildRequest({
+        messages: [
+          { role: 'system', content: 'Be helpful.' },
+          { role: 'user', content: 'hi' },
+        ],
+      }),
+    )
+
+    const args = createFn.mock.calls[0]?.[0]
+    expect(args.system).toBe('Be helpful.')
+    expect(args.messages).toEqual([{ role: 'user', content: 'hi' }])
+    expect(args.max_tokens).toBeGreaterThan(0)
+  })
+
+  it('wraps system with cache_control when enablePromptCache is true', async () => {
+    const { client, createFn } = buildMockClient()
+    const provider = createAnthropicProvider({ client })
+
+    await provider.chat(
+      buildRequest({
+        enablePromptCache: true,
+        messages: [
+          { role: 'system', content: 'Cached prompt.' },
+          { role: 'user', content: 'hi' },
+        ],
+      }),
+    )
+
+    const args = createFn.mock.calls[0]?.[0]
+    expect(Array.isArray(args.system)).toBe(true)
+    expect(args.system[0]).toMatchObject({
+      type: 'text',
+      text: 'Cached prompt.',
+      cache_control: { type: 'ephemeral' },
+    })
+  })
+
+  it('omits system when request has no system message', async () => {
+    const { client, createFn } = buildMockClient()
+    const provider = createAnthropicProvider({ client })
+
+    await provider.chat(buildRequest({ messages: [{ role: 'user', content: 'hi' }] }))
+
+    const args = createFn.mock.calls[0]?.[0]
+    expect(args.system).toBeUndefined()
+  })
+
+  it('maps usage.input_tokens / output_tokens into the response', async () => {
+    const { client } = buildMockClient()
+    const provider = createAnthropicProvider({ client })
+
+    const response = await provider.chat(buildRequest())
+
+    expect(response.content).toBe('hello from claude')
+    expect(response.provider).toBe('claude')
+    expect(response.usage).toEqual({ promptTokens: 42, completionTokens: 17 })
+    expect(response.cached).toBe(false)
+  })
+
+  it('applies maxOutputTokens and temperature when provided', async () => {
+    const { client, createFn } = buildMockClient()
+    const provider = createAnthropicProvider({ client })
+
+    await provider.chat(
+      buildRequest({
+        maxOutputTokens: 200,
+        temperature: 0.4,
+      }),
+    )
+
+    const args = createFn.mock.calls[0]?.[0]
+    expect(args.max_tokens).toBe(200)
+    expect(args.temperature).toBe(0.4)
+  })
+
+  it('uses ANTHROPIC_MODEL env var when set', async () => {
+    process.env.ANTHROPIC_MODEL = 'claude-test-model'
+    const { client, createFn } = buildMockClient()
+    const provider = createAnthropicProvider({ client })
+
+    await provider.chat(buildRequest())
+
+    const args = createFn.mock.calls[0]?.[0]
+    expect(args.model).toBe('claude-test-model')
+
+    delete process.env.ANTHROPIC_MODEL
+  })
+
+  it('wraps API errors in AIProviderError', async () => {
+    const createFn = vi.fn().mockRejectedValue(new Error('upstream 500'))
+    const { client } = buildMockClient({ createFn })
+    const provider = createAnthropicProvider({ client })
+
+    await expect(provider.chat(buildRequest())).rejects.toBeInstanceOf(AIProviderError)
+    await expect(provider.chat(buildRequest())).rejects.toThrow(/upstream 500/)
+  })
+
+  it('returns empty content when response has no text blocks', async () => {
+    const createFn = vi.fn().mockResolvedValue({
+      content: [],
+      usage: { input_tokens: 1, output_tokens: 0 },
+    })
+    const { client } = buildMockClient({ createFn })
+    const provider = createAnthropicProvider({ client })
+
+    const response = await provider.chat(buildRequest())
+    expect(response.content).toBe('')
+  })
+})

--- a/src/tests/ai-gateway/openai-provider.test.ts
+++ b/src/tests/ai-gateway/openai-provider.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type OpenAI from 'openai'
+
+import { createOpenAIProvider } from '@/lib/ai-gateway/providers/openai-provider'
+import {
+  AIConfigurationError,
+  AIProviderError,
+  type AIChatRequest,
+} from '@/lib/ai-gateway/ai-gateway-types'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+function buildMockClient(overrides: {
+  createFn?: ReturnType<typeof vi.fn>
+} = {}): { client: OpenAI; createFn: ReturnType<typeof vi.fn> } {
+  const createFn =
+    overrides.createFn ??
+    vi.fn().mockResolvedValue({
+      choices: [{ message: { content: 'hello from openai' } }],
+      usage: { prompt_tokens: 11, completion_tokens: 7 },
+    })
+  return {
+    client: {
+      chat: { completions: { create: createFn } },
+    } as unknown as OpenAI,
+    createFn,
+  }
+}
+
+function buildRequest(overrides: Partial<AIChatRequest> = {}): AIChatRequest {
+  return {
+    domain: 'feedback',
+    messages: [{ role: 'user', content: 'hi' }],
+    ...overrides,
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Factory behaviour
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('createOpenAIProvider', () => {
+  const originalEnv = { ...process.env }
+
+  beforeEach(() => {
+    delete process.env.OPENAI_API_KEY
+    delete process.env.OPENAI_MODEL
+  })
+
+  afterEach(() => {
+    process.env = { ...originalEnv }
+  })
+
+  it('throws AIConfigurationError when no API key and no client provided', () => {
+    expect(() => createOpenAIProvider()).toThrow(AIConfigurationError)
+  })
+
+  it('uses injected client when provided (no API key required)', async () => {
+    const { client, createFn } = buildMockClient()
+    const provider = createOpenAIProvider({ client })
+
+    expect(provider.name).toBe('openai')
+
+    await provider.chat(buildRequest())
+    expect(createFn).toHaveBeenCalledOnce()
+  })
+
+  it('accepts an apiKey option without throwing', () => {
+    expect(() => createOpenAIProvider({ apiKey: 'sk-openai-test' })).not.toThrow()
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// chat() behaviour
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('OpenAIChatProvider.chat', () => {
+  it('forwards messages as-is including system role', async () => {
+    const { client, createFn } = buildMockClient()
+    const provider = createOpenAIProvider({ client })
+
+    await provider.chat(
+      buildRequest({
+        messages: [
+          { role: 'system', content: 'system prompt' },
+          { role: 'user', content: 'hi' },
+        ],
+      }),
+    )
+
+    const args = createFn.mock.calls[0]?.[0]
+    expect(args.messages).toEqual([
+      { role: 'system', content: 'system prompt' },
+      { role: 'user', content: 'hi' },
+    ])
+  })
+
+  it('maps usage.prompt_tokens / completion_tokens into the response', async () => {
+    const { client } = buildMockClient()
+    const provider = createOpenAIProvider({ client })
+
+    const response = await provider.chat(buildRequest())
+
+    expect(response.content).toBe('hello from openai')
+    expect(response.provider).toBe('openai')
+    expect(response.usage).toEqual({ promptTokens: 11, completionTokens: 7 })
+    expect(response.cached).toBe(false)
+  })
+
+  it('applies maxOutputTokens as max_completion_tokens and temperature', async () => {
+    const { client, createFn } = buildMockClient()
+    const provider = createOpenAIProvider({ client })
+
+    await provider.chat(
+      buildRequest({ maxOutputTokens: 300, temperature: 0.2 }),
+    )
+
+    const args = createFn.mock.calls[0]?.[0]
+    expect(args.max_completion_tokens).toBe(300)
+    expect(args.temperature).toBe(0.2)
+  })
+
+  it('uses OPENAI_MODEL env var when set', async () => {
+    process.env.OPENAI_MODEL = 'gpt-test-model'
+    const { client, createFn } = buildMockClient()
+    const provider = createOpenAIProvider({ client })
+
+    await provider.chat(buildRequest())
+
+    expect(createFn.mock.calls[0]?.[0].model).toBe('gpt-test-model')
+
+    delete process.env.OPENAI_MODEL
+  })
+
+  it('wraps API errors in AIProviderError', async () => {
+    const createFn = vi.fn().mockRejectedValue(new Error('openai down'))
+    const { client } = buildMockClient({ createFn })
+    const provider = createOpenAIProvider({ client })
+
+    await expect(provider.chat(buildRequest())).rejects.toBeInstanceOf(AIProviderError)
+    await expect(provider.chat(buildRequest())).rejects.toThrow(/openai down/)
+  })
+
+  it('returns empty content when choices is empty', async () => {
+    const createFn = vi.fn().mockResolvedValue({
+      choices: [],
+      usage: { prompt_tokens: 1, completion_tokens: 0 },
+    })
+    const { client } = buildMockClient({ createFn })
+    const provider = createOpenAIProvider({ client })
+
+    const response = await provider.chat(buildRequest())
+    expect(response.content).toBe('')
+  })
+
+  it('returns empty content when message.content is null', async () => {
+    const createFn = vi.fn().mockResolvedValue({
+      choices: [{ message: { content: null } }],
+      usage: { prompt_tokens: 1, completion_tokens: 0 },
+    })
+    const { client } = buildMockClient({ createFn })
+    const provider = createOpenAIProvider({ client })
+
+    const response = await provider.chat(buildRequest())
+    expect(response.content).toBe('')
+  })
+})


### PR DESCRIPTION
## Summary

- Anthropic Claude / OpenAI SDK を共通 `ChatProvider` 抽象でラップし、環境変数 `AI_PROVIDER` のみでモデル切替可能な `AIGateway` を実装 (Req 20.13)
- 同一入力の AI レスポンスを Redis (`ai:cache:<sha256>`) に TTL 5 分でキャッシュしコスト削減 (Req 19.8)、REDIS_URL 未設定時は InMemory にフォールバック
- AI プロンプトから氏名・社員番号・メール・電話番号を除外する匿名化ユーティリティを追加 (Req 9.8)

Closes #15

## 実装内容

- `src/lib/ai-gateway/ai-gateway-types.ts` — 共通型 / Zod スキーマ / `AIProviderError`・`AITimeoutError`・`AIConfigurationError`
- `src/lib/ai-gateway/anonymizer.ts` — PII 匿名化 (`emp_NNN` トークン置換 + メール/電話/コードの REDACTED)
- `src/lib/ai-gateway/ai-response-cache.ts` — `AIResponseCache` + Redis / InMemory 実装、sha256 ベースのキャッシュキー
- `src/lib/ai-gateway/chat-provider.ts` — プロバイダ抽象インターフェース
- `src/lib/ai-gateway/providers/anthropic-provider.ts` — `@anthropic-ai/sdk` ラッパー、プロンプトキャッシュ対応 (`cache_control: ephemeral`)
- `src/lib/ai-gateway/providers/openai-provider.ts` — `openai` SDK ラッパー
- `src/lib/ai-gateway/ai-gateway.ts` — Zod バリデーション + キャッシュ + 5 秒タイムアウト + `onUsage` フック + env ベース factory
- テスト: 7 ファイル / 81 件すべてパス

## アーキテクチャ

```
    ┌─────────── createAIGatewayFromEnv() ───────────┐
    │  AI_PROVIDER=claude|openai  (default: claude)   │
    │  REDIS_URL → Redis / 未設定 → InMemory          │
    └─────────────────────┬──────────────────────────┘
                          ▼
               ┌──────── AIGateway ────────┐
               │  • Zod validate            │
               │  • cache.get (sha256 key)  │
               │  • withTimeout(provider)   │
               │  • cache.set + onUsage     │
               └────────────┬───────────────┘
                            ▼
               ┌────── ChatProvider ───────┐
               │  Anthropic / OpenAI       │
               └────────────────────────────┘
```

- `onUsage` は optional callback として AIGatewayDeps に持たせ、トークン使用量・キャッシュヒット率の実際のロギング実装は後続タスクに委譲 (Task 5.1 の要求通り)
- プロバイダクラスは `client` 引数で SDK クライアントを DI 可能 → テストでは実 API 呼び出し 0

## セキュリティ

- `anonymize()` は氏名・社員番号・メールを `emp_NNN` トークンに置換し、AI プロンプトから PII を除去 (Req 9.8)
- 同一社員の複数フィールド (fullName / employeeCode / email) は同一トークンに集約され、逆方向に `deanonymize()` で復元可能
- 正規表現マッチ (メール / 電話番号 / E-コード) は `[EMAIL_REDACTED]` / `[PHONE_REDACTED]` / `[CODE_REDACTED]` に置換し、復元不可 (意図的な情報破棄)
- API キーはすべて環境変数経由、ハードコーディング禁止。factory は未設定時に `AIConfigurationError` をフェイルファスト

## キャッシュ戦略

- キー: `ai:cache:${sha256(provider|domain|JSON.stringify(messages))}`
- TTL: デフォルト 300 秒 (`DEFAULT_AI_CACHE_TTL_SECONDS`)、呼び出し側・factory で上書き可能
- `cache.get` はヒット時に `cached: true` を注入して返却、`cache.set` は `cached: false` を正規化して保存

## テスト結果

- `pnpm test`: **463 件全パス** (新規 81 件含む)
  - `ai-gateway-types.test.ts`: 15
  - `anonymizer.test.ts`: 15
  - `ai-response-cache.test.ts`: 13
  - `anthropic-provider.test.ts`: 11
  - `openai-provider.test.ts`: 10
  - `ai-gateway.test.ts`: 10
  - `ai-gateway-from-env.test.ts`: 7
- `pnpm lint`: クリーン
- `pnpm type-check`: 本 PR の新規ファイルに関する型エラー 0。既存の pre-existing エラー (`prisma/extensions/encrypted-fields.ts`, `src/lib/access-log/access-log-repository.ts`, `src/lib/audit/audit-log-emitter.ts`) のみ、本 PR 範囲外
- 実 API 呼び出し 0 (すべて DI モック)

## Test Plan

- [ ] E2E 動作確認: `AI_PROVIDER=claude` + `ANTHROPIC_API_KEY` 設定で実 API 接続テスト
- [ ] E2E 動作確認: `AI_PROVIDER=openai` + `OPENAI_API_KEY` 設定で実 API 接続テスト
- [ ] Redis 実接続確認: `REDIS_URL` 設定時にキャッシュ get/set が機能すること
- [ ] プロンプトキャッシュヒット率のモニタリング (後続タスクで実装)

## Requirements

- Req 9.8 (PII 除外)
- Req 19.8 (Redis キャッシュによるコスト削減)
- Req 20.13 (設定変更のみでのモデル切替アーキテクチャ)

## スコープ外 (後続タスク)

- `lib/ai-monitoring` の `AIUsageRecord` DB 永続化 (本 PR では `onUsage` callback フックのみ用意)
- プロバイダ自動フェイルオーバー (Claude → OpenAI 等)
- ドメイン別プロンプトテンプレート
- 実際の呼び出し元サービス (ai-coach / feedback 変換) の実装