### PR TITLE
feat(ai-monitoring): Task 5.4 — AI 運用ダッシュボード

### DIFF
--- a/src/lib/ai-monitoring/ai-dashboard-service.ts
+++ b/src/lib/ai-monitoring/ai-dashboard-service.ts
@@ -1,0 +1,415 @@
+/**
+ * AI 運用ダッシュボードサービス
+ *
+ * Task 5.4 — ADMIN 向けに AI 利用状況をスナップショット / プロバイダ比較 /
+ * 失敗率 として集計する。
+ *
+ * 依存方針:
+ * - Task 5.2 の AIMonitoringService / AIUsageRepository には直接依存せず、
+ *   narrow port `DashboardUsageQueryPort` 経由で DI する。これにより
+ *   永続化実装 (Prisma/memory) や呼び出し元 (API route / CLI / Job) を選ばない。
+ *
+ * 関連要件:
+ * - Req 19.2: 月次/週次/日次のコスト推移とユーザー別使用量
+ * - Req 19.6: AI API 失敗率の記録と表示
+ * - Req 19.7: プロバイダ切替前後の利用量とコストの並列表示
+ */
+import { type AIProviderName, AI_PROVIDER_NAMES } from '@/lib/ai-gateway/ai-gateway-types'
+import { type UserRole } from '@/lib/notification/notification-types'
+
+import {
+  dashboardRangeSchema,
+  isAdminRole,
+  type CostTimeSeries,
+  type CostTimeSeriesPoint,
+  type DashboardRange,
+  type DashboardSnapshot,
+  type FailureRateSnapshot,
+  type Granularity,
+  type ProviderComparisonReport,
+  type ProviderComparisonRow,
+  type UserUsageRow,
+} from './ai-dashboard-types'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 例外
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** ADMIN 以外がダッシュボードを閲覧しようとした場合 */
+export class AIDashboardForbiddenError extends Error {
+  public readonly role: UserRole
+
+  constructor(role: UserRole) {
+    super(`AI dashboard forbidden for role: ${role}`)
+    this.name = 'AIDashboardForbiddenError'
+    this.role = role
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// narrow port — 外部の AI 利用ログストアへのクエリ抽象
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** 使用ログ 1 件。Task 5.2 の AIUsageRecord 相当 (narrow) */
+export interface DashboardUsageRecord {
+  readonly userId: string
+  readonly domain: string
+  readonly provider: AIProviderName
+  readonly promptTokens: number
+  readonly completionTokens: number
+  readonly estimatedCostUsd: number
+  readonly latencyMs: number
+  readonly cacheHit: boolean
+  readonly createdAt: Date
+}
+
+/** 失敗ログ 1 件 (Req 19.6) */
+export interface DashboardFailureRecord {
+  readonly userId: string
+  readonly errorCategory: string
+  readonly createdAt: Date
+}
+
+export interface DashboardUsageQueryPort {
+  listByDateRange(range: {
+    readonly from: Date
+    readonly to: Date
+  }): Promise<readonly DashboardUsageRecord[]>
+
+  listFailuresByDateRange(range: {
+    readonly from: Date
+    readonly to: Date
+  }): Promise<readonly DashboardFailureRecord[]>
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Service 公開 API
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface DashboardRequester {
+  readonly userId: string
+  readonly role: UserRole
+}
+
+export interface GetSnapshotRequest {
+  readonly requester: DashboardRequester
+  readonly range: DashboardRange
+  /** topUsers に表示するユーザー数。default 10 */
+  readonly topUsersLimit?: number
+}
+
+export interface GetProviderComparisonRequest {
+  readonly requester: DashboardRequester
+  readonly period: { readonly from: Date; readonly to: Date }
+}
+
+export interface GetFailureRateRequest {
+  readonly requester: DashboardRequester
+  readonly period: { readonly from: Date; readonly to: Date }
+}
+
+export interface AIDashboardService {
+  /** ADMIN のみ。他ロールは AIDashboardForbiddenError */
+  getSnapshot(request: GetSnapshotRequest): Promise<DashboardSnapshot>
+
+  /** プロバイダ比較 (Req 19.7) */
+  getProviderComparison(request: GetProviderComparisonRequest): Promise<ProviderComparisonReport>
+
+  /** 失敗率スナップショット (Req 19.6) */
+  getFailureRate(request: GetFailureRateRequest): Promise<FailureRateSnapshot>
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 定数
+// ─────────────────────────────────────────────────────────────────────────────
+
+const DEFAULT_TOP_USERS_LIMIT = 10
+const MS_PER_DAY = 86_400_000
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 内部ヘルパ — バケット化
+// ─────────────────────────────────────────────────────────────────────────────
+
+function pad2(n: number): string {
+  return n < 10 ? `0${n}` : `${n}`
+}
+
+/** UTC ベースの 'YYYY-MM-DD' */
+function formatDayBucket(d: Date): string {
+  const y = d.getUTCFullYear()
+  const m = pad2(d.getUTCMonth() + 1)
+  const day = pad2(d.getUTCDate())
+  return `${y}-${m}-${day}`
+}
+
+/** UTC ベースの 'YYYY-MM' */
+function formatMonthBucket(d: Date): string {
+  const y = d.getUTCFullYear()
+  const m = pad2(d.getUTCMonth() + 1)
+  return `${y}-${m}`
+}
+
+/**
+ * ISO 8601 週番号。'YYYY-Www' 形式。
+ * ISO 週は月曜始まり、木曜を含む週の年を "週番号年" とする。
+ */
+function formatWeekBucket(d: Date): string {
+  // UTC ベースで日付のみに正規化
+  const utc = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()))
+  // ISO 週: 月曜始まり (getUTCDay() は日=0..土=6)。木曜へ移動して週年を決める
+  const dayOfWeek = utc.getUTCDay() || 7
+  utc.setUTCDate(utc.getUTCDate() + 4 - dayOfWeek)
+  const weekYear = utc.getUTCFullYear()
+  const yearStart = new Date(Date.UTC(weekYear, 0, 1))
+  const weekNo = Math.ceil(((utc.getTime() - yearStart.getTime()) / MS_PER_DAY + 1) / 7)
+  return `${weekYear}-W${pad2(weekNo)}`
+}
+
+function bucketKey(d: Date, granularity: Granularity): string {
+  if (granularity === 'DAY') {
+    return formatDayBucket(d)
+  }
+  if (granularity === 'WEEK') {
+    return formatWeekBucket(d)
+  }
+  return formatMonthBucket(d)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 内部ヘルパ — 集計
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface MutableCostBucket {
+  costUsd: number
+  requests: number
+  promptTokens: number
+  completionTokens: number
+}
+
+function emptyCostBucket(): MutableCostBucket {
+  return { costUsd: 0, requests: 0, promptTokens: 0, completionTokens: 0 }
+}
+
+function aggregateCostSeries(
+  records: readonly DashboardUsageRecord[],
+  granularity: Granularity,
+): CostTimeSeries {
+  const buckets = new Map<string, MutableCostBucket>()
+  for (const r of records) {
+    const key = bucketKey(r.createdAt, granularity)
+    const cur = buckets.get(key) ?? emptyCostBucket()
+    cur.costUsd += r.estimatedCostUsd
+    cur.requests += 1
+    cur.promptTokens += r.promptTokens
+    cur.completionTokens += r.completionTokens
+    buckets.set(key, cur)
+  }
+
+  const points: CostTimeSeriesPoint[] = Array.from(buckets.entries())
+    .map(([bucket, agg]) => ({
+      bucket,
+      costUsd: agg.costUsd,
+      requests: agg.requests,
+      promptTokens: agg.promptTokens,
+      completionTokens: agg.completionTokens,
+    }))
+    .sort((a, b) => (a.bucket < b.bucket ? -1 : a.bucket > b.bucket ? 1 : 0))
+
+  return { granularity, points }
+}
+
+function aggregateTopUsers(
+  records: readonly DashboardUsageRecord[],
+  limit: number,
+): readonly UserUsageRow[] {
+  interface MutableRow {
+    userId: string
+    costUsd: number
+    requests: number
+    promptTokens: number
+    completionTokens: number
+  }
+  const byUser = new Map<string, MutableRow>()
+  for (const r of records) {
+    const cur = byUser.get(r.userId) ?? {
+      userId: r.userId,
+      costUsd: 0,
+      requests: 0,
+      promptTokens: 0,
+      completionTokens: 0,
+    }
+    cur.costUsd += r.estimatedCostUsd
+    cur.requests += 1
+    cur.promptTokens += r.promptTokens
+    cur.completionTokens += r.completionTokens
+    byUser.set(r.userId, cur)
+  }
+
+  return Array.from(byUser.values())
+    .sort((a, b) => b.costUsd - a.costUsd)
+    .slice(0, limit)
+    .map((row) => ({
+      userId: row.userId,
+      costUsd: row.costUsd,
+      requests: row.requests,
+      promptTokens: row.promptTokens,
+      completionTokens: row.completionTokens,
+    }))
+}
+
+function providerOrder(provider: AIProviderName): number {
+  const idx = AI_PROVIDER_NAMES.indexOf(provider)
+  return idx === -1 ? AI_PROVIDER_NAMES.length : idx
+}
+
+function aggregateProviderComparison(
+  records: readonly DashboardUsageRecord[],
+  period: { readonly from: Date; readonly to: Date },
+): ProviderComparisonReport {
+  interface MutableRow {
+    provider: AIProviderName
+    requests: number
+    costUsd: number
+    totalLatencyMs: number
+    cacheHits: number
+  }
+  const byProvider = new Map<AIProviderName, MutableRow>()
+  for (const r of records) {
+    const cur = byProvider.get(r.provider) ?? {
+      provider: r.provider,
+      requests: 0,
+      costUsd: 0,
+      totalLatencyMs: 0,
+      cacheHits: 0,
+    }
+    cur.requests += 1
+    cur.costUsd += r.estimatedCostUsd
+    cur.totalLatencyMs += r.latencyMs
+    if (r.cacheHit) {
+      cur.cacheHits += 1
+    }
+    byProvider.set(r.provider, cur)
+  }
+
+  const rows: ProviderComparisonRow[] = Array.from(byProvider.values())
+    .map((row) => ({
+      provider: row.provider,
+      requests: row.requests,
+      costUsd: row.costUsd,
+      avgLatencyMs: row.requests === 0 ? 0 : row.totalLatencyMs / row.requests,
+      cacheHitRate: row.requests === 0 ? 0 : row.cacheHits / row.requests,
+    }))
+    .sort((a, b) => providerOrder(a.provider) - providerOrder(b.provider))
+
+  return { period, rows }
+}
+
+function aggregateFailureRate(
+  successes: readonly DashboardUsageRecord[],
+  failures: readonly DashboardFailureRecord[],
+): FailureRateSnapshot {
+  const totalAttempts = successes.length + failures.length
+  const failureCount = failures.length
+  const failureRate = totalAttempts === 0 ? 0 : failureCount / totalAttempts
+  const byErrorCategory: Record<string, number> = {}
+  for (const f of failures) {
+    byErrorCategory[f.errorCategory] = (byErrorCategory[f.errorCategory] ?? 0) + 1
+  }
+  return {
+    totalAttempts,
+    failureCount,
+    failureRate,
+    byErrorCategory,
+  }
+}
+
+function assertPeriod(period: { readonly from: Date; readonly to: Date }): {
+  readonly from: Date
+  readonly to: Date
+} {
+  if (!(period.from instanceof Date) || !(period.to instanceof Date)) {
+    throw new TypeError('period.from and period.to must be Date instances')
+  }
+  if (period.from > period.to) {
+    throw new RangeError('period.from must be <= period.to')
+  }
+  return { from: period.from, to: period.to }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Implementation
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface Dependencies {
+  readonly usageQuery: DashboardUsageQueryPort
+}
+
+class AIDashboardServiceImpl implements AIDashboardService {
+  constructor(private readonly deps: Dependencies) {}
+
+  async getSnapshot(request: GetSnapshotRequest): Promise<DashboardSnapshot> {
+    // 1) ロール判定を最初に行い、副作用を一切起こさない
+    this.assertAdmin(request.requester.role)
+
+    // 2) 入力検証
+    const range = dashboardRangeSchema.parse(request.range)
+    const topUsersLimit = request.topUsersLimit ?? DEFAULT_TOP_USERS_LIMIT
+    if (!Number.isInteger(topUsersLimit) || topUsersLimit <= 0) {
+      throw new RangeError(`topUsersLimit must be a positive integer (got ${topUsersLimit})`)
+    }
+
+    // 3) 使用ログと失敗ログを取得
+    const period = { from: range.from, to: range.to }
+    const [usageRecords, failureRecords] = await Promise.all([
+      this.deps.usageQuery.listByDateRange(period),
+      this.deps.usageQuery.listFailuresByDateRange(period),
+    ])
+
+    // 4) 集計
+    const costSeries = aggregateCostSeries(usageRecords, range.granularity)
+    const topUsers = aggregateTopUsers(usageRecords, topUsersLimit)
+    const failureRate = aggregateFailureRate(usageRecords, failureRecords)
+    const providerComparison = aggregateProviderComparison(usageRecords, period)
+
+    return {
+      range: { from: range.from, to: range.to, granularity: range.granularity },
+      costSeries,
+      topUsers,
+      failureRate,
+      providerComparison,
+    }
+  }
+
+  async getProviderComparison(
+    request: GetProviderComparisonRequest,
+  ): Promise<ProviderComparisonReport> {
+    this.assertAdmin(request.requester.role)
+    const period = assertPeriod(request.period)
+    const usageRecords = await this.deps.usageQuery.listByDateRange(period)
+    return aggregateProviderComparison(usageRecords, period)
+  }
+
+  async getFailureRate(request: GetFailureRateRequest): Promise<FailureRateSnapshot> {
+    this.assertAdmin(request.requester.role)
+    const period = assertPeriod(request.period)
+    const [usageRecords, failureRecords] = await Promise.all([
+      this.deps.usageQuery.listByDateRange(period),
+      this.deps.usageQuery.listFailuresByDateRange(period),
+    ])
+    return aggregateFailureRate(usageRecords, failureRecords)
+  }
+
+  private assertAdmin(role: UserRole): void {
+    if (!isAdminRole(role)) {
+      throw new AIDashboardForbiddenError(role)
+    }
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Factory
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function createAIDashboardService(deps: Dependencies): AIDashboardService {
+  return new AIDashboardServiceImpl(deps)
+}

--- a/src/lib/ai-monitoring/ai-dashboard-types.ts
+++ b/src/lib/ai-monitoring/ai-dashboard-types.ts
@@ -1,0 +1,129 @@
+/**
+ * AI 運用ダッシュボード 型定義
+ *
+ * Task 5.4 — AI コスト推移・プロバイダ比較・失敗率を ADMIN 向けに集計する
+ * ダッシュボードの共通型とスキーマ。
+ *
+ * 関連要件:
+ * - Req 19.2: 月次/週次/日次のコスト推移とユーザー別使用量
+ * - Req 19.6: AI API 失敗率・再試行の記録と表示
+ * - Req 19.7: プロバイダ切替前後の利用量とコストの並列表示
+ */
+import { z } from 'zod'
+
+import { type AIProviderName } from '@/lib/ai-gateway/ai-gateway-types'
+import { type UserRole } from '@/lib/notification/notification-types'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 粒度 (Granularity)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** コスト推移の集計粒度 */
+export const GRANULARITIES = ['DAY', 'WEEK', 'MONTH'] as const
+export type Granularity = (typeof GRANULARITIES)[number]
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ダッシュボード期間
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** ダッシュボード取得範囲 (from <= to) */
+export const dashboardRangeSchema = z
+  .object({
+    from: z.date(),
+    to: z.date(),
+    granularity: z.enum(GRANULARITIES),
+  })
+  .refine((v) => v.from <= v.to, { message: 'from must be <= to' })
+
+export type DashboardRange = z.infer<typeof dashboardRangeSchema>
+
+// ─────────────────────────────────────────────────────────────────────────────
+// コスト推移
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** コスト推移の 1 バケット */
+export interface CostTimeSeriesPoint {
+  /** 'YYYY-MM-DD' (DAY) / 'YYYY-Www' (WEEK, ISO 週) / 'YYYY-MM' (MONTH) */
+  readonly bucket: string
+  readonly costUsd: number
+  readonly requests: number
+  readonly promptTokens: number
+  readonly completionTokens: number
+}
+
+export interface CostTimeSeries {
+  readonly granularity: Granularity
+  readonly points: readonly CostTimeSeriesPoint[]
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ユーザー別使用量
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface UserUsageRow {
+  readonly userId: string
+  readonly costUsd: number
+  readonly requests: number
+  readonly promptTokens: number
+  readonly completionTokens: number
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 失敗率スナップショット (Req 19.6)
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface FailureRateSnapshot {
+  /** 成功 + 失敗の合計試行数 */
+  readonly totalAttempts: number
+  readonly failureCount: number
+  /** 0.0 - 1.0。試行 0 件の場合は 0 */
+  readonly failureRate: number
+  /** エラーカテゴリ別の失敗内訳 */
+  readonly byErrorCategory: Readonly<Record<string, number>>
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// プロバイダ比較 (Req 19.7)
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface ProviderComparisonRow {
+  readonly provider: AIProviderName
+  readonly requests: number
+  readonly costUsd: number
+  readonly avgLatencyMs: number
+  /** 0.0 - 1.0。データが 0 件の場合は 0 */
+  readonly cacheHitRate: number
+}
+
+export interface ProviderComparisonReport {
+  readonly period: { readonly from: Date; readonly to: Date }
+  readonly rows: readonly ProviderComparisonRow[]
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ダッシュボードスナップショット
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface DashboardSnapshot {
+  readonly range: {
+    readonly from: Date
+    readonly to: Date
+    readonly granularity: Granularity
+  }
+  readonly costSeries: CostTimeSeries
+  readonly topUsers: readonly UserUsageRow[]
+  readonly failureRate: FailureRateSnapshot
+  readonly providerComparison: ProviderComparisonReport
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 認可
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** ダッシュボードを閲覧可能なロール (ADMIN のみ) */
+export const ADMIN_ROLES: readonly UserRole[] = ['ADMIN']
+
+/** 指定ロールが ADMIN 相当かを判定する */
+export function isAdminRole(role: UserRole): boolean {
+  return ADMIN_ROLES.includes(role)
+}

--- a/src/tests/ai-monitoring/ai-dashboard-service.test.ts
+++ b/src/tests/ai-monitoring/ai-dashboard-service.test.ts
@@ -1,0 +1,420 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+import {
+  AIDashboardForbiddenError,
+  createAIDashboardService,
+  type AIDashboardService,
+  type DashboardFailureRecord,
+  type DashboardUsageQueryPort,
+  type DashboardUsageRecord,
+} from '@/lib/ai-monitoring/ai-dashboard-service'
+import type { DashboardRange } from '@/lib/ai-monitoring/ai-dashboard-types'
+import type { UserRole } from '@/lib/notification/notification-types'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test doubles
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface UsageQuerySpy extends DashboardUsageQueryPort {
+  readonly listByDateRange: ReturnType<typeof vi.fn>
+  readonly listFailuresByDateRange: ReturnType<typeof vi.fn>
+}
+
+function makeUsageQuerySpy(
+  usage: readonly DashboardUsageRecord[] = [],
+  failures: readonly DashboardFailureRecord[] = [],
+): UsageQuerySpy {
+  const listByDateRange = vi.fn(async () => usage)
+  const listFailuresByDateRange = vi.fn(async () => failures)
+  return {
+    listByDateRange,
+    listFailuresByDateRange,
+  } as UsageQuerySpy
+}
+
+function makeUsage(overrides: Partial<DashboardUsageRecord> = {}): DashboardUsageRecord {
+  return {
+    userId: 'u1',
+    domain: 'ai-coach',
+    provider: 'claude',
+    promptTokens: 100,
+    completionTokens: 200,
+    estimatedCostUsd: 1.0,
+    latencyMs: 500,
+    cacheHit: false,
+    createdAt: new Date('2026-04-05T10:00:00Z'),
+    ...overrides,
+  }
+}
+
+function makeFailure(overrides: Partial<DashboardFailureRecord> = {}): DashboardFailureRecord {
+  return {
+    userId: 'u1',
+    errorCategory: 'TIMEOUT',
+    createdAt: new Date('2026-04-05T10:00:00Z'),
+    ...overrides,
+  }
+}
+
+const ADMIN: { userId: string; role: UserRole } = { userId: 'admin-1', role: 'ADMIN' }
+
+const DEFAULT_RANGE: DashboardRange = {
+  from: new Date('2026-04-01T00:00:00Z'),
+  to: new Date('2026-04-30T23:59:59Z'),
+  granularity: 'DAY',
+}
+
+function setup(
+  usage: readonly DashboardUsageRecord[] = [],
+  failures: readonly DashboardFailureRecord[] = [],
+): { readonly service: AIDashboardService; readonly usageQuery: UsageQuerySpy } {
+  const usageQuery = makeUsageQuerySpy(usage, failures)
+  const service = createAIDashboardService({ usageQuery })
+  return { service, usageQuery }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 認可 (ADMIN のみ許可、他ロールは副作用なしで拒否)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('AIDashboardService - authorization', () => {
+  const nonAdmins: readonly UserRole[] = ['HR_MANAGER', 'MANAGER', 'EMPLOYEE']
+
+  it.each(nonAdmins)(
+    'getSnapshot throws AIDashboardForbiddenError for %s without touching usageQuery',
+    async (role) => {
+      const { service, usageQuery } = setup()
+      await expect(
+        service.getSnapshot({ requester: { userId: 'x', role }, range: DEFAULT_RANGE }),
+      ).rejects.toBeInstanceOf(AIDashboardForbiddenError)
+      expect(usageQuery.listByDateRange).not.toHaveBeenCalled()
+      expect(usageQuery.listFailuresByDateRange).not.toHaveBeenCalled()
+    },
+  )
+
+  it.each(nonAdmins)(
+    'getProviderComparison throws for %s without touching usageQuery',
+    async (role) => {
+      const { service, usageQuery } = setup()
+      await expect(
+        service.getProviderComparison({
+          requester: { userId: 'x', role },
+          period: { from: DEFAULT_RANGE.from, to: DEFAULT_RANGE.to },
+        }),
+      ).rejects.toBeInstanceOf(AIDashboardForbiddenError)
+      expect(usageQuery.listByDateRange).not.toHaveBeenCalled()
+    },
+  )
+
+  it.each(nonAdmins)('getFailureRate throws for %s without touching usageQuery', async (role) => {
+    const { service, usageQuery } = setup()
+    await expect(
+      service.getFailureRate({
+        requester: { userId: 'x', role },
+        period: { from: DEFAULT_RANGE.from, to: DEFAULT_RANGE.to },
+      }),
+    ).rejects.toBeInstanceOf(AIDashboardForbiddenError)
+    expect(usageQuery.listByDateRange).not.toHaveBeenCalled()
+    expect(usageQuery.listFailuresByDateRange).not.toHaveBeenCalled()
+  })
+
+  it('allows ADMIN to call getSnapshot', async () => {
+    const { service, usageQuery } = setup()
+    const result = await service.getSnapshot({ requester: ADMIN, range: DEFAULT_RANGE })
+    expect(result.range.granularity).toBe('DAY')
+    expect(usageQuery.listByDateRange).toHaveBeenCalledTimes(1)
+    expect(usageQuery.listFailuresByDateRange).toHaveBeenCalledTimes(1)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// getSnapshot — バケット化 / topUsers
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('AIDashboardService.getSnapshot - bucketing', () => {
+  let baseUsage: readonly DashboardUsageRecord[]
+
+  beforeEach(() => {
+    baseUsage = [
+      makeUsage({ createdAt: new Date('2026-04-05T10:00:00Z'), estimatedCostUsd: 1 }),
+      makeUsage({ createdAt: new Date('2026-04-05T22:00:00Z'), estimatedCostUsd: 2 }),
+      makeUsage({ createdAt: new Date('2026-04-06T09:00:00Z'), estimatedCostUsd: 4 }),
+      makeUsage({ createdAt: new Date('2026-04-13T09:00:00Z'), estimatedCostUsd: 8 }),
+      makeUsage({ createdAt: new Date('2026-05-01T09:00:00Z'), estimatedCostUsd: 16 }),
+    ]
+  })
+
+  it('DAY granularity groups by YYYY-MM-DD', async () => {
+    const { service } = setup(baseUsage)
+    const snap = await service.getSnapshot({
+      requester: ADMIN,
+      range: {
+        from: new Date('2026-04-01T00:00:00Z'),
+        to: new Date('2026-05-31T00:00:00Z'),
+        granularity: 'DAY',
+      },
+    })
+    const buckets = snap.costSeries.points.map((p) => p.bucket)
+    expect(buckets).toEqual(['2026-04-05', '2026-04-06', '2026-04-13', '2026-05-01'])
+    const day5 = snap.costSeries.points.find((p) => p.bucket === '2026-04-05')
+    expect(day5?.costUsd).toBe(3)
+    expect(day5?.requests).toBe(2)
+  })
+
+  it('WEEK granularity groups by ISO YYYY-Www', async () => {
+    const { service } = setup(baseUsage)
+    const snap = await service.getSnapshot({
+      requester: ADMIN,
+      range: {
+        from: new Date('2026-04-01T00:00:00Z'),
+        to: new Date('2026-05-31T00:00:00Z'),
+        granularity: 'WEEK',
+      },
+    })
+    // 2026-04-05 は日曜 => ISO週14 (2026-03-30〜2026-04-05)
+    // 2026-04-06 月曜 => ISO週15
+    // 2026-04-13 月曜 => ISO週16
+    // 2026-05-01 金曜 => ISO週18
+    const buckets = snap.costSeries.points.map((p) => p.bucket)
+    expect(buckets).toEqual(['2026-W14', '2026-W15', '2026-W16', '2026-W18'])
+    buckets.forEach((b) => expect(b).toMatch(/^\d{4}-W\d{2}$/))
+  })
+
+  it('MONTH granularity groups by YYYY-MM', async () => {
+    const { service } = setup(baseUsage)
+    const snap = await service.getSnapshot({
+      requester: ADMIN,
+      range: {
+        from: new Date('2026-04-01T00:00:00Z'),
+        to: new Date('2026-05-31T00:00:00Z'),
+        granularity: 'MONTH',
+      },
+    })
+    const buckets = snap.costSeries.points.map((p) => p.bucket)
+    expect(buckets).toEqual(['2026-04', '2026-05'])
+    const april = snap.costSeries.points.find((p) => p.bucket === '2026-04')
+    expect(april?.costUsd).toBe(15)
+    expect(april?.requests).toBe(4)
+    const may = snap.costSeries.points.find((p) => p.bucket === '2026-05')
+    expect(may?.costUsd).toBe(16)
+  })
+})
+
+describe('AIDashboardService.getSnapshot - topUsers', () => {
+  it('sorts users by costUsd descending and applies limit', async () => {
+    const usage: readonly DashboardUsageRecord[] = [
+      makeUsage({ userId: 'u1', estimatedCostUsd: 1 }),
+      makeUsage({ userId: 'u2', estimatedCostUsd: 5 }),
+      makeUsage({ userId: 'u2', estimatedCostUsd: 5 }),
+      makeUsage({ userId: 'u3', estimatedCostUsd: 3 }),
+      makeUsage({ userId: 'u4', estimatedCostUsd: 7 }),
+      makeUsage({ userId: 'u5', estimatedCostUsd: 0.5 }),
+    ]
+    const { service } = setup(usage)
+    const snap = await service.getSnapshot({
+      requester: ADMIN,
+      range: DEFAULT_RANGE,
+      topUsersLimit: 3,
+    })
+    expect(snap.topUsers.map((r) => r.userId)).toEqual(['u2', 'u4', 'u3'])
+    expect(snap.topUsers[0]).toMatchObject({ userId: 'u2', costUsd: 10, requests: 2 })
+  })
+
+  it('defaults topUsersLimit to 10', async () => {
+    const usage = Array.from({ length: 15 }, (_, i) =>
+      makeUsage({ userId: `u${i + 1}`, estimatedCostUsd: 15 - i }),
+    )
+    const { service } = setup(usage)
+    const snap = await service.getSnapshot({ requester: ADMIN, range: DEFAULT_RANGE })
+    expect(snap.topUsers).toHaveLength(10)
+    expect(snap.topUsers[0]?.userId).toBe('u1')
+  })
+
+  it('rejects non-positive topUsersLimit', async () => {
+    const { service } = setup()
+    await expect(
+      service.getSnapshot({ requester: ADMIN, range: DEFAULT_RANGE, topUsersLimit: 0 }),
+    ).rejects.toBeInstanceOf(RangeError)
+    await expect(
+      service.getSnapshot({ requester: ADMIN, range: DEFAULT_RANGE, topUsersLimit: -1 }),
+    ).rejects.toBeInstanceOf(RangeError)
+  })
+
+  it('rejects invalid range (from > to) via Zod', async () => {
+    const { service, usageQuery } = setup()
+    await expect(
+      service.getSnapshot({
+        requester: ADMIN,
+        range: {
+          from: new Date('2026-05-01T00:00:00Z'),
+          to: new Date('2026-04-01T00:00:00Z'),
+          granularity: 'DAY',
+        },
+      }),
+    ).rejects.toThrow()
+    expect(usageQuery.listByDateRange).not.toHaveBeenCalled()
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// getProviderComparison
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('AIDashboardService.getProviderComparison', () => {
+  it('aggregates requests / cost / avg latency / cache hit rate per provider', async () => {
+    const usage: readonly DashboardUsageRecord[] = [
+      makeUsage({ provider: 'claude', latencyMs: 100, cacheHit: true, estimatedCostUsd: 1 }),
+      makeUsage({ provider: 'claude', latencyMs: 300, cacheHit: false, estimatedCostUsd: 2 }),
+      makeUsage({ provider: 'claude', latencyMs: 500, cacheHit: false, estimatedCostUsd: 3 }),
+      makeUsage({ provider: 'openai', latencyMs: 200, cacheHit: true, estimatedCostUsd: 4 }),
+      makeUsage({ provider: 'openai', latencyMs: 400, cacheHit: true, estimatedCostUsd: 6 }),
+    ]
+    const { service } = setup(usage)
+    const report = await service.getProviderComparison({
+      requester: ADMIN,
+      period: { from: DEFAULT_RANGE.from, to: DEFAULT_RANGE.to },
+    })
+    const claude = report.rows.find((r) => r.provider === 'claude')
+    const openai = report.rows.find((r) => r.provider === 'openai')
+
+    expect(claude).toEqual({
+      provider: 'claude',
+      requests: 3,
+      costUsd: 6,
+      avgLatencyMs: 300,
+      cacheHitRate: 1 / 3,
+    })
+    expect(openai).toEqual({
+      provider: 'openai',
+      requests: 2,
+      costUsd: 10,
+      avgLatencyMs: 300,
+      cacheHitRate: 1,
+    })
+  })
+
+  it('returns empty rows when there are no usage records', async () => {
+    const { service } = setup([])
+    const report = await service.getProviderComparison({
+      requester: ADMIN,
+      period: { from: DEFAULT_RANGE.from, to: DEFAULT_RANGE.to },
+    })
+    expect(report.rows).toEqual([])
+  })
+
+  it('rejects period where from > to', async () => {
+    const { service } = setup()
+    await expect(
+      service.getProviderComparison({
+        requester: ADMIN,
+        period: {
+          from: new Date('2026-05-01T00:00:00Z'),
+          to: new Date('2026-04-01T00:00:00Z'),
+        },
+      }),
+    ).rejects.toBeInstanceOf(RangeError)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// getFailureRate
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('AIDashboardService.getFailureRate', () => {
+  it('computes failures / (failures + successes) with byErrorCategory breakdown', async () => {
+    const usage: readonly DashboardUsageRecord[] = [
+      makeUsage(),
+      makeUsage(),
+      makeUsage(),
+      makeUsage(),
+      makeUsage(),
+      makeUsage(),
+      makeUsage(),
+      makeUsage(), // 8 successes
+    ]
+    const failures: readonly DashboardFailureRecord[] = [
+      makeFailure({ errorCategory: 'TIMEOUT' }),
+      makeFailure({ errorCategory: 'TIMEOUT' }),
+      makeFailure({ errorCategory: 'PROVIDER_ERROR' }),
+      makeFailure({ errorCategory: 'RATE_LIMIT' }),
+    ]
+    const { service } = setup(usage, failures)
+    const snap = await service.getFailureRate({
+      requester: ADMIN,
+      period: { from: DEFAULT_RANGE.from, to: DEFAULT_RANGE.to },
+    })
+    expect(snap.totalAttempts).toBe(12)
+    expect(snap.failureCount).toBe(4)
+    expect(snap.failureRate).toBeCloseTo(4 / 12, 10)
+    expect(snap.byErrorCategory).toEqual({
+      TIMEOUT: 2,
+      PROVIDER_ERROR: 1,
+      RATE_LIMIT: 1,
+    })
+  })
+
+  it('returns failureRate=0 and empty breakdown when there are no records', async () => {
+    const { service } = setup([], [])
+    const snap = await service.getFailureRate({
+      requester: ADMIN,
+      period: { from: DEFAULT_RANGE.from, to: DEFAULT_RANGE.to },
+    })
+    expect(snap).toEqual({
+      totalAttempts: 0,
+      failureCount: 0,
+      failureRate: 0,
+      byErrorCategory: {},
+    })
+  })
+
+  it('returns failureRate=1 when every attempt failed', async () => {
+    const failures: readonly DashboardFailureRecord[] = [
+      makeFailure({ errorCategory: 'TIMEOUT' }),
+      makeFailure({ errorCategory: 'PROVIDER_ERROR' }),
+    ]
+    const { service } = setup([], failures)
+    const snap = await service.getFailureRate({
+      requester: ADMIN,
+      period: { from: DEFAULT_RANGE.from, to: DEFAULT_RANGE.to },
+    })
+    expect(snap.totalAttempts).toBe(2)
+    expect(snap.failureCount).toBe(2)
+    expect(snap.failureRate).toBe(1)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// getSnapshot — 統合 (failureRate + providerComparison が 1 スナップショットに同梱)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('AIDashboardService.getSnapshot - integrated snapshot', () => {
+  it('bundles costSeries, topUsers, failureRate and providerComparison', async () => {
+    const usage: readonly DashboardUsageRecord[] = [
+      makeUsage({
+        userId: 'u1',
+        provider: 'claude',
+        latencyMs: 100,
+        cacheHit: true,
+        estimatedCostUsd: 2,
+      }),
+      makeUsage({
+        userId: 'u2',
+        provider: 'openai',
+        latencyMs: 200,
+        cacheHit: false,
+        estimatedCostUsd: 5,
+      }),
+    ]
+    const failures: readonly DashboardFailureRecord[] = [makeFailure({ errorCategory: 'TIMEOUT' })]
+    const { service } = setup(usage, failures)
+    const snap = await service.getSnapshot({ requester: ADMIN, range: DEFAULT_RANGE })
+
+    expect(snap.range.granularity).toBe('DAY')
+    expect(snap.costSeries.points).toHaveLength(1)
+    expect(snap.topUsers.map((r) => r.userId)).toEqual(['u2', 'u1'])
+    expect(snap.failureRate.totalAttempts).toBe(3)
+    expect(snap.failureRate.failureCount).toBe(1)
+    expect(snap.failureRate.byErrorCategory).toEqual({ TIMEOUT: 1 })
+    expect(snap.providerComparison.rows).toHaveLength(2)
+  })
+})

--- a/src/tests/ai-monitoring/ai-dashboard-types.test.ts
+++ b/src/tests/ai-monitoring/ai-dashboard-types.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest'
+
+import {
+  ADMIN_ROLES,
+  GRANULARITIES,
+  dashboardRangeSchema,
+  isAdminRole,
+  type Granularity,
+} from '@/lib/ai-monitoring/ai-dashboard-types'
+import type { UserRole } from '@/lib/notification/notification-types'
+
+describe('GRANULARITIES', () => {
+  it('exposes DAY / WEEK / MONTH only, in that order', () => {
+    expect(GRANULARITIES).toEqual(['DAY', 'WEEK', 'MONTH'])
+  })
+
+  it('infers Granularity as a literal union of the enum members', () => {
+    const values: readonly Granularity[] = ['DAY', 'WEEK', 'MONTH']
+    expect(values).toHaveLength(3)
+  })
+})
+
+describe('dashboardRangeSchema', () => {
+  it('accepts from === to with any granularity', () => {
+    const at = new Date('2026-04-01T00:00:00Z')
+    const result = dashboardRangeSchema.safeParse({ from: at, to: at, granularity: 'DAY' })
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts from < to with granularity WEEK', () => {
+    const from = new Date('2026-04-01T00:00:00Z')
+    const to = new Date('2026-04-30T00:00:00Z')
+    const result = dashboardRangeSchema.safeParse({ from, to, granularity: 'WEEK' })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.granularity).toBe('WEEK')
+    }
+  })
+
+  it('rejects from > to', () => {
+    const from = new Date('2026-05-01T00:00:00Z')
+    const to = new Date('2026-04-01T00:00:00Z')
+    const result = dashboardRangeSchema.safeParse({ from, to, granularity: 'MONTH' })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toBe('from must be <= to')
+    }
+  })
+
+  it('rejects unknown granularity values', () => {
+    const at = new Date('2026-04-01T00:00:00Z')
+    const result = dashboardRangeSchema.safeParse({ from: at, to: at, granularity: 'HOUR' })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects non-Date from / to', () => {
+    const result = dashboardRangeSchema.safeParse({
+      from: '2026-04-01',
+      to: '2026-04-02',
+      granularity: 'DAY',
+    })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('isAdminRole / ADMIN_ROLES', () => {
+  it('ADMIN_ROLES contains ADMIN only', () => {
+    expect(ADMIN_ROLES).toEqual(['ADMIN'])
+  })
+
+  it('returns true for ADMIN', () => {
+    expect(isAdminRole('ADMIN')).toBe(true)
+  })
+
+  it.each<UserRole>(['HR_MANAGER', 'MANAGER', 'EMPLOYEE'])('returns false for %s', (role) => {
+    expect(isAdminRole(role)).toBe(false)
+  })
+})


### PR DESCRIPTION
Closes #18

## Summary

Task 5.4 — ADMIN 向けの AI 運用ダッシュボード集計サービスを実装。AI コスト推移 / プロバイダ比較 / 失敗率を 1 つのスナップショットとして返す。

### 要件マッピング

| Req   | 内容                                                                 | 実装箇所                                                                 |
| ----- | -------------------------------------------------------------------- | ------------------------------------------------------------------------ |
| 19.2  | 月次・週次・日次のコスト推移とユーザー別使用量                       | `getSnapshot` + `costSeries` (DAY / ISO WEEK / MONTH) + `topUsers`       |
| 19.6  | AI API 失敗率・再試行の記録と表示                                    | `getFailureRate`, `FailureRateSnapshot.byErrorCategory`                   |
| 19.7  | プロバイダ切替前後の利用量・コストの並列表示                         | `getProviderComparison` (provider 別 requests/cost/avg latency/cache hit) |

### ADMIN 認可

- 非 ADMIN (`HR_MANAGER` / `MANAGER` / `EMPLOYEE`) は `AIDashboardForbiddenError` を即座に throw
- ロール判定は Zod 検証・I/O より **前に最初** に行い、`DashboardUsageQueryPort` には一切触れない (副作用ゼロ)
- テストで全 3 メソッド × 3 非 ADMIN ロール = 9 ケースを `expect(...).not.toHaveBeenCalled()` で検証

### 設計メモ

- narrow port `DashboardUsageQueryPort` 経由で DI。Task 5.2 の `AIMonitoringService` / `AIUsageRepository` には直接依存しない
- 永続化 (Prisma / in-memory) や呼び出し元 (API route / CLI / Job) を選ばない
- ISO 週計算は依存なしで自前実装 (`formatWeekBucket`: 木曜ベースで週年算出)
- 不変データ: すべての集計結果は `readonly` で返す

### スコープ外

- Next.js UI ページ (ダッシュボード表示)
- Prisma 実装 (`DashboardUsageQueryPort` の具体)
- 実際の HTTP Route ハンドラ
- プロバイダ切替の設定 UI

## 変更ファイル

- `src/lib/ai-monitoring/ai-dashboard-types.ts` (new, 129 lines)
- `src/lib/ai-monitoring/ai-dashboard-service.ts` (new, 415 lines)
- `src/tests/ai-monitoring/ai-dashboard-types.test.ts` (new, 12 tests)
- `src/tests/ai-monitoring/ai-dashboard-service.test.ts` (new, 24 tests)

## Test plan

- [x] `pnpm test src/tests/ai-monitoring` — 36 tests passed
- [x] `pnpm test` (全体) — 499 tests passed (44 test files)
- [x] `pnpm lint` — No ESLint warnings or errors
- [x] `pnpm type-check` — 新規ファイルに型エラーなし (既存の Prisma 関連エラーは Task 5.4 範囲外)
- [x] カバレッジ: `src/lib/ai-monitoring` 99.13% lines / 100% functions / 90.16% branches (80% 閾値超過)
- [ ] Next.js UI / API route 実装時の E2E (次タスク)

## 並列実行の衝突回避

Task 5.2 (#16) / Task 5.3 (#17) と並列実行のため以下に触れていない:
- `ai-usage-*.ts`, `ai-monitoring-service.ts` (5.2)
- `ai-budget-*.ts`, `feature-flag-*.ts`, `ai-alert-notifier.ts` (5.3)
- barrel `index.ts` 未作成