### PR TITLE
feat(ai-monitoring): Task 5.2 — AIUsageRecord 記録と AIMonitoringService

### DIFF
--- a/src/lib/ai-monitoring/ai-monitoring-service.ts
+++ b/src/lib/ai-monitoring/ai-monitoring-service.ts
@@ -1,0 +1,299 @@
+/**
+ * AIMonitoringService
+ *
+ * AI 呼び出し記録と集計を提供するアプリケーションサービス。
+ * - recordUsage / recordFailure: AIUsageRepository への Zod 検証付き書き込み
+ * - getMonthlyCost / getUserUsage / getFailureRate: 集計クエリ
+ * - detectAnomaly: 通常の 5 倍超ユーザーを検出 (Req 19.5)
+ *
+ * 関連要件: Req 19.1, Req 19.2, Req 19.5, Req 19.6, Req 19.8
+ * 注: Req 19.3/19.4 の予算アラート・機能停止は Task 5.3 で別サービスとして実装する。
+ */
+import {
+  aiUsageEntrySchema,
+  aiUsageFailureSchema,
+  InvalidYearMonthError,
+  type AIUsageEntry,
+  type AIUsageFailure,
+  type AnomalyFlag,
+  type DateRange,
+  type FailureRateSummary,
+  type MonthlyCostSummary,
+  type UserUsageSummary,
+} from './ai-usage-types'
+import type { AIUsageRepository } from './ai-usage-repository'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 定数
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** 異常判定のしきい値 (通常の 5 倍超) */
+const ANOMALY_MULTIPLIER_THRESHOLD = 5
+
+/** ベースライン算出に使用する直近月数 (対象月の前 3 ヶ月) */
+const ANOMALY_BASELINE_MONTHS = 3
+
+/** 対象月のコストがこの値未満の場合、異常検知からノイズとして除外する (USD) */
+const ANOMALY_NOISE_THRESHOLD_USD = 1
+
+/** yearMonth の書式 'YYYY-MM' (01-12) */
+const YEAR_MONTH_PATTERN = /^\d{4}-(0[1-9]|1[0-2])$/
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 公開型
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface AIMonitoringService {
+  recordUsage(entry: AIUsageEntry): Promise<void>
+  recordFailure(entry: AIUsageFailure): Promise<void>
+  getMonthlyCost(yearMonth: string): Promise<MonthlyCostSummary>
+  getUserUsage(userId: string, period: DateRange): Promise<UserUsageSummary>
+  getFailureRate(period: DateRange): Promise<FailureRateSummary>
+  detectAnomaly(yearMonth: string): Promise<readonly AnomalyFlag[]>
+}
+
+export interface AIMonitoringDeps {
+  readonly repository: AIUsageRepository
+  /** 時刻ソース (テスト容易化のため DI)。detectAnomaly の detectedAt に使う */
+  readonly clock?: () => Date
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ヘルパ
+// ─────────────────────────────────────────────────────────────────────────────
+
+function assertYearMonth(yearMonth: string): void {
+  if (!YEAR_MONTH_PATTERN.test(yearMonth)) {
+    throw new InvalidYearMonthError(yearMonth)
+  }
+}
+
+/** 'YYYY-MM' → DateRange (UTC、半開区間 [from, to)) */
+function yearMonthToRange(yearMonth: string): DateRange {
+  assertYearMonth(yearMonth)
+  const [yearStr, monthStr] = yearMonth.split('-')
+  const year = Number(yearStr)
+  const month = Number(monthStr) // 1-12
+  const from = new Date(Date.UTC(year, month - 1, 1, 0, 0, 0, 0))
+  const to = new Date(Date.UTC(year, month, 1, 0, 0, 0, 0))
+  return { from, to }
+}
+
+/** 'YYYY-MM' を n ヶ月シフト (負数で過去へ) */
+function shiftYearMonth(yearMonth: string, deltaMonths: number): string {
+  const [yearStr, monthStr] = yearMonth.split('-')
+  const base = new Date(Date.UTC(Number(yearStr), Number(monthStr) - 1, 1))
+  base.setUTCMonth(base.getUTCMonth() + deltaMonths)
+  const y = base.getUTCFullYear()
+  const m = base.getUTCMonth() + 1
+  return `${y}-${String(m).padStart(2, '0')}`
+}
+
+/** Date → 'YYYY-MM-DD' (UTC) */
+function toUtcDateString(d: Date): string {
+  const y = d.getUTCFullYear()
+  const m = String(d.getUTCMonth() + 1).padStart(2, '0')
+  const day = String(d.getUTCDate()).padStart(2, '0')
+  return `${y}-${m}-${day}`
+}
+
+function sumCost(entries: readonly AIUsageEntry[]): number {
+  return entries.reduce((acc, e) => acc + e.estimatedCostUsd, 0)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 集計関数
+// ─────────────────────────────────────────────────────────────────────────────
+
+function aggregateMonthlyCost(
+  yearMonth: string,
+  entries: readonly AIUsageEntry[],
+): MonthlyCostSummary {
+  const byProvider: Record<string, number> = {}
+  const byDomain: Record<string, number> = {}
+  const byDayMap = new Map<string, { costUsd: number; requests: number }>()
+
+  for (const entry of entries) {
+    byProvider[entry.provider] = (byProvider[entry.provider] ?? 0) + entry.estimatedCostUsd
+    byDomain[entry.domain] = (byDomain[entry.domain] ?? 0) + entry.estimatedCostUsd
+
+    const dayKey = toUtcDateString(entry.createdAt)
+    const bucket = byDayMap.get(dayKey) ?? { costUsd: 0, requests: 0 }
+    bucket.costUsd += entry.estimatedCostUsd
+    bucket.requests += 1
+    byDayMap.set(dayKey, bucket)
+  }
+
+  const byDay = [...byDayMap.entries()]
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+    .map(([date, v]) => ({ date, costUsd: v.costUsd, requests: v.requests }))
+
+  return {
+    yearMonth,
+    totalCostUsd: sumCost(entries),
+    totalRequests: entries.length,
+    byProvider,
+    byDomain,
+    byDay,
+  }
+}
+
+function aggregateUserUsage(
+  userId: string,
+  period: DateRange,
+  entries: readonly AIUsageEntry[],
+): UserUsageSummary {
+  const totalRequests = entries.length
+  const totalPromptTokens = entries.reduce((acc, e) => acc + e.promptTokens, 0)
+  const totalCompletionTokens = entries.reduce((acc, e) => acc + e.completionTokens, 0)
+  const cacheHits = entries.filter((e) => e.cacheHit).length
+  const cacheHitRate = totalRequests === 0 ? 0 : cacheHits / totalRequests
+
+  return {
+    userId,
+    period,
+    totalCostUsd: sumCost(entries),
+    totalRequests,
+    totalPromptTokens,
+    totalCompletionTokens,
+    cacheHitRate,
+  }
+}
+
+function aggregateFailureRate(
+  period: DateRange,
+  successes: readonly AIUsageEntry[],
+  failures: readonly AIUsageFailure[],
+): FailureRateSummary {
+  const totalAttempts = successes.length + failures.length
+  const failureCount = failures.length
+  const failureRate = totalAttempts === 0 ? 0 : failureCount / totalAttempts
+  const byErrorCategory: Record<string, number> = {}
+  for (const f of failures) {
+    byErrorCategory[f.errorCategory] = (byErrorCategory[f.errorCategory] ?? 0) + 1
+  }
+  return {
+    period,
+    totalAttempts,
+    failureCount,
+    failureRate,
+    byErrorCategory,
+  }
+}
+
+/** userId 別のコスト合計 Map を返す */
+function groupCostByUser(entries: readonly AIUsageEntry[]): Map<string, number> {
+  const map = new Map<string, number>()
+  for (const e of entries) {
+    map.set(e.userId, (map.get(e.userId) ?? 0) + e.estimatedCostUsd)
+  }
+  return map
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 異常検知 (Req 19.5)
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function collectBaselineCostsByUser(
+  repository: AIUsageRepository,
+  yearMonth: string,
+): Promise<Map<string, number>> {
+  const totals = new Map<string, number>()
+  for (let i = 1; i <= ANOMALY_BASELINE_MONTHS; i++) {
+    const ym = shiftYearMonth(yearMonth, -i)
+    const range = yearMonthToRange(ym)
+    const entries = await repository.listByDateRange(range)
+    for (const [userId, cost] of groupCostByUser(entries)) {
+      totals.set(userId, (totals.get(userId) ?? 0) + cost)
+    }
+  }
+  return totals
+}
+
+function buildAnomalyFlag(
+  userId: string,
+  yearMonth: string,
+  currentCost: number,
+  baselineTotal: number,
+  detectedAt: Date,
+): AnomalyFlag | null {
+  // 対象月のコストが小さすぎるときはノイズとしてスキップ
+  if (currentCost < ANOMALY_NOISE_THRESHOLD_USD) return null
+
+  const baselineAverage = baselineTotal / ANOMALY_BASELINE_MONTHS
+  // 直近 3 ヶ月のベースラインが 0 のユーザーは比較不能なのでスキップ
+  if (baselineAverage <= 0) return null
+
+  const multiplier = currentCost / baselineAverage
+  if (multiplier <= ANOMALY_MULTIPLIER_THRESHOLD) return null
+
+  return {
+    userId,
+    yearMonth,
+    currentCostUsd: currentCost,
+    baselineCostUsd: baselineAverage,
+    multiplier,
+    detectedAt,
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Factory
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function createAIMonitoringService(deps: AIMonitoringDeps): AIMonitoringService {
+  const { repository } = deps
+  const clock = deps.clock ?? (() => new Date())
+
+  async function recordUsage(entry: AIUsageEntry): Promise<void> {
+    const parsed = aiUsageEntrySchema.parse(entry)
+    await repository.create(parsed)
+  }
+
+  async function recordFailure(entry: AIUsageFailure): Promise<void> {
+    const parsed = aiUsageFailureSchema.parse(entry)
+    await repository.createFailure(parsed)
+  }
+
+  async function getMonthlyCost(yearMonth: string): Promise<MonthlyCostSummary> {
+    const range = yearMonthToRange(yearMonth)
+    const entries = await repository.listByDateRange(range)
+    return aggregateMonthlyCost(yearMonth, entries)
+  }
+
+  async function getUserUsage(userId: string, period: DateRange): Promise<UserUsageSummary> {
+    const entries = await repository.listByUser(userId, period)
+    return aggregateUserUsage(userId, period, entries)
+  }
+
+  async function getFailureRate(period: DateRange): Promise<FailureRateSummary> {
+    const successes = await repository.listByDateRange(period)
+    const failures = await repository.listFailuresByDateRange(period)
+    return aggregateFailureRate(period, successes, failures)
+  }
+
+  async function detectAnomaly(yearMonth: string): Promise<readonly AnomalyFlag[]> {
+    const currentRange = yearMonthToRange(yearMonth)
+    const currentEntries = await repository.listByDateRange(currentRange)
+    const currentByUser = groupCostByUser(currentEntries)
+    const baselineByUser = await collectBaselineCostsByUser(repository, yearMonth)
+
+    const detectedAt = clock()
+    const flags: AnomalyFlag[] = []
+    for (const [userId, currentCost] of currentByUser) {
+      const baselineTotal = baselineByUser.get(userId) ?? 0
+      const flag = buildAnomalyFlag(userId, yearMonth, currentCost, baselineTotal, detectedAt)
+      if (flag) flags.push(flag)
+    }
+    return flags
+  }
+
+  return {
+    recordUsage,
+    recordFailure,
+    getMonthlyCost,
+    getUserUsage,
+    getFailureRate,
+    detectAnomaly,
+  }
+}

--- a/src/lib/ai-monitoring/ai-usage-recorder.ts
+++ b/src/lib/ai-monitoring/ai-usage-recorder.ts
@@ -1,0 +1,118 @@
+/**
+ * AI Usage Recorder
+ *
+ * AIGateway の `onUsage` コールバック形状を受け取り、AIMonitoringService.recordUsage
+ * に整形して渡す薄いアダプタ。
+ *  - userId は呼び出しコンテキストから DI で解決
+ *  - requestId は factory で発番
+ *  - estimatedCostUsd は provider 別の簡易単価テーブルで算出 (Haiku / gpt-4o-mini 想定)
+ *
+ * 関連要件: Req 19.1, Req 19.8
+ */
+import { randomUUID } from 'node:crypto'
+import type { AIDomain, AIProviderName } from '@/lib/ai-gateway/ai-gateway-types'
+import type { AIMonitoringService } from './ai-monitoring-service'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 単価テーブル (USD per token)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * provider ごとの簡易単価 (USD / 1 token)。
+ * - claude: Haiku 想定 ($0.80 / 1M prompt, $4.00 / 1M completion)
+ * - openai: gpt-4o-mini 想定 ($0.15 / 1M prompt, $0.60 / 1M completion)
+ */
+export const AI_TOKEN_PRICES_USD: Readonly<
+  Record<AIProviderName, { readonly promptPerToken: number; readonly completionPerToken: number }>
+> = {
+  claude: {
+    promptPerToken: 0.8 / 1_000_000,
+    completionPerToken: 4.0 / 1_000_000,
+  },
+  openai: {
+    promptPerToken: 0.15 / 1_000_000,
+    completionPerToken: 0.6 / 1_000_000,
+  },
+}
+
+/** 認証コンテキストがない場合のユーザー ID フォールバック */
+export const UNKNOWN_USER_ID = 'unknown'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 型
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** AIGateway の `onUsage` コールバックが受け取るエントリ形状 */
+export interface GatewayUsageEvent {
+  readonly domain: AIDomain
+  readonly provider: AIProviderName
+  readonly promptTokens: number
+  readonly completionTokens: number
+  readonly cached: boolean
+  /** provider 呼び出しのレイテンシ (ms)。未提供時は 0 として扱う */
+  readonly latencyMs?: number
+}
+
+export interface UsageCallbackOptions {
+  /** 呼び出しコンテキストからユーザー ID を解決する。null を返す場合は 'unknown' 固定 */
+  readonly userIdResolver: () => string | null
+  /** requestId 発番 (既定: randomUUID) */
+  readonly requestIdFactory?: () => string
+  /** 時刻ソース (既定: Date.now 基準の `new Date()`) */
+  readonly clock?: () => Date
+}
+
+export type UsageCallback = (event: GatewayUsageEvent) => Promise<void>
+
+// ─────────────────────────────────────────────────────────────────────────────
+// コスト計算
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function estimateCostUsd(
+  provider: AIProviderName,
+  promptTokens: number,
+  completionTokens: number,
+): number {
+  const price = AI_TOKEN_PRICES_USD[provider]
+  return promptTokens * price.promptPerToken + completionTokens * price.completionPerToken
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Factory
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * AIGateway の `onUsage` として渡せるコールバックを生成する。
+ * recordUsage の失敗は AIGateway 側で握りつぶされる前提 (フェイルオープン)。
+ */
+export function createUsageCallback(
+  service: AIMonitoringService,
+  opts: UsageCallbackOptions,
+): UsageCallback {
+  const requestIdFactory = opts.requestIdFactory ?? (() => randomUUID())
+  const clock = opts.clock ?? (() => new Date())
+
+  return async function handleUsage(event: GatewayUsageEvent): Promise<void> {
+    const resolved = opts.userIdResolver()
+    const userId = resolved && resolved.length > 0 ? resolved : UNKNOWN_USER_ID
+    const latencyMs = event.latencyMs ?? 0
+    const estimatedCostUsd = estimateCostUsd(
+      event.provider,
+      event.promptTokens,
+      event.completionTokens,
+    )
+
+    await service.recordUsage({
+      userId,
+      domain: event.domain,
+      provider: event.provider,
+      promptTokens: event.promptTokens,
+      completionTokens: event.completionTokens,
+      estimatedCostUsd,
+      latencyMs,
+      cacheHit: event.cached,
+      requestId: requestIdFactory(),
+      createdAt: clock(),
+    })
+  }
+}

--- a/src/lib/ai-monitoring/ai-usage-repository.ts
+++ b/src/lib/ai-monitoring/ai-usage-repository.ts
@@ -1,0 +1,107 @@
+/**
+ * AIUsageRepository
+ *
+ * AIUsageEntry / AIUsageFailure の永続化インターフェース。
+ * 本タスクでは InMemory 実装のみ提供。Prisma 実装は DB 整備後に別タスクで追加する。
+ *
+ * 関連要件: Req 19.1, Req 19.6
+ */
+import type { AIUsageEntry, AIUsageFailure, DateRange } from './ai-usage-types'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Interface
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface AIUsageRepository {
+  /** 成功呼び出しを 1 件記録する */
+  create(entry: AIUsageEntry): Promise<void>
+
+  /** 失敗呼び出しを 1 件記録する (Req 19.6) */
+  createFailure(entry: AIUsageFailure): Promise<void>
+
+  /**
+   * 期間内の成功呼び出しを createdAt 昇順で返す。
+   * - range.from: inclusive
+   * - range.to:   exclusive (半開区間)
+   */
+  listByDateRange(range: DateRange): Promise<readonly AIUsageEntry[]>
+
+  /** 指定ユーザーの期間内の成功呼び出しを createdAt 昇順で返す */
+  listByUser(userId: string, range: DateRange): Promise<readonly AIUsageEntry[]>
+
+  /** 期間内の失敗呼び出しを createdAt 昇順で返す */
+  listFailuresByDateRange(range: DateRange): Promise<readonly AIUsageFailure[]>
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 内部ヘルパ
+// ─────────────────────────────────────────────────────────────────────────────
+
+function cloneEntry(entry: AIUsageEntry): AIUsageEntry {
+  return { ...entry, createdAt: new Date(entry.createdAt.getTime()) }
+}
+
+function cloneFailure(entry: AIUsageFailure): AIUsageFailure {
+  return { ...entry, createdAt: new Date(entry.createdAt.getTime()) }
+}
+
+function isWithinRange(createdAt: Date, range: DateRange): boolean {
+  const t = createdAt.getTime()
+  return t >= range.from.getTime() && t < range.to.getTime()
+}
+
+function sortByCreatedAtAsc<T extends { createdAt: Date }>(list: readonly T[]): T[] {
+  return [...list].sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime())
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// InMemory 実装
+// ─────────────────────────────────────────────────────────────────────────────
+
+class InMemoryAIUsageRepository implements AIUsageRepository {
+  private readonly entries: AIUsageEntry[]
+  private readonly failures: AIUsageFailure[]
+
+  constructor(seed?: { entries?: readonly AIUsageEntry[]; failures?: readonly AIUsageFailure[] }) {
+    this.entries = []
+    this.failures = []
+    if (seed?.entries) {
+      for (const e of seed.entries) this.entries.push(cloneEntry(e))
+    }
+    if (seed?.failures) {
+      for (const f of seed.failures) this.failures.push(cloneFailure(f))
+    }
+  }
+
+  async create(entry: AIUsageEntry): Promise<void> {
+    this.entries.push(cloneEntry(entry))
+  }
+
+  async createFailure(entry: AIUsageFailure): Promise<void> {
+    this.failures.push(cloneFailure(entry))
+  }
+
+  async listByDateRange(range: DateRange): Promise<readonly AIUsageEntry[]> {
+    const matched = this.entries.filter((e) => isWithinRange(e.createdAt, range)).map(cloneEntry)
+    return sortByCreatedAtAsc(matched)
+  }
+
+  async listByUser(userId: string, range: DateRange): Promise<readonly AIUsageEntry[]> {
+    const matched = this.entries
+      .filter((e) => e.userId === userId && isWithinRange(e.createdAt, range))
+      .map(cloneEntry)
+    return sortByCreatedAtAsc(matched)
+  }
+
+  async listFailuresByDateRange(range: DateRange): Promise<readonly AIUsageFailure[]> {
+    const matched = this.failures.filter((f) => isWithinRange(f.createdAt, range)).map(cloneFailure)
+    return sortByCreatedAtAsc(matched)
+  }
+}
+
+export function createInMemoryAIUsageRepository(seed?: {
+  entries?: readonly AIUsageEntry[]
+  failures?: readonly AIUsageFailure[]
+}): AIUsageRepository {
+  return new InMemoryAIUsageRepository(seed)
+}

--- a/src/lib/ai-monitoring/ai-usage-types.ts
+++ b/src/lib/ai-monitoring/ai-usage-types.ts
@@ -1,0 +1,131 @@
+/**
+ * AIMonitoring 型定義
+ *
+ * AI 呼び出しのトークン使用量・コスト・失敗記録を集計する型群。
+ * AIUsageRecord (Prisma モデル相当) の in-memory 表現と、集計結果の型を提供する。
+ *
+ * 関連要件: Req 19.1, Req 19.2, Req 19.5, Req 19.6, Req 19.8
+ */
+import { z } from 'zod'
+import { AI_DOMAINS, AI_PROVIDER_NAMES } from '@/lib/ai-gateway/ai-gateway-types'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// AIUsageEntry — 成功した AI 呼び出し 1 件の記録 (Req 19.1, 19.8)
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const aiUsageEntrySchema = z.object({
+  /** 呼び出し元ユーザー ID。認証コンテキストがない場合は 'unknown' で埋める */
+  userId: z.string().min(1),
+  /** 機能ドメイン ('ai-coach' | 'feedback') */
+  domain: z.enum(AI_DOMAINS),
+  /** 実際に呼び出されたプロバイダ */
+  provider: z.enum(AI_PROVIDER_NAMES),
+  /** 入力トークン数 (プロンプト全体) */
+  promptTokens: z.number().int().min(0),
+  /** 出力トークン数 */
+  completionTokens: z.number().int().min(0),
+  /** 推定コスト (USD, 単価 × トークン数) */
+  estimatedCostUsd: z.number().min(0),
+  /** プロバイダ呼び出しレイテンシ (ms)。キャッシュヒット時は 0 を許容 */
+  latencyMs: z.number().int().min(0),
+  /** キャッシュヒットだったか (Req 19.8) */
+  cacheHit: z.boolean(),
+  /** リクエストトレース ID */
+  requestId: z.string().min(1),
+  /** 発生時刻 */
+  createdAt: z.date(),
+})
+
+export type AIUsageEntry = z.infer<typeof aiUsageEntrySchema>
+
+// ─────────────────────────────────────────────────────────────────────────────
+// AIUsageFailure — 失敗した AI 呼び出し 1 件の記録 (Req 19.6)
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const AI_USAGE_ERROR_CATEGORIES = ['TIMEOUT', 'PROVIDER_ERROR', 'INVALID_OUTPUT'] as const
+export type AIUsageErrorCategory = (typeof AI_USAGE_ERROR_CATEGORIES)[number]
+
+export const aiUsageFailureSchema = z.object({
+  userId: z.string().min(1),
+  domain: z.enum(AI_DOMAINS),
+  provider: z.enum(AI_PROVIDER_NAMES),
+  /** 何回目の試行で失敗したか (1 から始まる) */
+  attemptCount: z.number().int().min(1),
+  errorCategory: z.enum(AI_USAGE_ERROR_CATEGORIES),
+  latencyMs: z.number().int().min(0),
+  requestId: z.string().min(1),
+  createdAt: z.date(),
+})
+
+export type AIUsageFailure = z.infer<typeof aiUsageFailureSchema>
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 集計用共通型
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface DateRange {
+  readonly from: Date
+  readonly to: Date
+}
+
+/** 月次コストサマリ (yearMonth: 'YYYY-MM') */
+export interface MonthlyCostSummary {
+  readonly yearMonth: string
+  readonly totalCostUsd: number
+  readonly totalRequests: number
+  readonly byProvider: Readonly<Record<string, number>>
+  readonly byDomain: Readonly<Record<string, number>>
+  readonly byDay: readonly {
+    readonly date: string
+    readonly costUsd: number
+    readonly requests: number
+  }[]
+}
+
+/** ユーザー単位の使用量サマリ */
+export interface UserUsageSummary {
+  readonly userId: string
+  readonly period: DateRange
+  readonly totalCostUsd: number
+  readonly totalRequests: number
+  readonly totalPromptTokens: number
+  readonly totalCompletionTokens: number
+  /** 0.0 - 1.0。リクエスト 0 件のときは 0 */
+  readonly cacheHitRate: number
+}
+
+/** 異常利用フラグ (Req 19.5: 通常の 5 倍超過) */
+export interface AnomalyFlag {
+  readonly userId: string
+  readonly yearMonth: string
+  readonly currentCostUsd: number
+  readonly baselineCostUsd: number
+  /** currentCost / baseline。baseline が 0 の場合は検出対象外 */
+  readonly multiplier: number
+  readonly detectedAt: Date
+}
+
+/** 失敗率サマリ (Req 19.6) */
+export interface FailureRateSummary {
+  readonly period: DateRange
+  readonly totalAttempts: number
+  readonly failureCount: number
+  /** failureCount / totalAttempts。attempts 0 のときは 0 */
+  readonly failureRate: number
+  readonly byErrorCategory: Readonly<Record<string, number>>
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 独自例外
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** yearMonth が 'YYYY-MM' 形式でないとき */
+export class InvalidYearMonthError extends Error {
+  public readonly input: string
+
+  constructor(input: string) {
+    super(`Invalid yearMonth format: "${input}" (expected 'YYYY-MM')`)
+    this.name = 'InvalidYearMonthError'
+    this.input = input
+  }
+}

--- a/src/tests/ai-monitoring/ai-monitoring-service.test.ts
+++ b/src/tests/ai-monitoring/ai-monitoring-service.test.ts
@@ -1,0 +1,352 @@
+import { describe, it, expect } from 'vitest'
+import { createAIMonitoringService } from '@/lib/ai-monitoring/ai-monitoring-service'
+import { createInMemoryAIUsageRepository } from '@/lib/ai-monitoring/ai-usage-repository'
+import {
+  InvalidYearMonthError,
+  type AIUsageEntry,
+  type AIUsageFailure,
+} from '@/lib/ai-monitoring/ai-usage-types'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// フィクスチャ
+// ─────────────────────────────────────────────────────────────────────────────
+
+function makeEntry(overrides: Partial<AIUsageEntry> = {}): AIUsageEntry {
+  return {
+    userId: overrides.userId ?? 'user-1',
+    domain: overrides.domain ?? 'ai-coach',
+    provider: overrides.provider ?? 'claude',
+    promptTokens: overrides.promptTokens ?? 100,
+    completionTokens: overrides.completionTokens ?? 50,
+    estimatedCostUsd: overrides.estimatedCostUsd ?? 0.001,
+    latencyMs: overrides.latencyMs ?? 200,
+    cacheHit: overrides.cacheHit ?? false,
+    requestId: overrides.requestId ?? 'req-1',
+    createdAt: overrides.createdAt ?? new Date('2026-04-17T10:00:00Z'),
+  }
+}
+
+function makeFailure(overrides: Partial<AIUsageFailure> = {}): AIUsageFailure {
+  return {
+    userId: overrides.userId ?? 'user-1',
+    domain: overrides.domain ?? 'ai-coach',
+    provider: overrides.provider ?? 'claude',
+    attemptCount: overrides.attemptCount ?? 1,
+    errorCategory: overrides.errorCategory ?? 'TIMEOUT',
+    latencyMs: overrides.latencyMs ?? 5000,
+    requestId: overrides.requestId ?? 'fail-1',
+    createdAt: overrides.createdAt ?? new Date('2026-04-17T10:00:00Z'),
+  }
+}
+
+const APRIL_2026 = '2026-04'
+const APRIL_2026_RANGE = {
+  from: new Date('2026-04-01T00:00:00Z'),
+  to: new Date('2026-05-01T00:00:00Z'),
+}
+
+const FIXED_NOW = new Date('2026-04-17T12:00:00Z')
+const fixedClock = () => FIXED_NOW
+
+// ─────────────────────────────────────────────────────────────────────────────
+// recordUsage / recordFailure
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('AIMonitoringService.recordUsage()', () => {
+  it('validates and persists a valid entry', async () => {
+    const repo = createInMemoryAIUsageRepository()
+    const service = createAIMonitoringService({ repository: repo, clock: fixedClock })
+    await service.recordUsage(makeEntry({ requestId: 'record-1' }))
+
+    const stored = await repo.listByDateRange(APRIL_2026_RANGE)
+    expect(stored).toHaveLength(1)
+    expect(stored[0]?.requestId).toBe('record-1')
+  })
+
+  it('rejects invalid entries via Zod (negative tokens)', async () => {
+    const repo = createInMemoryAIUsageRepository()
+    const service = createAIMonitoringService({ repository: repo, clock: fixedClock })
+    await expect(service.recordUsage(makeEntry({ promptTokens: -1 }))).rejects.toThrow()
+  })
+})
+
+describe('AIMonitoringService.recordFailure()', () => {
+  it('validates and persists a valid failure', async () => {
+    const repo = createInMemoryAIUsageRepository()
+    const service = createAIMonitoringService({ repository: repo, clock: fixedClock })
+    await service.recordFailure(makeFailure({ requestId: 'fail-a' }))
+
+    const stored = await repo.listFailuresByDateRange(APRIL_2026_RANGE)
+    expect(stored).toHaveLength(1)
+    expect(stored[0]?.requestId).toBe('fail-a')
+  })
+
+  it('rejects invalid failures via Zod (attemptCount=0)', async () => {
+    const repo = createInMemoryAIUsageRepository()
+    const service = createAIMonitoringService({ repository: repo, clock: fixedClock })
+    await expect(service.recordFailure(makeFailure({ attemptCount: 0 }))).rejects.toThrow()
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// getMonthlyCost
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('AIMonitoringService.getMonthlyCost()', () => {
+  it('aggregates total/byProvider/byDomain/byDay correctly', async () => {
+    const repo = createInMemoryAIUsageRepository({
+      entries: [
+        makeEntry({
+          provider: 'claude',
+          domain: 'ai-coach',
+          estimatedCostUsd: 0.5,
+          createdAt: new Date('2026-04-01T09:00:00Z'),
+        }),
+        makeEntry({
+          provider: 'claude',
+          domain: 'feedback',
+          estimatedCostUsd: 0.2,
+          createdAt: new Date('2026-04-01T10:00:00Z'),
+        }),
+        makeEntry({
+          provider: 'openai',
+          domain: 'ai-coach',
+          estimatedCostUsd: 0.3,
+          createdAt: new Date('2026-04-15T00:00:00Z'),
+        }),
+        // out of month
+        makeEntry({
+          provider: 'claude',
+          estimatedCostUsd: 100,
+          createdAt: new Date('2026-05-01T00:00:00Z'),
+        }),
+      ],
+    })
+    const service = createAIMonitoringService({ repository: repo, clock: fixedClock })
+    const summary = await service.getMonthlyCost(APRIL_2026)
+
+    expect(summary.yearMonth).toBe(APRIL_2026)
+    expect(summary.totalRequests).toBe(3)
+    expect(summary.totalCostUsd).toBeCloseTo(1.0, 10)
+    expect(summary.byProvider).toEqual({ claude: 0.7, openai: 0.3 })
+    expect(summary.byDomain).toEqual({ 'ai-coach': 0.8, feedback: 0.2 })
+    expect(summary.byDay).toEqual([
+      { date: '2026-04-01', costUsd: 0.7, requests: 2 },
+      { date: '2026-04-15', costUsd: 0.3, requests: 1 },
+    ])
+  })
+
+  it('returns zeros when no entries exist', async () => {
+    const service = createAIMonitoringService({
+      repository: createInMemoryAIUsageRepository(),
+      clock: fixedClock,
+    })
+    const summary = await service.getMonthlyCost(APRIL_2026)
+    expect(summary.totalCostUsd).toBe(0)
+    expect(summary.totalRequests).toBe(0)
+    expect(summary.byDay).toEqual([])
+  })
+
+  it('throws InvalidYearMonthError for malformed yearMonth', async () => {
+    const service = createAIMonitoringService({
+      repository: createInMemoryAIUsageRepository(),
+      clock: fixedClock,
+    })
+    await expect(service.getMonthlyCost('2026/04')).rejects.toBeInstanceOf(InvalidYearMonthError)
+    await expect(service.getMonthlyCost('2026-13')).rejects.toBeInstanceOf(InvalidYearMonthError)
+    await expect(service.getMonthlyCost('2026-00')).rejects.toBeInstanceOf(InvalidYearMonthError)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// getUserUsage
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('AIMonitoringService.getUserUsage()', () => {
+  it('aggregates cost, tokens, and cacheHitRate for the user', async () => {
+    const repo = createInMemoryAIUsageRepository({
+      entries: [
+        makeEntry({
+          userId: 'user-1',
+          promptTokens: 100,
+          completionTokens: 50,
+          estimatedCostUsd: 0.1,
+          cacheHit: true,
+        }),
+        makeEntry({
+          userId: 'user-1',
+          promptTokens: 200,
+          completionTokens: 80,
+          estimatedCostUsd: 0.2,
+          cacheHit: false,
+        }),
+        // other user
+        makeEntry({ userId: 'user-2', estimatedCostUsd: 9 }),
+      ],
+    })
+    const service = createAIMonitoringService({ repository: repo, clock: fixedClock })
+    const summary = await service.getUserUsage('user-1', APRIL_2026_RANGE)
+
+    expect(summary.userId).toBe('user-1')
+    expect(summary.totalRequests).toBe(2)
+    expect(summary.totalPromptTokens).toBe(300)
+    expect(summary.totalCompletionTokens).toBe(130)
+    expect(summary.totalCostUsd).toBeCloseTo(0.3, 10)
+    expect(summary.cacheHitRate).toBeCloseTo(0.5, 10)
+  })
+
+  it('returns cacheHitRate=0 when user has no entries', async () => {
+    const service = createAIMonitoringService({
+      repository: createInMemoryAIUsageRepository(),
+      clock: fixedClock,
+    })
+    const summary = await service.getUserUsage('ghost', APRIL_2026_RANGE)
+    expect(summary.totalRequests).toBe(0)
+    expect(summary.cacheHitRate).toBe(0)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// getFailureRate
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('AIMonitoringService.getFailureRate()', () => {
+  it('computes failures / (failures + successes)', async () => {
+    const repo = createInMemoryAIUsageRepository({
+      entries: [
+        makeEntry({ requestId: 's1' }),
+        makeEntry({ requestId: 's2' }),
+        makeEntry({ requestId: 's3' }),
+      ],
+      failures: [
+        makeFailure({ errorCategory: 'TIMEOUT', requestId: 'f1' }),
+        makeFailure({ errorCategory: 'PROVIDER_ERROR', requestId: 'f2' }),
+      ],
+    })
+    const service = createAIMonitoringService({ repository: repo, clock: fixedClock })
+    const summary = await service.getFailureRate(APRIL_2026_RANGE)
+
+    expect(summary.totalAttempts).toBe(5)
+    expect(summary.failureCount).toBe(2)
+    expect(summary.failureRate).toBeCloseTo(0.4, 10)
+    expect(summary.byErrorCategory).toEqual({ TIMEOUT: 1, PROVIDER_ERROR: 1 })
+  })
+
+  it('returns zero rate when no attempts', async () => {
+    const service = createAIMonitoringService({
+      repository: createInMemoryAIUsageRepository(),
+      clock: fixedClock,
+    })
+    const summary = await service.getFailureRate(APRIL_2026_RANGE)
+    expect(summary.totalAttempts).toBe(0)
+    expect(summary.failureRate).toBe(0)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// detectAnomaly (Req 19.5)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('AIMonitoringService.detectAnomaly()', () => {
+  it('flags users whose current cost exceeds 5x the last-3-months average', async () => {
+    const baselineDates = [
+      new Date('2026-01-15T00:00:00Z'),
+      new Date('2026-02-15T00:00:00Z'),
+      new Date('2026-03-15T00:00:00Z'),
+    ]
+    const repo = createInMemoryAIUsageRepository({
+      entries: [
+        // baseline: user-heavy に 3 ヶ月それぞれ 1 USD (平均 1 USD)
+        ...baselineDates.map((d) =>
+          makeEntry({ userId: 'user-heavy', estimatedCostUsd: 1, createdAt: d }),
+        ),
+        // 対象月: user-heavy は 10 USD → 10x で検出
+        makeEntry({
+          userId: 'user-heavy',
+          estimatedCostUsd: 10,
+          createdAt: new Date('2026-04-05T00:00:00Z'),
+        }),
+        // 普通ユーザー: 2 USD → 2x なので検出されない (非anomaly)
+        ...baselineDates.map((d) =>
+          makeEntry({ userId: 'user-normal', estimatedCostUsd: 1, createdAt: d }),
+        ),
+        makeEntry({
+          userId: 'user-normal',
+          estimatedCostUsd: 2,
+          createdAt: new Date('2026-04-05T00:00:00Z'),
+        }),
+      ],
+    })
+    const service = createAIMonitoringService({ repository: repo, clock: fixedClock })
+
+    const flags = await service.detectAnomaly(APRIL_2026)
+    expect(flags).toHaveLength(1)
+    const flag = flags[0]!
+    expect(flag.userId).toBe('user-heavy')
+    expect(flag.yearMonth).toBe(APRIL_2026)
+    expect(flag.currentCostUsd).toBeCloseTo(10, 10)
+    expect(flag.baselineCostUsd).toBeCloseTo(1, 10)
+    expect(flag.multiplier).toBeCloseTo(10, 10)
+    expect(flag.detectedAt.getTime()).toBe(FIXED_NOW.getTime())
+  })
+
+  it('skips users whose baseline average is zero (no prior usage)', async () => {
+    const repo = createInMemoryAIUsageRepository({
+      entries: [
+        // baseline なし、当月いきなり高額
+        makeEntry({
+          userId: 'new-user',
+          estimatedCostUsd: 100,
+          createdAt: new Date('2026-04-05T00:00:00Z'),
+        }),
+      ],
+    })
+    const service = createAIMonitoringService({ repository: repo, clock: fixedClock })
+
+    const flags = await service.detectAnomaly(APRIL_2026)
+    expect(flags).toHaveLength(0)
+  })
+
+  it('skips users whose current cost is below the noise threshold', async () => {
+    const baselineDates = [
+      new Date('2026-01-15T00:00:00Z'),
+      new Date('2026-02-15T00:00:00Z'),
+      new Date('2026-03-15T00:00:00Z'),
+    ]
+    const repo = createInMemoryAIUsageRepository({
+      entries: [
+        // baseline 極小 (合計 0.03 USD → 平均 0.01 USD)
+        ...baselineDates.map((d) =>
+          makeEntry({ userId: 'tiny-user', estimatedCostUsd: 0.01, createdAt: d }),
+        ),
+        // 当月 0.5 USD → 50x ではあるがノイズ閾値未満 (1 USD 未満) で除外
+        makeEntry({
+          userId: 'tiny-user',
+          estimatedCostUsd: 0.5,
+          createdAt: new Date('2026-04-05T00:00:00Z'),
+        }),
+      ],
+    })
+    const service = createAIMonitoringService({ repository: repo, clock: fixedClock })
+
+    const flags = await service.detectAnomaly(APRIL_2026)
+    expect(flags).toHaveLength(0)
+  })
+
+  it('throws InvalidYearMonthError for malformed yearMonth', async () => {
+    const service = createAIMonitoringService({
+      repository: createInMemoryAIUsageRepository(),
+      clock: fixedClock,
+    })
+    await expect(service.detectAnomaly('not-a-date')).rejects.toBeInstanceOf(InvalidYearMonthError)
+  })
+
+  it('uses the default clock when not provided', async () => {
+    // clock を省略しても例外なく動作することを確認
+    const service = createAIMonitoringService({
+      repository: createInMemoryAIUsageRepository(),
+    })
+    const flags = await service.detectAnomaly(APRIL_2026)
+    expect(flags).toEqual([])
+  })
+})

--- a/src/tests/ai-monitoring/ai-usage-recorder.test.ts
+++ b/src/tests/ai-monitoring/ai-usage-recorder.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect, vi } from 'vitest'
+import {
+  createUsageCallback,
+  estimateCostUsd,
+  UNKNOWN_USER_ID,
+  AI_TOKEN_PRICES_USD,
+} from '@/lib/ai-monitoring/ai-usage-recorder'
+import type { AIMonitoringService } from '@/lib/ai-monitoring/ai-monitoring-service'
+import type { AIUsageEntry } from '@/lib/ai-monitoring/ai-usage-types'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// モック
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface RecordedCall {
+  readonly entry: AIUsageEntry
+}
+
+function createMockService(): {
+  service: AIMonitoringService
+  calls: readonly RecordedCall[]
+} {
+  const calls: RecordedCall[] = []
+  const service: AIMonitoringService = {
+    async recordUsage(entry) {
+      calls.push({ entry: { ...entry } })
+    },
+    async recordFailure() {
+      // not used in these tests
+    },
+    async getMonthlyCost() {
+      throw new Error('not used')
+    },
+    async getUserUsage() {
+      throw new Error('not used')
+    },
+    async getFailureRate() {
+      throw new Error('not used')
+    },
+    async detectAnomaly() {
+      return []
+    },
+  }
+  return { service, calls }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// estimateCostUsd
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('estimateCostUsd', () => {
+  it('matches claude pricing ($0.80/1M prompt, $4.00/1M completion)', () => {
+    // 1M prompt tokens only
+    expect(estimateCostUsd('claude', 1_000_000, 0)).toBeCloseTo(0.8, 10)
+    // 1M completion tokens only
+    expect(estimateCostUsd('claude', 0, 1_000_000)).toBeCloseTo(4.0, 10)
+    // mixed
+    expect(estimateCostUsd('claude', 500_000, 250_000)).toBeCloseTo(0.4 + 1.0, 10)
+  })
+
+  it('matches openai pricing ($0.15/1M prompt, $0.60/1M completion)', () => {
+    expect(estimateCostUsd('openai', 1_000_000, 0)).toBeCloseTo(0.15, 10)
+    expect(estimateCostUsd('openai', 0, 1_000_000)).toBeCloseTo(0.6, 10)
+    expect(estimateCostUsd('openai', 2_000_000, 500_000)).toBeCloseTo(0.3 + 0.3, 10)
+  })
+
+  it('returns 0 when both token counts are 0', () => {
+    expect(estimateCostUsd('claude', 0, 0)).toBe(0)
+    expect(estimateCostUsd('openai', 0, 0)).toBe(0)
+  })
+
+  it('exposes immutable price table', () => {
+    expect(AI_TOKEN_PRICES_USD.claude.promptPerToken).toBeCloseTo(0.8 / 1_000_000, 15)
+    expect(AI_TOKEN_PRICES_USD.openai.completionPerToken).toBeCloseTo(0.6 / 1_000_000, 15)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// createUsageCallback
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('createUsageCallback', () => {
+  const FIXED_NOW = new Date('2026-04-17T12:00:00Z')
+
+  it('forwards gateway event to recordUsage with computed cost and context metadata', async () => {
+    const { service, calls } = createMockService()
+    const callback = createUsageCallback(service, {
+      userIdResolver: () => 'user-42',
+      requestIdFactory: () => 'req-fixed',
+      clock: () => FIXED_NOW,
+    })
+
+    await callback({
+      domain: 'ai-coach',
+      provider: 'claude',
+      promptTokens: 1_000_000,
+      completionTokens: 500_000,
+      cached: false,
+      latencyMs: 250,
+    })
+
+    expect(calls).toHaveLength(1)
+    const entry = calls[0]!.entry
+    expect(entry.userId).toBe('user-42')
+    expect(entry.domain).toBe('ai-coach')
+    expect(entry.provider).toBe('claude')
+    expect(entry.promptTokens).toBe(1_000_000)
+    expect(entry.completionTokens).toBe(500_000)
+    // claude: 1M prompt $0.8 + 0.5M completion $2 = $2.8
+    expect(entry.estimatedCostUsd).toBeCloseTo(2.8, 10)
+    expect(entry.latencyMs).toBe(250)
+    expect(entry.cacheHit).toBe(false)
+    expect(entry.requestId).toBe('req-fixed')
+    expect(entry.createdAt.getTime()).toBe(FIXED_NOW.getTime())
+  })
+
+  it("falls back to 'unknown' userId when resolver returns null", async () => {
+    const { service, calls } = createMockService()
+    const callback = createUsageCallback(service, {
+      userIdResolver: () => null,
+      requestIdFactory: () => 'req-1',
+      clock: () => FIXED_NOW,
+    })
+
+    await callback({
+      domain: 'feedback',
+      provider: 'openai',
+      promptTokens: 0,
+      completionTokens: 0,
+      cached: true,
+    })
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0]!.entry.userId).toBe(UNKNOWN_USER_ID)
+    expect(calls[0]!.entry.cacheHit).toBe(true)
+    // latencyMs undefined → 0 に正規化される
+    expect(calls[0]!.entry.latencyMs).toBe(0)
+    // token 0 → cost 0
+    expect(calls[0]!.entry.estimatedCostUsd).toBe(0)
+  })
+
+  it("falls back to 'unknown' when resolver returns empty string", async () => {
+    const { service, calls } = createMockService()
+    const callback = createUsageCallback(service, {
+      userIdResolver: () => '',
+      requestIdFactory: () => 'req-2',
+      clock: () => FIXED_NOW,
+    })
+
+    await callback({
+      domain: 'ai-coach',
+      provider: 'claude',
+      promptTokens: 10,
+      completionTokens: 5,
+      cached: false,
+    })
+
+    expect(calls[0]!.entry.userId).toBe(UNKNOWN_USER_ID)
+  })
+
+  it('uses default requestIdFactory and clock when not provided', async () => {
+    const { service, calls } = createMockService()
+    const callback = createUsageCallback(service, {
+      userIdResolver: () => 'user-x',
+    })
+
+    const before = Date.now()
+    await callback({
+      domain: 'ai-coach',
+      provider: 'openai',
+      promptTokens: 10,
+      completionTokens: 10,
+      cached: false,
+    })
+    const after = Date.now()
+
+    expect(calls).toHaveLength(1)
+    const entry = calls[0]!.entry
+    expect(typeof entry.requestId).toBe('string')
+    expect(entry.requestId.length).toBeGreaterThan(0)
+    expect(entry.createdAt.getTime()).toBeGreaterThanOrEqual(before)
+    expect(entry.createdAt.getTime()).toBeLessThanOrEqual(after)
+  })
+
+  it('propagates recordUsage rejection to caller', async () => {
+    const service: AIMonitoringService = {
+      recordUsage: vi.fn().mockRejectedValue(new Error('boom')),
+      recordFailure: vi.fn(),
+      getMonthlyCost: vi.fn(),
+      getUserUsage: vi.fn(),
+      getFailureRate: vi.fn(),
+      detectAnomaly: vi.fn(),
+    }
+    const callback = createUsageCallback(service, {
+      userIdResolver: () => 'user-y',
+    })
+
+    await expect(
+      callback({
+        domain: 'ai-coach',
+        provider: 'claude',
+        promptTokens: 1,
+        completionTokens: 1,
+        cached: false,
+      }),
+    ).rejects.toThrow('boom')
+  })
+})

--- a/src/tests/ai-monitoring/ai-usage-repository.test.ts
+++ b/src/tests/ai-monitoring/ai-usage-repository.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from 'vitest'
+import { createInMemoryAIUsageRepository } from '@/lib/ai-monitoring/ai-usage-repository'
+import type { AIUsageEntry, AIUsageFailure, DateRange } from '@/lib/ai-monitoring/ai-usage-types'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// フィクスチャ
+// ─────────────────────────────────────────────────────────────────────────────
+
+function makeEntry(overrides: Partial<AIUsageEntry> = {}): AIUsageEntry {
+  return {
+    userId: overrides.userId ?? 'user-1',
+    domain: overrides.domain ?? 'ai-coach',
+    provider: overrides.provider ?? 'claude',
+    promptTokens: overrides.promptTokens ?? 100,
+    completionTokens: overrides.completionTokens ?? 50,
+    estimatedCostUsd: overrides.estimatedCostUsd ?? 0.001,
+    latencyMs: overrides.latencyMs ?? 200,
+    cacheHit: overrides.cacheHit ?? false,
+    requestId: overrides.requestId ?? 'req-1',
+    createdAt: overrides.createdAt ?? new Date('2026-04-17T10:00:00Z'),
+  }
+}
+
+function makeFailure(overrides: Partial<AIUsageFailure> = {}): AIUsageFailure {
+  return {
+    userId: overrides.userId ?? 'user-1',
+    domain: overrides.domain ?? 'ai-coach',
+    provider: overrides.provider ?? 'claude',
+    attemptCount: overrides.attemptCount ?? 1,
+    errorCategory: overrides.errorCategory ?? 'TIMEOUT',
+    latencyMs: overrides.latencyMs ?? 5000,
+    requestId: overrides.requestId ?? 'fail-req',
+    createdAt: overrides.createdAt ?? new Date('2026-04-17T10:00:00Z'),
+  }
+}
+
+const APRIL_2026: DateRange = {
+  from: new Date('2026-04-01T00:00:00Z'),
+  to: new Date('2026-05-01T00:00:00Z'),
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// create / listByDateRange
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('InMemoryAIUsageRepository', () => {
+  describe('create()', () => {
+    it('persists an entry that is returned by listByDateRange', async () => {
+      const repo = createInMemoryAIUsageRepository()
+      await repo.create(makeEntry({ requestId: 'new-1' }))
+      const result = await repo.listByDateRange(APRIL_2026)
+      expect(result).toHaveLength(1)
+      expect(result[0]?.requestId).toBe('new-1')
+    })
+
+    it('defensively clones input so outside mutation does not leak', async () => {
+      const repo = createInMemoryAIUsageRepository()
+      const entry = makeEntry({ promptTokens: 10 })
+      await repo.create(entry)
+      // 外部で変更しても保存済みデータに影響しない
+      ;(entry as { promptTokens: number }).promptTokens = 999
+      const result = await repo.listByDateRange(APRIL_2026)
+      expect(result[0]?.promptTokens).toBe(10)
+    })
+  })
+
+  describe('createFailure()', () => {
+    it('persists a failure', async () => {
+      const repo = createInMemoryAIUsageRepository()
+      await repo.createFailure(makeFailure({ requestId: 'fail-new' }))
+      const result = await repo.listFailuresByDateRange(APRIL_2026)
+      expect(result).toHaveLength(1)
+      expect(result[0]?.requestId).toBe('fail-new')
+    })
+  })
+
+  describe('seed behavior', () => {
+    it('defensively clones seed entries and failures', async () => {
+      const seedEntry = makeEntry({ promptTokens: 5 })
+      const seedFailure = makeFailure({ attemptCount: 2 })
+      const repo = createInMemoryAIUsageRepository({
+        entries: [seedEntry],
+        failures: [seedFailure],
+      })
+      ;(seedEntry as { promptTokens: number }).promptTokens = 9999
+      ;(seedFailure as { attemptCount: number }).attemptCount = 9999
+
+      const entries = await repo.listByDateRange(APRIL_2026)
+      const failures = await repo.listFailuresByDateRange(APRIL_2026)
+      expect(entries[0]?.promptTokens).toBe(5)
+      expect(failures[0]?.attemptCount).toBe(2)
+    })
+  })
+
+  describe('listByDateRange()', () => {
+    it('filters entries within [from, to) and sorts by createdAt asc', async () => {
+      const repo = createInMemoryAIUsageRepository({
+        entries: [
+          makeEntry({ requestId: 'march', createdAt: new Date('2026-03-31T23:59:59Z') }),
+          makeEntry({ requestId: 'mid', createdAt: new Date('2026-04-15T00:00:00Z') }),
+          makeEntry({ requestId: 'first', createdAt: new Date('2026-04-01T00:00:00Z') }),
+          makeEntry({ requestId: 'may', createdAt: new Date('2026-05-01T00:00:00Z') }),
+        ],
+      })
+      const result = await repo.listByDateRange(APRIL_2026)
+      expect(result.map((e) => e.requestId)).toEqual(['first', 'mid'])
+    })
+
+    it('returns empty when nothing matches', async () => {
+      const repo = createInMemoryAIUsageRepository({
+        entries: [makeEntry({ createdAt: new Date('2026-01-01T00:00:00Z') })],
+      })
+      const result = await repo.listByDateRange(APRIL_2026)
+      expect(result).toEqual([])
+    })
+  })
+
+  describe('listByUser()', () => {
+    it('returns only the specified user entries within range', async () => {
+      const repo = createInMemoryAIUsageRepository({
+        entries: [
+          makeEntry({ userId: 'user-1', requestId: 'a' }),
+          makeEntry({ userId: 'user-2', requestId: 'b' }),
+          makeEntry({ userId: 'user-1', requestId: 'c' }),
+        ],
+      })
+      const result = await repo.listByUser('user-1', APRIL_2026)
+      expect(result.map((e) => e.requestId)).toEqual(['a', 'c'])
+    })
+  })
+
+  describe('listFailuresByDateRange()', () => {
+    it('filters and sorts failures', async () => {
+      const repo = createInMemoryAIUsageRepository({
+        failures: [
+          makeFailure({ requestId: 'f2', createdAt: new Date('2026-04-15T10:00:00Z') }),
+          makeFailure({ requestId: 'f1', createdAt: new Date('2026-04-01T00:00:00Z') }),
+          makeFailure({ requestId: 'fout', createdAt: new Date('2026-03-01T00:00:00Z') }),
+        ],
+      })
+      const result = await repo.listFailuresByDateRange(APRIL_2026)
+      expect(result.map((f) => f.requestId)).toEqual(['f1', 'f2'])
+    })
+  })
+})

--- a/src/tests/ai-monitoring/ai-usage-types.test.ts
+++ b/src/tests/ai-monitoring/ai-usage-types.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest'
+import {
+  aiUsageEntrySchema,
+  aiUsageFailureSchema,
+  AI_USAGE_ERROR_CATEGORIES,
+  InvalidYearMonthError,
+} from '@/lib/ai-monitoring/ai-usage-types'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// aiUsageEntrySchema
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('aiUsageEntrySchema', () => {
+  const base = {
+    userId: 'user-1',
+    domain: 'ai-coach' as const,
+    provider: 'claude' as const,
+    promptTokens: 100,
+    completionTokens: 50,
+    estimatedCostUsd: 0.0012,
+    latencyMs: 300,
+    cacheHit: false,
+    requestId: 'req-1',
+    createdAt: new Date('2026-04-17T00:00:00Z'),
+  }
+
+  it('accepts a valid entry', () => {
+    const result = aiUsageEntrySchema.safeParse(base)
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts cacheHit=true with 0 latency', () => {
+    const result = aiUsageEntrySchema.safeParse({ ...base, cacheHit: true, latencyMs: 0 })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects empty userId', () => {
+    const result = aiUsageEntrySchema.safeParse({ ...base, userId: '' })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects negative tokens', () => {
+    const result = aiUsageEntrySchema.safeParse({ ...base, promptTokens: -1 })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects negative cost', () => {
+    const result = aiUsageEntrySchema.safeParse({ ...base, estimatedCostUsd: -0.01 })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects non-integer tokens', () => {
+    const result = aiUsageEntrySchema.safeParse({ ...base, completionTokens: 1.5 })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects unknown domain', () => {
+    const result = aiUsageEntrySchema.safeParse({ ...base, domain: 'unknown' })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects unknown provider', () => {
+    const result = aiUsageEntrySchema.safeParse({ ...base, provider: 'gemini' })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects empty requestId', () => {
+    const result = aiUsageEntrySchema.safeParse({ ...base, requestId: '' })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects non-Date createdAt', () => {
+    const result = aiUsageEntrySchema.safeParse({ ...base, createdAt: '2026-04-17' })
+    expect(result.success).toBe(false)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// aiUsageFailureSchema
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('aiUsageFailureSchema', () => {
+  const base = {
+    userId: 'user-1',
+    domain: 'feedback' as const,
+    provider: 'openai' as const,
+    attemptCount: 2,
+    errorCategory: 'TIMEOUT' as const,
+    latencyMs: 5000,
+    requestId: 'req-2',
+    createdAt: new Date('2026-04-17T12:00:00Z'),
+  }
+
+  it('accepts a valid failure', () => {
+    const result = aiUsageFailureSchema.safeParse(base)
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects attemptCount = 0', () => {
+    const result = aiUsageFailureSchema.safeParse({ ...base, attemptCount: 0 })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects unknown errorCategory', () => {
+    const result = aiUsageFailureSchema.safeParse({ ...base, errorCategory: 'SOMETHING' })
+    expect(result.success).toBe(false)
+  })
+
+  it('accepts all defined error categories', () => {
+    for (const category of AI_USAGE_ERROR_CATEGORIES) {
+      const result = aiUsageFailureSchema.safeParse({ ...base, errorCategory: category })
+      expect(result.success).toBe(true)
+    }
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// InvalidYearMonthError
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('InvalidYearMonthError', () => {
+  it('sets name and input', () => {
+    const err = new InvalidYearMonthError('2026/04')
+    expect(err.name).toBe('InvalidYearMonthError')
+    expect(err.input).toBe('2026/04')
+    expect(err.message).toContain('2026/04')
+    expect(err).toBeInstanceOf(Error)
+  })
+})


### PR DESCRIPTION
Closes #16

## 概要

Task 5.2 として、AI 呼び出しの使用量記録・月次/週次/日次集計・ユーザー別異常検知を行う `AIMonitoringService` を実装しました。Prisma 実装は DB 整備後の別タスクに委譲し、本 PR では InMemory リポジトリとサービス層・AIGateway 接続アダプタを提供します。

## 実装内容

### 新規ファイル (src/lib/ai-monitoring/)
- `ai-usage-types.ts` — `AIUsageEntry` / `AIUsageFailure` の Zod スキーマ、集計結果型 (MonthlyCostSummary / UserUsageSummary / AnomalyFlag / FailureRateSummary)、`InvalidYearMonthError`
- `ai-usage-repository.ts` — `AIUsageRepository` interface + `createInMemoryAIUsageRepository` (防御的コピーで不変性を担保)
- `ai-monitoring-service.ts` — 6 メソッド (recordUsage / recordFailure / getMonthlyCost / getUserUsage / getFailureRate / detectAnomaly) を公開
- `ai-usage-recorder.ts` — AIGateway `onUsage` コールバック形状を `recordUsage` に橋渡しする薄いアダプタ。provider 別単価テーブルで `estimatedCostUsd` を算出

### 新規テスト (src/tests/ai-monitoring/)
- `ai-usage-types.test.ts` — 15 tests (Zod 正常/異常系、例外)
- `ai-usage-repository.test.ts` — 8 tests (CRUD + [from, to) フィルタ + 防御コピー)
- `ai-monitoring-service.test.ts` — 16 tests (全 6 メソッド + 異常検知 3 シナリオ + yearMonth バリデーション)
- `ai-usage-recorder.test.ts` — 9 tests (コスト計算 / userId フォールバック / デフォルト clock / エラー伝搬)

## 要件マッピング

| 要件 | 実装 |
|------|------|
| Req 19.1 | `recordUsage` が userId・domain・provider・promptTokens・completionTokens・estimatedCostUsd を記録 |
| Req 19.2 | `getMonthlyCost` (月次 + byDay/byProvider/byDomain)、`getUserUsage` (ユーザー別期間集計) ※ UI は Task 5.4 |
| Req 19.5 | `detectAnomaly` が直近 3 ヶ月平均の 5 倍超ユーザーを返却。ベースライン 0 ならスキップ、対象月コスト 1 USD 未満はノイズ除外 |
| Req 19.6 | `recordFailure` + `getFailureRate` で失敗率と errorCategory 別集計 |
| Req 19.8 | `cacheHit` フラグを `AIUsageEntry` に保存、`getUserUsage.cacheHitRate` で集計 |

## スコープ外 (他タスクに委譲)

- 予算アラート / 非クリティカル機能停止 → **Task 5.3** (Issue #17)
- コスト可視化ダッシュボード UI → **Task 5.4** (Issue #18)
- Prisma 実装 → DB マイグレーション整備後の別タスク
- `disableNonCriticalFeatures()` は本 Service の interface から除外 (Task 5.3 の別 Service が提供予定)

## テスト結果

```
Test Files  4 passed (4)
     Tests  48 passed (48)
```

カバレッジ (ai-monitoring):
```
File               | % Stmts | % Branch | % Funcs | % Lines
All files          |     100 |    97.77 |     100 |     100
 ai-monitoring-service.ts |     100 |    96.15 |     100 |     100
 ai-usage-recorder.ts     |     100 |      100 |     100 |     100
 ai-usage-repository.ts   |     100 |      100 |     100 |     100
 ai-usage-types.ts        |     100 |      100 |     100 |     100
```

## 品質ゲート

- [x] `pnpm test src/tests/ai-monitoring/` (48/48 passing)
- [x] `pnpm lint` (No ESLint warnings or errors)
- [x] `pnpm type-check` で ai-monitoring 関連エラーなし (既存の Prisma 関連エラーは本 PR と無関係)
- [x] カバレッジ 95% 以上

## Test plan

- [ ] レビュー時に `pnpm test src/tests/ai-monitoring/` で 48 テスト全成功を確認
- [ ] `pnpm test:coverage` で ai-monitoring のカバレッジが維持されることを確認
- [ ] Task 5.3 (#17) と Task 5.4 (#18) とのファイル競合なし (`ai-budget-*` / `feature-flag-*` / `ai-dashboard-*` / `index.ts` は未作成)
- [ ] 将来 AIGateway を使う AICoachService / FeedbackService で `createUsageCallback` を `onUsage` に接続する統合 PR を別途作成