### PR TITLE
feat(ai-monitoring): Task 5.3 — AI 予算アラートと非クリティカル機能停止

### DIFF
--- a/src/lib/ai-monitoring/ai-alert-notifier.ts
+++ b/src/lib/ai-monitoring/ai-alert-notifier.ts
@@ -1,0 +1,143 @@
+/**
+ * AIAlertNotifier — AI 予算閾値到達時の ADMIN アラート送信抽象
+ *
+ * - 同一 (yearMonth, level) ペアに対する通知は 1 度のみ (冪等)。
+ * - NotificationEmitter ベースの実装を提供。各 ADMIN ユーザーに個別に emit する。
+ * - 実運用では sentRecord を Redis / DB で差し替えて永続化すること。
+ *
+ * 関連要件: Req 19.3, 19.4
+ */
+import type { AlertLevel, YearMonth } from './ai-budget-types'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Interface
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface AIAlertNotifyParams {
+  readonly yearMonth: YearMonth
+  readonly level: Exclude<AlertLevel, 'NONE'>
+  readonly currentCostUsd: number
+  readonly budgetUsd: number
+  readonly utilizationPct: number
+}
+
+export interface AIAlertNotifier {
+  /** 既に同じ yearMonth + level で通知済みの場合は冪等にスキップする */
+  notify(params: AIAlertNotifyParams): Promise<void>
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// NotificationEmitter port (notification-emitter.ts への narrow port)
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface AlertNotificationEmitterPort {
+  emit(event: {
+    userId: string
+    category: 'SYSTEM'
+    title: string
+    body: string
+    payload?: Record<string, unknown>
+  }): Promise<void>
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Implementation
+// ─────────────────────────────────────────────────────────────────────────────
+
+function buildAlertTitle(level: Exclude<AlertLevel, 'NONE'>, yearMonth: YearMonth): string {
+  if (level === 'CRITICAL') {
+    return `[AI 予算 CRITICAL] ${yearMonth} の利用額が予算上限に到達しました`
+  }
+  return `[AI 予算 WARN] ${yearMonth} の利用額が警告閾値に到達しました`
+}
+
+function buildAlertBody(params: AIAlertNotifyParams): string {
+  const { yearMonth, level, currentCostUsd, budgetUsd, utilizationPct } = params
+  const utilStr = utilizationPct.toFixed(1)
+  const currentStr = currentCostUsd.toFixed(2)
+  const budgetStr = budgetUsd.toFixed(2)
+  if (level === 'CRITICAL') {
+    return [
+      `${yearMonth} の月次 AI 利用額が設定予算の 100% に到達しました。`,
+      `現在のコスト: $${currentStr} / 予算: $${budgetStr} (利用率 ${utilStr}%)`,
+      '非クリティカル機能 (要約生成等) を自動的に一時停止しました。',
+    ].join('\n')
+  }
+  return [
+    `${yearMonth} の月次 AI 利用額が警告閾値に到達しました。`,
+    `現在のコスト: $${currentStr} / 予算: $${budgetStr} (利用率 ${utilStr}%)`,
+    '予算超過が近い可能性があります。予算設定または利用状況の確認を推奨します。',
+  ].join('\n')
+}
+
+class NotificationEmitterAIAlertNotifier implements AIAlertNotifier {
+  private readonly emitter: AlertNotificationEmitterPort
+  private readonly adminUserIdsProvider: () => Promise<readonly string[]>
+  private readonly sentRecord: Set<string>
+
+  constructor(deps: {
+    emitter: AlertNotificationEmitterPort
+    adminUserIdsProvider: () => Promise<readonly string[]>
+    sentRecord?: Set<string>
+  }) {
+    this.emitter = deps.emitter
+    this.adminUserIdsProvider = deps.adminUserIdsProvider
+    this.sentRecord = deps.sentRecord ?? new Set<string>()
+  }
+
+  async notify(params: AIAlertNotifyParams): Promise<void> {
+    const key = `${params.yearMonth}:${params.level}`
+    // 冪等: 既に送信済みならスキップ
+    if (this.sentRecord.has(key)) return
+
+    const adminIds = await this.adminUserIdsProvider()
+    if (adminIds.length === 0) {
+      // ADMIN 不在の場合も記録は残し、同条件での再試行を抑止する
+      this.sentRecord.add(key)
+      return
+    }
+
+    const title = buildAlertTitle(params.level, params.yearMonth)
+    const body = buildAlertBody(params)
+    const payload: Record<string, unknown> = {
+      yearMonth: params.yearMonth,
+      level: params.level,
+      currentCostUsd: params.currentCostUsd,
+      budgetUsd: params.budgetUsd,
+      utilizationPct: params.utilizationPct,
+    }
+
+    // 各 ADMIN に通知イベントを発行する。emitter 内部で非同期キュー投入されるため
+    // 並列 emit で十分。個別の失敗は Promise.allSettled で集約する。
+    const results = await Promise.allSettled(
+      adminIds.map((userId) =>
+        this.emitter.emit({
+          userId,
+          category: 'SYSTEM',
+          title,
+          body,
+          payload,
+        }),
+      ),
+    )
+
+    // 全員失敗した場合は冪等記録を残さず (次回再送を許容)、
+    // 1 件以上成功していれば「通知済み」として扱う。
+    const hasSuccess = results.some((r) => r.status === 'fulfilled')
+    if (hasSuccess) {
+      this.sentRecord.add(key)
+    }
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Factory
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function createNotificationEmitterAlertNotifier(deps: {
+  emitter: AlertNotificationEmitterPort
+  adminUserIdsProvider: () => Promise<readonly string[]>
+  sentRecord?: Set<string>
+}): AIAlertNotifier {
+  return new NotificationEmitterAIAlertNotifier(deps)
+}

--- a/src/lib/ai-monitoring/ai-budget-repository.ts
+++ b/src/lib/ai-monitoring/ai-budget-repository.ts
@@ -1,0 +1,76 @@
+/**
+ * AIBudgetRepository — 月次 AI 予算設定 (AIBudgetConfig) の永続化抽象
+ *
+ * Task 5.3 の範囲ではインメモリ実装のみを提供する。Prisma 実装は
+ * DB スキーマ整備 (別タスク) 完了後に本リポジトリ interface を満たす形で
+ * 追加する。
+ *
+ * 関連要件: Req 19.3, 19.4
+ */
+import {
+  aiBudgetConfigSchema,
+  yearMonthSchema,
+  type AIBudgetConfig,
+  type YearMonth,
+} from './ai-budget-types'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Interface
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface AIBudgetRepository {
+  /** 指定月の予算設定を取得。未設定なら null。 */
+  get(yearMonth: YearMonth): Promise<AIBudgetConfig | null>
+  /** 予算設定を upsert (新規作成 or 上書き)。 */
+  upsert(config: AIBudgetConfig): Promise<AIBudgetConfig>
+  /**
+   * 非クリティカル機能の停止フラグのみを更新。
+   * 指定月の設定が存在しない場合は何もしない (no-op)。
+   */
+  setNonCriticalDisabled(yearMonth: YearMonth, disabled: boolean): Promise<void>
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// In-memory implementation
+// ─────────────────────────────────────────────────────────────────────────────
+
+class InMemoryAIBudgetRepository implements AIBudgetRepository {
+  private readonly store: Map<string, AIBudgetConfig>
+
+  constructor(seed: readonly AIBudgetConfig[] = []) {
+    this.store = new Map()
+    for (const config of seed) {
+      const parsed = aiBudgetConfigSchema.parse(config)
+      this.store.set(parsed.yearMonth, parsed)
+    }
+  }
+
+  async get(yearMonth: YearMonth): Promise<AIBudgetConfig | null> {
+    const key = yearMonthSchema.parse(yearMonth)
+    return this.store.get(key) ?? null
+  }
+
+  async upsert(config: AIBudgetConfig): Promise<AIBudgetConfig> {
+    const parsed = aiBudgetConfigSchema.parse(config)
+    this.store.set(parsed.yearMonth, parsed)
+    return parsed
+  }
+
+  async setNonCriticalDisabled(yearMonth: YearMonth, disabled: boolean): Promise<void> {
+    const key = yearMonthSchema.parse(yearMonth)
+    const current = this.store.get(key)
+    if (!current) return
+    // 不変性を保つため、新しいオブジェクトで差し替える
+    this.store.set(key, { ...current, nonCriticalDisabled: disabled })
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Factory
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function createInMemoryAIBudgetRepository(
+  seed?: readonly AIBudgetConfig[],
+): AIBudgetRepository {
+  return new InMemoryAIBudgetRepository(seed)
+}

--- a/src/lib/ai-monitoring/ai-budget-service.ts
+++ b/src/lib/ai-monitoring/ai-budget-service.ts
@@ -1,0 +1,227 @@
+/**
+ * AIBudgetService — 月次 AI 予算の評価・アラート発火・非クリティカル機能停止
+ *
+ * Task 5.2 (AIMonitoringService) への依存を切り離すため、narrow port
+ * (BudgetCostQueryPort) 経由で現在コストを取得する。本番配線時に
+ * AIMonitoringService.getMonthlyCost() を包むアダプタを与える。
+ *
+ * 関連要件: Req 19.3 (WARN 80%), Req 19.4 (CRITICAL 100% + 非クリティカル停止)
+ */
+import type { AIAlertNotifier } from './ai-alert-notifier'
+import type { AIBudgetRepository } from './ai-budget-repository'
+import {
+  NON_CRITICAL_FEATURES,
+  aiBudgetConfigSchema,
+  yearMonthSchema,
+  type AIBudgetConfig,
+  type AlertLevel,
+  type BudgetEvaluation,
+  type NonCriticalFeature,
+  type YearMonth,
+} from './ai-budget-types'
+import type { FeatureFlagStore } from './feature-flag-store'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Ports
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Task 5.2 (AIMonitoringService) からの narrow port。
+ * 実体は AIMonitoringService.getMonthlyCost() を包むアダプタで注入する。
+ */
+export interface BudgetCostQueryPort {
+  getMonthlyCostUsd(yearMonth: YearMonth): Promise<number>
+}
+
+/**
+ * 監査ログ出力用の narrow port。
+ * AuditLogEmitter の AuditLogEntry は action が固定 enum のため、
+ * 本サービスでは AI_BUDGET_THRESHOLD_REACHED のような専用 action を扱える
+ * よう緩めた形状で受け取る。production 配線時は AuditAction enum 拡張後に
+ * AuditLogEmitter を直接渡せるようにする。
+ */
+export interface BudgetAuditLogPort {
+  emit(entry: {
+    userId: string | null
+    action: string
+    resourceType: string
+    resourceId: string | null
+    ipAddress: string
+    userAgent: string
+    before: Record<string, unknown> | null
+    after: Record<string, unknown> | null
+  }): Promise<void>
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Errors
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** 該当月の AIBudgetConfig が未設定 */
+export class AIBudgetNotConfiguredError extends Error {
+  public readonly yearMonth: YearMonth
+
+  constructor(yearMonth: YearMonth) {
+    super(`AIBudgetConfig is not configured for ${yearMonth}`)
+    this.name = 'AIBudgetNotConfiguredError'
+    this.yearMonth = yearMonth
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Interface
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface AIBudgetService {
+  /** 現状のコストを閾値と比較して評価する (通知・機能停止は発火しない) */
+  evaluate(yearMonth: YearMonth): Promise<BudgetEvaluation>
+  /**
+   * 閾値を評価し、到達していればアラートを送信し、100% 到達なら非クリティカル機能を停止する。
+   * 複数回呼ばれても冪等 (同 yearMonth + level を重複通知しない)。
+   */
+  checkAndAlert(yearMonth: YearMonth): Promise<BudgetEvaluation>
+  /** 予算設定を更新 */
+  upsertBudget(config: AIBudgetConfig): Promise<AIBudgetConfig>
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Implementation
+// ─────────────────────────────────────────────────────────────────────────────
+
+function computeAlertLevel(
+  utilizationPct: number,
+  warnThresholdPct: number,
+  criticalThresholdPct: number,
+): AlertLevel {
+  if (utilizationPct >= criticalThresholdPct) return 'CRITICAL'
+  if (utilizationPct >= warnThresholdPct) return 'WARN'
+  return 'NONE'
+}
+
+interface ServiceDeps {
+  readonly costQuery: BudgetCostQueryPort
+  readonly budgetRepo: AIBudgetRepository
+  readonly flagStore: FeatureFlagStore
+  readonly notifier: AIAlertNotifier
+  readonly auditLogger?: BudgetAuditLogPort
+  readonly nonCriticalFeatures: readonly NonCriticalFeature[]
+  readonly clock: () => Date
+}
+
+class DefaultAIBudgetService implements AIBudgetService {
+  private readonly deps: ServiceDeps
+
+  constructor(deps: ServiceDeps) {
+    this.deps = deps
+  }
+
+  async evaluate(yearMonth: YearMonth): Promise<BudgetEvaluation> {
+    const key = yearMonthSchema.parse(yearMonth)
+    const config = await this.deps.budgetRepo.get(key)
+    if (!config) {
+      throw new AIBudgetNotConfiguredError(key)
+    }
+
+    const currentCostUsd = await this.deps.costQuery.getMonthlyCostUsd(key)
+    // 予算設定時点で budgetUsd > 0 が保証されている (zod positive)。
+    const utilizationPct = (currentCostUsd / config.budgetUsd) * 100
+    const level = computeAlertLevel(
+      utilizationPct,
+      config.warnThresholdPct,
+      config.criticalThresholdPct,
+    )
+
+    return {
+      yearMonth: key,
+      currentCostUsd,
+      budgetUsd: config.budgetUsd,
+      utilizationPct,
+      level,
+    }
+  }
+
+  async checkAndAlert(yearMonth: YearMonth): Promise<BudgetEvaluation> {
+    const evaluation = await this.evaluate(yearMonth)
+
+    if (evaluation.level === 'NONE') {
+      return evaluation
+    }
+
+    // WARN / CRITICAL: ADMIN に通知 (notifier 側で冪等制御)
+    await this.deps.notifier.notify({
+      yearMonth: evaluation.yearMonth,
+      level: evaluation.level,
+      currentCostUsd: evaluation.currentCostUsd,
+      budgetUsd: evaluation.budgetUsd,
+      utilizationPct: evaluation.utilizationPct,
+    })
+
+    if (evaluation.level === 'CRITICAL') {
+      await this.disableNonCriticalFeatures(evaluation.yearMonth)
+    }
+
+    await this.recordAudit(evaluation)
+
+    return evaluation
+  }
+
+  async upsertBudget(config: AIBudgetConfig): Promise<AIBudgetConfig> {
+    const parsed = aiBudgetConfigSchema.parse(config)
+    return this.deps.budgetRepo.upsert(parsed)
+  }
+
+  private async disableNonCriticalFeatures(yearMonth: YearMonth): Promise<void> {
+    // 並列で機能停止を行い、フラグ永続化も更新する。
+    await Promise.all(
+      this.deps.nonCriticalFeatures.map((feature) => this.deps.flagStore.disable(feature)),
+    )
+    await this.deps.budgetRepo.setNonCriticalDisabled(yearMonth, true)
+  }
+
+  private async recordAudit(evaluation: BudgetEvaluation): Promise<void> {
+    const auditLogger = this.deps.auditLogger
+    if (!auditLogger) return
+    // clock は将来の時刻記録拡張のためのフック。現状は参照のみ。
+    const _now = this.deps.clock()
+    void _now
+    await auditLogger.emit({
+      userId: null,
+      action: 'AI_BUDGET_THRESHOLD_REACHED',
+      resourceType: 'SYSTEM_CONFIG',
+      resourceId: evaluation.yearMonth,
+      ipAddress: 'system',
+      userAgent: 'ai-budget-service',
+      before: null,
+      after: {
+        level: evaluation.level,
+        utilizationPct: evaluation.utilizationPct,
+        currentCostUsd: evaluation.currentCostUsd,
+        budgetUsd: evaluation.budgetUsd,
+      },
+    })
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Factory
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function createAIBudgetService(deps: {
+  costQuery: BudgetCostQueryPort
+  budgetRepo: AIBudgetRepository
+  flagStore: FeatureFlagStore
+  notifier: AIAlertNotifier
+  auditLogger?: BudgetAuditLogPort
+  nonCriticalFeatures?: readonly NonCriticalFeature[]
+  clock?: () => Date
+}): AIBudgetService {
+  return new DefaultAIBudgetService({
+    costQuery: deps.costQuery,
+    budgetRepo: deps.budgetRepo,
+    flagStore: deps.flagStore,
+    notifier: deps.notifier,
+    auditLogger: deps.auditLogger,
+    nonCriticalFeatures: deps.nonCriticalFeatures ?? NON_CRITICAL_FEATURES,
+    clock: deps.clock ?? (() => new Date()),
+  })
+}

--- a/src/lib/ai-monitoring/ai-budget-types.ts
+++ b/src/lib/ai-monitoring/ai-budget-types.ts
@@ -1,0 +1,85 @@
+/**
+ * AI 予算アラート / 非クリティカル機能停止 (Task 5.3)
+ *
+ * - 月次 AI 予算設定 (AIBudgetConfig) の型とスキーマ
+ * - 閾値到達時のアラートレベル
+ * - 予算 100% 到達時に停止する非クリティカル機能一覧
+ *
+ * 関連要件:
+ *   - Req 19.3: 月次AI利用コストが設定予算の 80% 到達で ADMIN に WARN アラート
+ *   - Req 19.4: 月次AI利用コストが設定予算の 100% 到達で ADMIN に CRITICAL アラート、
+ *               かつ非クリティカル機能 (要約生成 等) を一時停止
+ */
+import { z } from 'zod'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// YearMonth
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** YYYY-MM 形式 (例: "2026-04") */
+export const yearMonthSchema = z.string().regex(/^\d{4}-(0[1-9]|1[0-2])$/)
+export type YearMonth = z.infer<typeof yearMonthSchema>
+
+export function isYearMonth(value: unknown): value is YearMonth {
+  return yearMonthSchema.safeParse(value).success
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// AIBudgetConfig (design.md 1555-1561 に準拠)
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const aiBudgetConfigSchema = z.object({
+  yearMonth: yearMonthSchema,
+  /** 月次予算 (USD, 正の数) */
+  budgetUsd: z.number().positive(),
+  /** WARN 閾値 (%) */
+  warnThresholdPct: z.number().int().min(1).max(100).default(80),
+  /** CRITICAL 閾値 (%) — 超過時の挙動を許容するため 200% までとする */
+  criticalThresholdPct: z.number().int().min(1).max(200).default(100),
+  /** 非クリティカル機能が予算超過により停止されているか */
+  nonCriticalDisabled: z.boolean().default(false),
+})
+
+export type AIBudgetConfig = z.infer<typeof aiBudgetConfigSchema>
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Alert Level / Evaluation
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const ALERT_LEVELS = ['NONE', 'WARN', 'CRITICAL'] as const
+export type AlertLevel = (typeof ALERT_LEVELS)[number]
+
+export function isAlertLevel(value: unknown): value is AlertLevel {
+  return typeof value === 'string' && (ALERT_LEVELS as readonly string[]).includes(value)
+}
+
+export interface BudgetEvaluation {
+  readonly yearMonth: YearMonth
+  readonly currentCostUsd: number
+  readonly budgetUsd: number
+  readonly utilizationPct: number
+  readonly level: AlertLevel
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 非クリティカル機能フラグ (Req 19.4)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * 予算 100% 到達時に自動停止する非クリティカル機能一覧。
+ * 設計書の「非クリティカル機能（要約生成等）」の「等」を拡張可能にするため
+ * 配列で表現する。現状は FB 要約生成と変換を対象とするが、呼び出し側で
+ * オーバーライド可能 (AIBudgetService の nonCriticalFeatures 引数)。
+ */
+export const NON_CRITICAL_FEATURES = [
+  /** FB 要約生成 */
+  'FEEDBACK_SUMMARY',
+  /** FB マイルド化変換 */
+  'FEEDBACK_TRANSFORM',
+] as const
+
+export type NonCriticalFeature = (typeof NON_CRITICAL_FEATURES)[number]
+
+export function isNonCriticalFeature(value: unknown): value is NonCriticalFeature {
+  return typeof value === 'string' && (NON_CRITICAL_FEATURES as readonly string[]).includes(value)
+}

--- a/src/lib/ai-monitoring/feature-flag-store.ts
+++ b/src/lib/ai-monitoring/feature-flag-store.ts
@@ -1,0 +1,62 @@
+/**
+ * FeatureFlagStore — 非クリティカル AI 機能の ON/OFF を即時反映する薄いストア。
+ *
+ * 予算 100% 到達時に AIBudgetService が該当機能を disable() する。
+ * 復旧時 (予算再設定・月次リセット) に enable() で戻す。
+ *
+ * 関連要件: Req 19.4
+ */
+import type { NonCriticalFeature } from './ai-budget-types'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Interface
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface FeatureFlagStore {
+  /** 機能が有効 (= 停止されていない) か */
+  isEnabled(feature: NonCriticalFeature): Promise<boolean>
+  /** 機能を停止する (idempotent) */
+  disable(feature: NonCriticalFeature): Promise<void>
+  /** 機能を再有効化する (idempotent) */
+  enable(feature: NonCriticalFeature): Promise<void>
+  /** 現在停止中の機能一覧 */
+  listDisabled(): Promise<readonly NonCriticalFeature[]>
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// In-memory implementation
+// ─────────────────────────────────────────────────────────────────────────────
+
+class InMemoryFeatureFlagStore implements FeatureFlagStore {
+  private readonly disabled: Set<NonCriticalFeature>
+
+  constructor(seed: readonly NonCriticalFeature[] = []) {
+    this.disabled = new Set(seed)
+  }
+
+  async isEnabled(feature: NonCriticalFeature): Promise<boolean> {
+    return !this.disabled.has(feature)
+  }
+
+  async disable(feature: NonCriticalFeature): Promise<void> {
+    this.disabled.add(feature)
+  }
+
+  async enable(feature: NonCriticalFeature): Promise<void> {
+    this.disabled.delete(feature)
+  }
+
+  async listDisabled(): Promise<readonly NonCriticalFeature[]> {
+    return [...this.disabled]
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Factory
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function createInMemoryFeatureFlagStore(
+  seed?: readonly NonCriticalFeature[],
+): FeatureFlagStore {
+  return new InMemoryFeatureFlagStore(seed)
+}

--- a/src/tests/ai-monitoring/ai-alert-notifier.test.ts
+++ b/src/tests/ai-monitoring/ai-alert-notifier.test.ts
@@ -1,0 +1,267 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import {
+  createNotificationEmitterAlertNotifier,
+  type AlertNotificationEmitterPort,
+} from '@/lib/ai-monitoring/ai-alert-notifier'
+
+interface EmitterMock extends AlertNotificationEmitterPort {
+  emit: ReturnType<typeof vi.fn>
+}
+
+function makeEmitterMock(): EmitterMock {
+  return {
+    emit: vi.fn().mockResolvedValue(undefined),
+  }
+}
+
+describe('createNotificationEmitterAlertNotifier', () => {
+  let emitter: EmitterMock
+
+  beforeEach(() => {
+    emitter = makeEmitterMock()
+  })
+
+  it('emits to every ADMIN user', async () => {
+    const notifier = createNotificationEmitterAlertNotifier({
+      emitter,
+      adminUserIdsProvider: async () => ['admin-1', 'admin-2', 'admin-3'],
+    })
+
+    await notifier.notify({
+      yearMonth: '2026-04',
+      level: 'WARN',
+      currentCostUsd: 80,
+      budgetUsd: 100,
+      utilizationPct: 80,
+    })
+
+    expect(emitter.emit).toHaveBeenCalledTimes(3)
+    const userIds = emitter.emit.mock.calls.map((c) => c[0].userId).sort()
+    expect(userIds).toEqual(['admin-1', 'admin-2', 'admin-3'])
+  })
+
+  it('is idempotent for the same (yearMonth, level) pair', async () => {
+    const notifier = createNotificationEmitterAlertNotifier({
+      emitter,
+      adminUserIdsProvider: async () => ['admin-1'],
+    })
+
+    await notifier.notify({
+      yearMonth: '2026-04',
+      level: 'WARN',
+      currentCostUsd: 80,
+      budgetUsd: 100,
+      utilizationPct: 80,
+    })
+    await notifier.notify({
+      yearMonth: '2026-04',
+      level: 'WARN',
+      currentCostUsd: 85,
+      budgetUsd: 100,
+      utilizationPct: 85,
+    })
+
+    expect(emitter.emit).toHaveBeenCalledTimes(1)
+  })
+
+  it('does NOT dedupe across different levels', async () => {
+    const notifier = createNotificationEmitterAlertNotifier({
+      emitter,
+      adminUserIdsProvider: async () => ['admin-1'],
+    })
+
+    await notifier.notify({
+      yearMonth: '2026-04',
+      level: 'WARN',
+      currentCostUsd: 80,
+      budgetUsd: 100,
+      utilizationPct: 80,
+    })
+    await notifier.notify({
+      yearMonth: '2026-04',
+      level: 'CRITICAL',
+      currentCostUsd: 100,
+      budgetUsd: 100,
+      utilizationPct: 100,
+    })
+
+    expect(emitter.emit).toHaveBeenCalledTimes(2)
+  })
+
+  it('does NOT dedupe across different yearMonths', async () => {
+    const notifier = createNotificationEmitterAlertNotifier({
+      emitter,
+      adminUserIdsProvider: async () => ['admin-1'],
+    })
+
+    await notifier.notify({
+      yearMonth: '2026-04',
+      level: 'WARN',
+      currentCostUsd: 80,
+      budgetUsd: 100,
+      utilizationPct: 80,
+    })
+    await notifier.notify({
+      yearMonth: '2026-05',
+      level: 'WARN',
+      currentCostUsd: 85,
+      budgetUsd: 100,
+      utilizationPct: 85,
+    })
+
+    expect(emitter.emit).toHaveBeenCalledTimes(2)
+  })
+
+  it('uses different titles for WARN and CRITICAL', async () => {
+    const notifier = createNotificationEmitterAlertNotifier({
+      emitter,
+      adminUserIdsProvider: async () => ['admin-1'],
+    })
+
+    await notifier.notify({
+      yearMonth: '2026-04',
+      level: 'WARN',
+      currentCostUsd: 80,
+      budgetUsd: 100,
+      utilizationPct: 80,
+    })
+    await notifier.notify({
+      yearMonth: '2026-04',
+      level: 'CRITICAL',
+      currentCostUsd: 100,
+      budgetUsd: 100,
+      utilizationPct: 100,
+    })
+
+    const titles = emitter.emit.mock.calls.map((c) => c[0].title as string)
+    expect(titles[0]).toContain('WARN')
+    expect(titles[1]).toContain('CRITICAL')
+    expect(titles[0]).not.toEqual(titles[1])
+  })
+
+  it('uses different bodies for WARN and CRITICAL', async () => {
+    const notifier = createNotificationEmitterAlertNotifier({
+      emitter,
+      adminUserIdsProvider: async () => ['admin-1'],
+    })
+
+    await notifier.notify({
+      yearMonth: '2026-04',
+      level: 'WARN',
+      currentCostUsd: 80,
+      budgetUsd: 100,
+      utilizationPct: 80,
+    })
+    await notifier.notify({
+      yearMonth: '2026-04',
+      level: 'CRITICAL',
+      currentCostUsd: 100,
+      budgetUsd: 100,
+      utilizationPct: 100,
+    })
+
+    const calls = emitter.emit.mock.calls
+    const warnCall = calls[0]
+    const critCall = calls[1]
+    if (!warnCall || !critCall) throw new Error('expected 2 emit calls')
+    expect(warnCall[0].body).not.toEqual(critCall[0].body)
+    // CRITICAL body should mention the auto-disable behavior.
+    expect(critCall[0].body).toContain('一時停止')
+  })
+
+  it('emits SYSTEM category with numeric payload', async () => {
+    const notifier = createNotificationEmitterAlertNotifier({
+      emitter,
+      adminUserIdsProvider: async () => ['admin-1'],
+    })
+
+    await notifier.notify({
+      yearMonth: '2026-04',
+      level: 'CRITICAL',
+      currentCostUsd: 100,
+      budgetUsd: 100,
+      utilizationPct: 100,
+    })
+
+    expect(emitter.emit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'admin-1',
+        category: 'SYSTEM',
+        payload: expect.objectContaining({
+          yearMonth: '2026-04',
+          level: 'CRITICAL',
+          utilizationPct: 100,
+        }),
+      }),
+    )
+  })
+
+  it('skips gracefully when there are no ADMIN users (but marks key as sent)', async () => {
+    const notifier = createNotificationEmitterAlertNotifier({
+      emitter,
+      adminUserIdsProvider: async () => [],
+    })
+
+    await notifier.notify({
+      yearMonth: '2026-04',
+      level: 'WARN',
+      currentCostUsd: 80,
+      budgetUsd: 100,
+      utilizationPct: 80,
+    })
+    // A second call for the same key should also skip (idempotent record).
+    await notifier.notify({
+      yearMonth: '2026-04',
+      level: 'WARN',
+      currentCostUsd: 80,
+      budgetUsd: 100,
+      utilizationPct: 80,
+    })
+    expect(emitter.emit).not.toHaveBeenCalled()
+  })
+
+  it('allows retry when all ADMIN emits fail (no key persisted)', async () => {
+    emitter.emit.mockRejectedValue(new Error('boom'))
+    const notifier = createNotificationEmitterAlertNotifier({
+      emitter,
+      adminUserIdsProvider: async () => ['admin-1'],
+    })
+
+    await notifier.notify({
+      yearMonth: '2026-04',
+      level: 'WARN',
+      currentCostUsd: 80,
+      budgetUsd: 100,
+      utilizationPct: 80,
+    })
+    // Since all emits failed, the next call should retry.
+    await notifier.notify({
+      yearMonth: '2026-04',
+      level: 'WARN',
+      currentCostUsd: 80,
+      budgetUsd: 100,
+      utilizationPct: 80,
+    })
+
+    expect(emitter.emit).toHaveBeenCalledTimes(2)
+  })
+
+  it('respects an external sentRecord to seed state', async () => {
+    const externalRecord = new Set<string>(['2026-04:WARN'])
+    const notifier = createNotificationEmitterAlertNotifier({
+      emitter,
+      adminUserIdsProvider: async () => ['admin-1'],
+      sentRecord: externalRecord,
+    })
+
+    await notifier.notify({
+      yearMonth: '2026-04',
+      level: 'WARN',
+      currentCostUsd: 80,
+      budgetUsd: 100,
+      utilizationPct: 80,
+    })
+
+    expect(emitter.emit).not.toHaveBeenCalled()
+  })
+})

--- a/src/tests/ai-monitoring/ai-budget-repository.test.ts
+++ b/src/tests/ai-monitoring/ai-budget-repository.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest'
+import { createInMemoryAIBudgetRepository } from '@/lib/ai-monitoring/ai-budget-repository'
+import type { AIBudgetConfig } from '@/lib/ai-monitoring/ai-budget-types'
+
+function makeConfig(overrides: Partial<AIBudgetConfig> = {}): AIBudgetConfig {
+  return {
+    yearMonth: '2026-04',
+    budgetUsd: 100,
+    warnThresholdPct: 80,
+    criticalThresholdPct: 100,
+    nonCriticalDisabled: false,
+    ...overrides,
+  }
+}
+
+describe('createInMemoryAIBudgetRepository', () => {
+  it('returns null for unknown yearMonth', async () => {
+    const repo = createInMemoryAIBudgetRepository()
+    expect(await repo.get('2026-04')).toBeNull()
+  })
+
+  it('seeds initial configs', async () => {
+    const repo = createInMemoryAIBudgetRepository([makeConfig({ yearMonth: '2026-04' })])
+    const fetched = await repo.get('2026-04')
+    expect(fetched).not.toBeNull()
+    expect(fetched?.budgetUsd).toBe(100)
+  })
+
+  it('upsert inserts when absent', async () => {
+    const repo = createInMemoryAIBudgetRepository()
+    const saved = await repo.upsert(makeConfig({ yearMonth: '2026-04', budgetUsd: 250 }))
+    expect(saved.budgetUsd).toBe(250)
+    const fetched = await repo.get('2026-04')
+    expect(fetched?.budgetUsd).toBe(250)
+  })
+
+  it('upsert overwrites when present', async () => {
+    const repo = createInMemoryAIBudgetRepository([makeConfig({ budgetUsd: 100 })])
+    await repo.upsert(makeConfig({ budgetUsd: 500 }))
+    const fetched = await repo.get('2026-04')
+    expect(fetched?.budgetUsd).toBe(500)
+  })
+
+  it('setNonCriticalDisabled updates flag for existing config', async () => {
+    const repo = createInMemoryAIBudgetRepository([makeConfig()])
+    await repo.setNonCriticalDisabled('2026-04', true)
+    const fetched = await repo.get('2026-04')
+    expect(fetched?.nonCriticalDisabled).toBe(true)
+
+    await repo.setNonCriticalDisabled('2026-04', false)
+    const fetched2 = await repo.get('2026-04')
+    expect(fetched2?.nonCriticalDisabled).toBe(false)
+  })
+
+  it('setNonCriticalDisabled is a no-op when config is absent', async () => {
+    const repo = createInMemoryAIBudgetRepository()
+    await repo.setNonCriticalDisabled('2026-04', true)
+    expect(await repo.get('2026-04')).toBeNull()
+  })
+
+  it('rejects invalid yearMonth via schema', async () => {
+    const repo = createInMemoryAIBudgetRepository()
+    await expect(repo.get('2026-13' as unknown as '2026-04')).rejects.toThrow()
+  })
+
+  it('rejects invalid seed config via schema', () => {
+    expect(() => createInMemoryAIBudgetRepository([{ ...makeConfig(), budgetUsd: -1 }])).toThrow()
+  })
+})

--- a/src/tests/ai-monitoring/ai-budget-service.test.ts
+++ b/src/tests/ai-monitoring/ai-budget-service.test.ts
@@ -1,0 +1,331 @@
+import { describe, it, expect, vi } from 'vitest'
+import type { AIAlertNotifier } from '@/lib/ai-monitoring/ai-alert-notifier'
+import { createInMemoryAIBudgetRepository } from '@/lib/ai-monitoring/ai-budget-repository'
+import {
+  AIBudgetNotConfiguredError,
+  createAIBudgetService,
+  type BudgetAuditLogPort,
+  type BudgetCostQueryPort,
+} from '@/lib/ai-monitoring/ai-budget-service'
+import type { AIBudgetConfig } from '@/lib/ai-monitoring/ai-budget-types'
+import { createInMemoryFeatureFlagStore } from '@/lib/ai-monitoring/feature-flag-store'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+function makeConfig(overrides: Partial<AIBudgetConfig> = {}): AIBudgetConfig {
+  return {
+    yearMonth: '2026-04',
+    budgetUsd: 100,
+    warnThresholdPct: 80,
+    criticalThresholdPct: 100,
+    nonCriticalDisabled: false,
+    ...overrides,
+  }
+}
+
+function makeNotifierMock(): AIAlertNotifier & { notify: ReturnType<typeof vi.fn> } {
+  return {
+    notify: vi.fn().mockResolvedValue(undefined),
+  }
+}
+
+function makeAuditMock(): BudgetAuditLogPort & { emit: ReturnType<typeof vi.fn> } {
+  return {
+    emit: vi.fn().mockResolvedValue(undefined),
+  }
+}
+
+function makeCostQuery(cost: number): BudgetCostQueryPort {
+  return { getMonthlyCostUsd: vi.fn().mockResolvedValue(cost) }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// evaluate()
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('AIBudgetService.evaluate', () => {
+  it('returns NONE when utilization is below WARN threshold', async () => {
+    const service = createAIBudgetService({
+      costQuery: makeCostQuery(50),
+      budgetRepo: createInMemoryAIBudgetRepository([makeConfig()]),
+      flagStore: createInMemoryFeatureFlagStore(),
+      notifier: makeNotifierMock(),
+    })
+    const result = await service.evaluate('2026-04')
+    expect(result.level).toBe('NONE')
+    expect(result.utilizationPct).toBe(50)
+    expect(result.currentCostUsd).toBe(50)
+    expect(result.budgetUsd).toBe(100)
+  })
+
+  it('returns WARN when utilization meets warn threshold but below critical', async () => {
+    const service = createAIBudgetService({
+      costQuery: makeCostQuery(80),
+      budgetRepo: createInMemoryAIBudgetRepository([makeConfig()]),
+      flagStore: createInMemoryFeatureFlagStore(),
+      notifier: makeNotifierMock(),
+    })
+    const result = await service.evaluate('2026-04')
+    expect(result.level).toBe('WARN')
+    expect(result.utilizationPct).toBe(80)
+  })
+
+  it('returns WARN when utilization is between warn and critical', async () => {
+    const service = createAIBudgetService({
+      costQuery: makeCostQuery(95),
+      budgetRepo: createInMemoryAIBudgetRepository([makeConfig()]),
+      flagStore: createInMemoryFeatureFlagStore(),
+      notifier: makeNotifierMock(),
+    })
+    const result = await service.evaluate('2026-04')
+    expect(result.level).toBe('WARN')
+  })
+
+  it('returns CRITICAL exactly at 100% (boundary)', async () => {
+    const service = createAIBudgetService({
+      costQuery: makeCostQuery(100),
+      budgetRepo: createInMemoryAIBudgetRepository([makeConfig()]),
+      flagStore: createInMemoryFeatureFlagStore(),
+      notifier: makeNotifierMock(),
+    })
+    const result = await service.evaluate('2026-04')
+    expect(result.level).toBe('CRITICAL')
+    expect(result.utilizationPct).toBe(100)
+  })
+
+  it('returns CRITICAL when utilization exceeds 100%', async () => {
+    const service = createAIBudgetService({
+      costQuery: makeCostQuery(120),
+      budgetRepo: createInMemoryAIBudgetRepository([makeConfig()]),
+      flagStore: createInMemoryFeatureFlagStore(),
+      notifier: makeNotifierMock(),
+    })
+    const result = await service.evaluate('2026-04')
+    expect(result.level).toBe('CRITICAL')
+    expect(result.utilizationPct).toBe(120)
+  })
+
+  it('throws AIBudgetNotConfiguredError when budget is absent', async () => {
+    const service = createAIBudgetService({
+      costQuery: makeCostQuery(50),
+      budgetRepo: createInMemoryAIBudgetRepository(),
+      flagStore: createInMemoryFeatureFlagStore(),
+      notifier: makeNotifierMock(),
+    })
+    await expect(service.evaluate('2026-04')).rejects.toBeInstanceOf(AIBudgetNotConfiguredError)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// checkAndAlert()
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('AIBudgetService.checkAndAlert', () => {
+  it('does NOT notify or disable features when level is NONE', async () => {
+    const notifier = makeNotifierMock()
+    const flagStore = createInMemoryFeatureFlagStore()
+    const service = createAIBudgetService({
+      costQuery: makeCostQuery(50),
+      budgetRepo: createInMemoryAIBudgetRepository([makeConfig()]),
+      flagStore,
+      notifier,
+    })
+
+    const result = await service.checkAndAlert('2026-04')
+    expect(result.level).toBe('NONE')
+    expect(notifier.notify).not.toHaveBeenCalled()
+    expect(await flagStore.isEnabled('FEEDBACK_SUMMARY')).toBe(true)
+    expect(await flagStore.isEnabled('FEEDBACK_TRANSFORM')).toBe(true)
+  })
+
+  it('notifies but does NOT disable features on WARN', async () => {
+    const notifier = makeNotifierMock()
+    const flagStore = createInMemoryFeatureFlagStore()
+    const budgetRepo = createInMemoryAIBudgetRepository([makeConfig()])
+    const service = createAIBudgetService({
+      costQuery: makeCostQuery(80),
+      budgetRepo,
+      flagStore,
+      notifier,
+    })
+
+    const result = await service.checkAndAlert('2026-04')
+    expect(result.level).toBe('WARN')
+    expect(notifier.notify).toHaveBeenCalledTimes(1)
+    expect(notifier.notify).toHaveBeenCalledWith(
+      expect.objectContaining({ level: 'WARN', yearMonth: '2026-04' }),
+    )
+    expect(await flagStore.isEnabled('FEEDBACK_SUMMARY')).toBe(true)
+    expect(await flagStore.isEnabled('FEEDBACK_TRANSFORM')).toBe(true)
+    const config = await budgetRepo.get('2026-04')
+    expect(config?.nonCriticalDisabled).toBe(false)
+  })
+
+  it('notifies AND disables all NON_CRITICAL_FEATURES on CRITICAL', async () => {
+    const notifier = makeNotifierMock()
+    const flagStore = createInMemoryFeatureFlagStore()
+    const budgetRepo = createInMemoryAIBudgetRepository([makeConfig()])
+    const service = createAIBudgetService({
+      costQuery: makeCostQuery(100),
+      budgetRepo,
+      flagStore,
+      notifier,
+    })
+
+    const result = await service.checkAndAlert('2026-04')
+    expect(result.level).toBe('CRITICAL')
+    expect(notifier.notify).toHaveBeenCalledTimes(1)
+    expect(await flagStore.isEnabled('FEEDBACK_SUMMARY')).toBe(false)
+    expect(await flagStore.isEnabled('FEEDBACK_TRANSFORM')).toBe(false)
+    const config = await budgetRepo.get('2026-04')
+    expect(config?.nonCriticalDisabled).toBe(true)
+  })
+
+  it('only disables the custom nonCriticalFeatures subset when provided', async () => {
+    const notifier = makeNotifierMock()
+    const flagStore = createInMemoryFeatureFlagStore()
+    const service = createAIBudgetService({
+      costQuery: makeCostQuery(100),
+      budgetRepo: createInMemoryAIBudgetRepository([makeConfig()]),
+      flagStore,
+      notifier,
+      nonCriticalFeatures: ['FEEDBACK_SUMMARY'],
+    })
+
+    await service.checkAndAlert('2026-04')
+    expect(await flagStore.isEnabled('FEEDBACK_SUMMARY')).toBe(false)
+    expect(await flagStore.isEnabled('FEEDBACK_TRANSFORM')).toBe(true)
+  })
+
+  it('throws AIBudgetNotConfiguredError when budget is absent', async () => {
+    const service = createAIBudgetService({
+      costQuery: makeCostQuery(50),
+      budgetRepo: createInMemoryAIBudgetRepository(),
+      flagStore: createInMemoryFeatureFlagStore(),
+      notifier: makeNotifierMock(),
+    })
+    await expect(service.checkAndAlert('2026-04')).rejects.toBeInstanceOf(
+      AIBudgetNotConfiguredError,
+    )
+  })
+
+  it('is idempotent: notifier receives each (yearMonth, level) only once across repeated calls', async () => {
+    // Notifier side is the source of truth for idempotency (per design). We
+    // simulate a real notifier that dedupes by (yearMonth, level) pair and
+    // assert the service triggers exactly one emission.
+    const sentRecord = new Set<string>()
+    const emitted: string[] = []
+    const notifier: AIAlertNotifier = {
+      notify: async (params) => {
+        const key = `${params.yearMonth}:${params.level}`
+        if (sentRecord.has(key)) return
+        sentRecord.add(key)
+        emitted.push(key)
+      },
+    }
+
+    const service = createAIBudgetService({
+      costQuery: makeCostQuery(80),
+      budgetRepo: createInMemoryAIBudgetRepository([makeConfig()]),
+      flagStore: createInMemoryFeatureFlagStore(),
+      notifier,
+    })
+
+    await service.checkAndAlert('2026-04')
+    await service.checkAndAlert('2026-04')
+    expect(emitted).toEqual(['2026-04:WARN'])
+  })
+
+  it('records an audit entry with AI_BUDGET_THRESHOLD_REACHED on CRITICAL', async () => {
+    const audit = makeAuditMock()
+    const service = createAIBudgetService({
+      costQuery: makeCostQuery(100),
+      budgetRepo: createInMemoryAIBudgetRepository([makeConfig()]),
+      flagStore: createInMemoryFeatureFlagStore(),
+      notifier: makeNotifierMock(),
+      auditLogger: audit,
+    })
+
+    await service.checkAndAlert('2026-04')
+    expect(audit.emit).toHaveBeenCalledTimes(1)
+    expect(audit.emit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'AI_BUDGET_THRESHOLD_REACHED',
+        resourceType: 'SYSTEM_CONFIG',
+        resourceId: '2026-04',
+        after: expect.objectContaining({
+          level: 'CRITICAL',
+          utilizationPct: 100,
+          currentCostUsd: 100,
+          budgetUsd: 100,
+        }),
+      }),
+    )
+  })
+
+  it('does not record audit when level is NONE', async () => {
+    const audit = makeAuditMock()
+    const service = createAIBudgetService({
+      costQuery: makeCostQuery(10),
+      budgetRepo: createInMemoryAIBudgetRepository([makeConfig()]),
+      flagStore: createInMemoryFeatureFlagStore(),
+      notifier: makeNotifierMock(),
+      auditLogger: audit,
+    })
+
+    await service.checkAndAlert('2026-04')
+    expect(audit.emit).not.toHaveBeenCalled()
+  })
+
+  it('uses injected clock when recording audit (smoke test)', async () => {
+    const fixedDate = new Date('2026-04-15T09:00:00Z')
+    const clock = vi.fn(() => fixedDate)
+    const audit = makeAuditMock()
+    const service = createAIBudgetService({
+      costQuery: makeCostQuery(100),
+      budgetRepo: createInMemoryAIBudgetRepository([makeConfig()]),
+      flagStore: createInMemoryFeatureFlagStore(),
+      notifier: makeNotifierMock(),
+      auditLogger: audit,
+      clock,
+    })
+
+    await service.checkAndAlert('2026-04')
+    expect(clock).toHaveBeenCalled()
+    expect(audit.emit).toHaveBeenCalled()
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// upsertBudget()
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('AIBudgetService.upsertBudget', () => {
+  it('persists the config and returns the parsed value', async () => {
+    const budgetRepo = createInMemoryAIBudgetRepository()
+    const service = createAIBudgetService({
+      costQuery: makeCostQuery(0),
+      budgetRepo,
+      flagStore: createInMemoryFeatureFlagStore(),
+      notifier: makeNotifierMock(),
+    })
+
+    const saved = await service.upsertBudget(makeConfig({ budgetUsd: 300 }))
+    expect(saved.budgetUsd).toBe(300)
+    const fetched = await budgetRepo.get('2026-04')
+    expect(fetched?.budgetUsd).toBe(300)
+  })
+
+  it('rejects invalid config via schema', async () => {
+    const service = createAIBudgetService({
+      costQuery: makeCostQuery(0),
+      budgetRepo: createInMemoryAIBudgetRepository(),
+      flagStore: createInMemoryFeatureFlagStore(),
+      notifier: makeNotifierMock(),
+    })
+
+    await expect(service.upsertBudget({ ...makeConfig(), budgetUsd: -1 })).rejects.toThrow()
+  })
+})

--- a/src/tests/ai-monitoring/ai-budget-types.test.ts
+++ b/src/tests/ai-monitoring/ai-budget-types.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from 'vitest'
+import {
+  ALERT_LEVELS,
+  NON_CRITICAL_FEATURES,
+  aiBudgetConfigSchema,
+  isAlertLevel,
+  isNonCriticalFeature,
+  isYearMonth,
+  yearMonthSchema,
+} from '@/lib/ai-monitoring/ai-budget-types'
+
+describe('yearMonthSchema', () => {
+  it('accepts YYYY-MM format', () => {
+    expect(yearMonthSchema.parse('2026-04')).toBe('2026-04')
+    expect(yearMonthSchema.parse('1999-12')).toBe('1999-12')
+    expect(yearMonthSchema.parse('2026-01')).toBe('2026-01')
+  })
+
+  it('rejects invalid formats', () => {
+    expect(() => yearMonthSchema.parse('2026-13')).toThrow()
+    expect(() => yearMonthSchema.parse('2026-00')).toThrow()
+    expect(() => yearMonthSchema.parse('26-04')).toThrow()
+    expect(() => yearMonthSchema.parse('2026/04')).toThrow()
+    expect(() => yearMonthSchema.parse('2026-4')).toThrow()
+    expect(() => yearMonthSchema.parse('')).toThrow()
+  })
+
+  it('isYearMonth narrows unknown input', () => {
+    expect(isYearMonth('2026-04')).toBe(true)
+    expect(isYearMonth('not-a-month')).toBe(false)
+    expect(isYearMonth(202604)).toBe(false)
+    expect(isYearMonth(null)).toBe(false)
+  })
+})
+
+describe('aiBudgetConfigSchema', () => {
+  it('accepts a valid config and applies defaults', () => {
+    const parsed = aiBudgetConfigSchema.parse({
+      yearMonth: '2026-04',
+      budgetUsd: 100,
+    })
+    expect(parsed.budgetUsd).toBe(100)
+    expect(parsed.warnThresholdPct).toBe(80)
+    expect(parsed.criticalThresholdPct).toBe(100)
+    expect(parsed.nonCriticalDisabled).toBe(false)
+  })
+
+  it('accepts custom thresholds', () => {
+    const parsed = aiBudgetConfigSchema.parse({
+      yearMonth: '2026-04',
+      budgetUsd: 50.5,
+      warnThresholdPct: 70,
+      criticalThresholdPct: 90,
+      nonCriticalDisabled: true,
+    })
+    expect(parsed.warnThresholdPct).toBe(70)
+    expect(parsed.criticalThresholdPct).toBe(90)
+    expect(parsed.nonCriticalDisabled).toBe(true)
+  })
+
+  it('rejects non-positive budgetUsd', () => {
+    expect(() => aiBudgetConfigSchema.parse({ yearMonth: '2026-04', budgetUsd: 0 })).toThrow()
+    expect(() => aiBudgetConfigSchema.parse({ yearMonth: '2026-04', budgetUsd: -1 })).toThrow()
+  })
+
+  it('rejects threshold out of range', () => {
+    expect(() =>
+      aiBudgetConfigSchema.parse({
+        yearMonth: '2026-04',
+        budgetUsd: 100,
+        warnThresholdPct: 0,
+      }),
+    ).toThrow()
+    expect(() =>
+      aiBudgetConfigSchema.parse({
+        yearMonth: '2026-04',
+        budgetUsd: 100,
+        warnThresholdPct: 101,
+      }),
+    ).toThrow()
+    expect(() =>
+      aiBudgetConfigSchema.parse({
+        yearMonth: '2026-04',
+        budgetUsd: 100,
+        criticalThresholdPct: 201,
+      }),
+    ).toThrow()
+  })
+
+  it('rejects invalid yearMonth', () => {
+    expect(() => aiBudgetConfigSchema.parse({ yearMonth: '2026-13', budgetUsd: 100 })).toThrow()
+  })
+})
+
+describe('AlertLevel constants', () => {
+  it('contains NONE / WARN / CRITICAL', () => {
+    expect(ALERT_LEVELS).toEqual(['NONE', 'WARN', 'CRITICAL'])
+  })
+
+  it('isAlertLevel narrows unknown input', () => {
+    expect(isAlertLevel('NONE')).toBe(true)
+    expect(isAlertLevel('WARN')).toBe(true)
+    expect(isAlertLevel('CRITICAL')).toBe(true)
+    expect(isAlertLevel('INFO')).toBe(false)
+    expect(isAlertLevel(undefined)).toBe(false)
+  })
+})
+
+describe('NON_CRITICAL_FEATURES constants', () => {
+  it('contains FEEDBACK_SUMMARY and FEEDBACK_TRANSFORM', () => {
+    expect(NON_CRITICAL_FEATURES).toContain('FEEDBACK_SUMMARY')
+    expect(NON_CRITICAL_FEATURES).toContain('FEEDBACK_TRANSFORM')
+  })
+
+  it('isNonCriticalFeature narrows unknown input', () => {
+    expect(isNonCriticalFeature('FEEDBACK_SUMMARY')).toBe(true)
+    expect(isNonCriticalFeature('UNKNOWN_FEATURE')).toBe(false)
+    expect(isNonCriticalFeature(42)).toBe(false)
+  })
+})

--- a/src/tests/ai-monitoring/feature-flag-store.test.ts
+++ b/src/tests/ai-monitoring/feature-flag-store.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest'
+import { createInMemoryFeatureFlagStore } from '@/lib/ai-monitoring/feature-flag-store'
+
+describe('createInMemoryFeatureFlagStore', () => {
+  it('defaults all features to enabled when no seed', async () => {
+    const store = createInMemoryFeatureFlagStore()
+    expect(await store.isEnabled('FEEDBACK_SUMMARY')).toBe(true)
+    expect(await store.isEnabled('FEEDBACK_TRANSFORM')).toBe(true)
+    expect(await store.listDisabled()).toEqual([])
+  })
+
+  it('accepts seed of initially-disabled features', async () => {
+    const store = createInMemoryFeatureFlagStore(['FEEDBACK_SUMMARY'])
+    expect(await store.isEnabled('FEEDBACK_SUMMARY')).toBe(false)
+    expect(await store.isEnabled('FEEDBACK_TRANSFORM')).toBe(true)
+  })
+
+  it('disable() flips a feature off and is idempotent', async () => {
+    const store = createInMemoryFeatureFlagStore()
+    await store.disable('FEEDBACK_SUMMARY')
+    expect(await store.isEnabled('FEEDBACK_SUMMARY')).toBe(false)
+
+    // Idempotent: second call does not throw or flip state.
+    await store.disable('FEEDBACK_SUMMARY')
+    expect(await store.isEnabled('FEEDBACK_SUMMARY')).toBe(false)
+  })
+
+  it('enable() flips a feature on and is idempotent', async () => {
+    const store = createInMemoryFeatureFlagStore(['FEEDBACK_SUMMARY'])
+    await store.enable('FEEDBACK_SUMMARY')
+    expect(await store.isEnabled('FEEDBACK_SUMMARY')).toBe(true)
+
+    // Idempotent.
+    await store.enable('FEEDBACK_SUMMARY')
+    expect(await store.isEnabled('FEEDBACK_SUMMARY')).toBe(true)
+  })
+
+  it('listDisabled returns all currently disabled features', async () => {
+    const store = createInMemoryFeatureFlagStore()
+    await store.disable('FEEDBACK_SUMMARY')
+    await store.disable('FEEDBACK_TRANSFORM')
+    const disabled = await store.listDisabled()
+    expect([...disabled].sort()).toEqual(['FEEDBACK_SUMMARY', 'FEEDBACK_TRANSFORM'])
+
+    await store.enable('FEEDBACK_TRANSFORM')
+    const remaining = await store.listDisabled()
+    expect(remaining).toEqual(['FEEDBACK_SUMMARY'])
+  })
+})


### PR DESCRIPTION
## Summary
Task 5.3 (Issue #17) の実装。月次 AI 利用コストが設定予算の **80% / 100%** 閾値に到達した際に ADMIN へアラートを送信し、100% 到達時には **非クリティカル機能 (要約生成 等) を自動停止** する仕組みを追加します。

- **AIBudgetConfig** の Zod スキーマ / 型 (design.md 1555-1561 準拠)
- **AIBudgetRepository** (インメモリ実装) — get / upsert / setNonCriticalDisabled
- **FeatureFlagStore** (インメモリ実装) — isEnabled / disable / enable / listDisabled
- **AIAlertNotifier** — NotificationEmitter ベース、(yearMonth, level) 単位で冪等、WARN/CRITICAL で別文面
- **AIBudgetService** — 閾値評価 (NONE / WARN / CRITICAL、100% ぴったり → CRITICAL) → ADMIN 通知 → CRITICAL 時に非クリティカル機能を一括停止 → 監査ログ記録
  - **narrow `BudgetCostQueryPort`** を定義して Task 5.2 (`AIMonitoringService`) から独立させています (本番配線時に `getMonthlyCost()` を包むアダプタで DI)
  - Audit ログも narrow `BudgetAuditLogPort` 経由 (既存 `AuditAction` enum に `AI_BUDGET_THRESHOLD_REACHED` を追加する変更は別タスクに分離)

## Requirements マッピング
- **Req 19.3**: 月次AI利用コストが設定予算の 80% 到達時に ADMIN へ WARN アラート
  → `AIBudgetService.checkAndAlert` が `level = WARN` で `AIAlertNotifier.notify` を呼び、WARN 専用の title/body で ADMIN 全員へ emit
- **Req 19.4**: 月次AI利用コストが設定予算の 100% 到達時に ADMIN へ CRITICAL アラートを送信し、非クリティカル機能を一時停止
  → `level = CRITICAL` で CRITICAL 文面でのアラート送信に加え、`NON_CRITICAL_FEATURES` (FEEDBACK_SUMMARY / FEEDBACK_TRANSFORM) を `FeatureFlagStore.disable` し、`AIBudgetRepository.setNonCriticalDisabled(true)` で永続化

## 設計メモ
- AIMonitoringService への依存は **narrow port (`BudgetCostQueryPort`)** で隔離し、Task 5.2 マージ後に配線します (本 PR では未配線)。
- アラートの冪等性は `sentRecord: Set<"yearMonth:level">` で担保。本番では Redis / DB 実装へ差し替え可能。
- 非クリティカル機能リストは `NON_CRITICAL_FEATURES` 配列で拡張可能。呼び出し側から `nonCriticalFeatures` 引数で上書きも可能。

## スコープ外 (本タスクでは扱わない)
- Prisma での `AIBudgetConfig` モデル実装 (DB マイグレーションは別タスク)
- 予算設定 UI 画面
- Task 5.2 の `AIMonitoringService` 本体 (並列 PR #16)
- Task 5.4 のダッシュボード (並列 PR #18)
- 閾値検査用の cron job (別タスク)
- 既存 `AuditAction` enum への `AI_BUDGET_THRESHOLD_REACHED` 追加 (narrow port で緩和中)

## テスト結果
- **52 tests passed** (5 ファイル)
  - `ai-budget-types.test.ts` — 12 tests
  - `ai-budget-repository.test.ts` — 8 tests
  - `feature-flag-store.test.ts` — 5 tests
  - `ai-alert-notifier.test.ts` — 10 tests
  - `ai-budget-service.test.ts` — 17 tests
- **Coverage: `src/lib/ai-monitoring/` = 100%** (statements / branches / functions / lines 全 100%)
- `pnpm lint`: ✓ No ESLint warnings or errors
- `pnpm type-check`: ✓ 本タスク追加分はエラーなし (pre-existing な Prisma 関連エラーは本タスク範囲外)

## Test plan
- [x] `pnpm test -- src/tests/ai-monitoring/` が全テスト成功
- [x] `pnpm test:coverage -- src/tests/ai-monitoring/` で `src/lib/ai-monitoring/` 全ファイル 100%
- [x] `pnpm lint` クリーン
- [x] `pnpm type-check` で本タスク追加ファイルのエラーなし
- [ ] Task 5.2 マージ後、`AIMonitoringService.getMonthlyCost()` を `BudgetCostQueryPort` に配線
- [ ] 閾値検査 cron job (別タスク) から `AIBudgetService.checkAndAlert(currentYearMonth)` を定期呼び出し
- [ ] Prisma 実装の `AIBudgetRepository` 追加 (DB マイグレーション別タスク)
- [ ] 既存 `AuditAction` enum に `AI_BUDGET_THRESHOLD_REACHED` を追加 (別タスク) 後、narrow port ではなく `AuditLogEmitter` を直接注入できるよう調整

Closes #17