### PR TITLE
feat(auth): Task 6.2 — パスワードポリシーとロックアウト

### DIFF
--- a/src/lib/auth/auth-service.ts
+++ b/src/lib/auth/auth-service.ts
@@ -1,21 +1,27 @@
 /**
  * Task 6.1: 認証サービス (login / logout / session 取得 / touch)
+ * Task 6.2: アカウントロックアウト + ロック通知 + 監査ログ (Req 1.3)
  *
  * - Req 1.1 / 1.2: メール + パスワードによる認証とセッション発行
+ * - Req 1.3: 5 回連続失敗で 15 分ロック + 通知 (lockout / notifier / auditLogger は optional)
  * - Req 1.4 / 1.5: 絶対期限・アイドル期限切れ判定は SessionStore 側に委譲
  * - Req 1.6: logout でセッションを即時削除
  * - Req 1.11: パスワード検証は PasswordHasher (bcrypt) を経由
  *
  * 認証失敗は常に InvalidCredentialsError に丸め、ユーザー存在有無の漏洩を防ぐ。
+ * ロック中アカウントのみ AccountLockedError を返し、解除時刻を呼び出し側に伝える。
  */
 import { randomUUID } from 'node:crypto'
 import { computeEmailHash } from '@/lib/shared/crypto'
 import {
+  AccountLockedError,
   InvalidCredentialsError,
   loginInputSchema,
   type LoginInput,
   type Session,
 } from './auth-types'
+import type { LockoutNotifier } from './lockout-notifier'
+import type { LockoutStatus, LockoutStore } from './lockout-store'
 import type { PasswordHasher } from './password-hasher'
 import { SESSION_ABSOLUTE_TTL_MS } from './session-store'
 import type { SessionStore } from './session-store'
@@ -37,6 +43,24 @@ export interface AuthService {
   touchSession(sessionId: string, now?: Date): Promise<Session>
 }
 
+/**
+ * 監査ログ出力の narrow port。
+ * 既存 AuditLogEmitter (src/lib/audit/audit-log-emitter.ts) と互換な shape。
+ * AuthService は fire-and-forget で呼び、監査失敗は認証を止めない。
+ */
+export interface AuthAuditLoggerPort {
+  emit(entry: {
+    readonly userId: string | null
+    readonly action: 'ACCOUNT_LOCKED'
+    readonly resourceType: 'USER'
+    readonly resourceId: string | null
+    readonly ipAddress: string
+    readonly userAgent: string
+    readonly before: Record<string, unknown> | null
+    readonly after: Record<string, unknown> | null
+  }): Promise<void>
+}
+
 export interface AuthServiceDeps {
   readonly users: AuthUserRepository
   readonly sessions: SessionStore
@@ -46,6 +70,15 @@ export interface AuthServiceDeps {
   readonly sessionIdFactory?: () => string
   readonly clock?: () => Date
   readonly absoluteTtlMs?: number
+  /**
+   * Task 6.2 / Req 1.3: 連続ログイン失敗の追跡とロック判定。
+   * 未指定時はロックアウト機能は動作しない (後方互換)。
+   */
+  readonly lockout?: LockoutStore
+  /** Task 6.2 / Req 1.3: ロック通知メール。未指定時は通知を送らない */
+  readonly notifier?: LockoutNotifier
+  /** Task 6.2: ACCOUNT_LOCKED の監査ログ。未指定時は監査出力なし */
+  readonly auditLogger?: AuthAuditLoggerPort
 }
 
 function defaultSessionIdFactory(): string {
@@ -64,6 +97,9 @@ class AuthServiceImpl implements AuthService {
   private readonly sessionIdFactory: () => string
   private readonly clock: () => Date
   private readonly absoluteTtlMs: number
+  private readonly lockout?: LockoutStore
+  private readonly notifier?: LockoutNotifier
+  private readonly auditLogger?: AuthAuditLoggerPort
 
   constructor(deps: AuthServiceDeps) {
     if (typeof deps.appSecret !== 'string' || deps.appSecret.length === 0) {
@@ -76,28 +112,47 @@ class AuthServiceImpl implements AuthService {
     this.sessionIdFactory = deps.sessionIdFactory ?? defaultSessionIdFactory
     this.clock = deps.clock ?? defaultClock
     this.absoluteTtlMs = deps.absoluteTtlMs ?? SESSION_ABSOLUTE_TTL_MS
+    this.lockout = deps.lockout
+    this.notifier = deps.notifier
+    this.auditLogger = deps.auditLogger
   }
 
   async login(input: LoginInput, context?: LoginContext, now?: Date): Promise<Session> {
     // Zod バリデーション (email 形式 / password 必須)
     const parsed = loginInputSchema.parse(input)
+    const issuedAt = now ?? this.clock()
 
     const emailHash = await computeEmailHash(parsed.email, this.appSecret)
     const user = await this.users.findByEmailHash(emailHash)
-    // ユーザー不在・非アクティブ・パスワード不一致は全て InvalidCredentialsError に統一する
+    // ユーザー不在は InvalidCredentialsError に統一 (存在漏洩防止)。
+    // 存在しないユーザーの userId は特定できないため、lockout も記録しない。
     if (!user) {
       throw new InvalidCredentialsError()
     }
+
+    // Req 1.3: 既にロック中ならパスワードが正しくても拒否 (AccountLockedError)
+    if (this.lockout) {
+      const status = await this.lockout.get(user.id, issuedAt)
+      if (status.lockedUntil !== null && status.lockedUntil.getTime() > issuedAt.getTime()) {
+        throw new AccountLockedError(new Date(status.lockedUntil))
+      }
+    }
+
     if (user.status !== 'ACTIVE') {
       throw new InvalidCredentialsError()
     }
 
     const passwordOk = await this.passwordHasher.verify(parsed.password, user.passwordHash)
     if (!passwordOk) {
+      await this.handleFailedAttempt(user.id, user.email, issuedAt, context)
       throw new InvalidCredentialsError()
     }
 
-    const issuedAt = now ?? this.clock()
+    // 成功ログイン: 連続失敗カウンタを全リセット (Req 1.3)
+    if (this.lockout) {
+      await this.lockout.reset(user.id)
+    }
+
     const session: Session = {
       id: this.sessionIdFactory(),
       userId: user.id,
@@ -111,6 +166,61 @@ class AuthServiceImpl implements AuthService {
     }
     await this.sessions.create(session)
     return session
+  }
+
+  /**
+   * パスワード不一致時のロックアウト記録。
+   * 新たに閾値到達した瞬間のみ通知 + 監査ログを発火する。
+   */
+  private async handleFailedAttempt(
+    userId: string,
+    email: string,
+    now: Date,
+    context?: LoginContext,
+  ): Promise<void> {
+    if (!this.lockout) return
+
+    const updated: LockoutStatus = await this.lockout.recordFailure(userId, now)
+    // 新規ロック = lockedUntil が未来で設定されている状態。
+    // 既にロック中なら recordFailure は状態を変えない (status.failedCount は変わらず) が、
+    // AuthService では既ロック中は先頭の lockout.get で弾かれているため
+    // ここに到達したら必ず "今回新たにロックされた" ケース。
+    const isNewlyLocked =
+      updated.lockedUntil !== null && updated.lockedUntil.getTime() > now.getTime()
+
+    if (!isNewlyLocked) return
+
+    const lockedUntil = new Date(updated.lockedUntil as Date)
+
+    // 通知 (fire-and-forget エラーは ignore; 認証フローを止めない)
+    if (this.notifier) {
+      try {
+        await this.notifier.notifyLocked({ userId, email, lockedUntil })
+      } catch {
+        // 通知失敗は認証フローを止めない
+      }
+    }
+
+    // 監査ログ (ACCOUNT_LOCKED)
+    if (this.auditLogger) {
+      try {
+        await this.auditLogger.emit({
+          userId,
+          action: 'ACCOUNT_LOCKED',
+          resourceType: 'USER',
+          resourceId: userId,
+          ipAddress: context?.ipAddress ?? 'unknown',
+          userAgent: context?.userAgent ?? 'unknown',
+          before: null,
+          after: {
+            lockedUntil: lockedUntil.toISOString(),
+            failedCount: updated.failedCount,
+          },
+        })
+      } catch {
+        // 監査失敗は認証フローを止めない
+      }
+    }
   }
 
   async logout(sessionId: string): Promise<void> {

--- a/src/lib/auth/auth-types.ts
+++ b/src/lib/auth/auth-types.ts
@@ -119,6 +119,47 @@ export class SessionNotFoundError extends Error {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Task 6.2 / Req 1.3, 1.12, 1.13: パスワードポリシー & アカウントロック
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * パスワードポリシー違反の詳細ルール識別子。
+ * - LENGTH: 最低長 (12 文字) 未満 (Req 1.12)
+ * - COMPLEXITY: 英大文字 / 英小文字 / 数字 / 記号のうち 3 種未満 (Req 1.12)
+ * - REUSED: 過去 5 世代以内のパスワードと同一 (Req 1.13)
+ */
+export const PASSWORD_POLICY_RULES = ['LENGTH', 'COMPLEXITY', 'REUSED'] as const
+export type PasswordPolicyRule = (typeof PASSWORD_POLICY_RULES)[number]
+
+/**
+ * パスワードポリシー違反 (Req 1.12, 1.13)。
+ * rule で違反理由を保持し、呼び出し側はそれを見て UI メッセージを出し分ける。
+ */
+export class PasswordPolicyViolationError extends Error {
+  public readonly rule: PasswordPolicyRule
+
+  constructor(rule: PasswordPolicyRule) {
+    super(`Password policy violation: ${rule}`)
+    this.name = 'PasswordPolicyViolationError'
+    this.rule = rule
+  }
+}
+
+/**
+ * アカウントロック状態 (Req 1.3)。
+ * lockedUntil には解除予定時刻が入る。認証層はこの時刻まで login を拒否する。
+ */
+export class AccountLockedError extends Error {
+  public readonly lockedUntil: Date
+
+  constructor(lockedUntil: Date) {
+    super('Account is locked')
+    this.name = 'AccountLockedError'
+    this.lockedUntil = lockedUntil
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Re-exports
 // ─────────────────────────────────────────────────────────────────────────────
 

--- a/src/lib/auth/lockout-notifier.ts
+++ b/src/lib/auth/lockout-notifier.ts
@@ -1,0 +1,75 @@
+/**
+ * Task 6.2 / Req 1.3: アカウントロック通知
+ *
+ * ロック閾値に到達した瞬間、ユーザーへロック通知を送るための narrow port。
+ * 既存 NotificationEmitter (src/lib/notification/notification-emitter.ts) と
+ * 互換な shape を期待するが、直接依存させず型定義だけで結合する。
+ */
+
+/**
+ * Notification カテゴリは 'SYSTEM' 固定。
+ * 送信先側の詳細 (メール vs アプリ内) は NotificationEmitter 側の設定に従う。
+ */
+export interface LockoutNotifier {
+  notifyLocked(params: {
+    readonly userId: string
+    readonly email: string
+    readonly lockedUntil: Date
+  }): Promise<void>
+}
+
+/**
+ * 送信側 port。NotificationEmitter.emit と互換。
+ * - category は 'SYSTEM' に固定
+ * - payload は UI / テンプレート側で必要な情報を任意で渡す
+ */
+export interface LockoutNotifierEmitterPort {
+  emit(event: {
+    readonly userId: string
+    readonly category: 'SYSTEM'
+    readonly title: string
+    readonly body: string
+    readonly payload?: Record<string, unknown>
+  }): Promise<void>
+}
+
+export interface LockoutNotifierDeps {
+  readonly emitter: LockoutNotifierEmitterPort
+}
+
+const LOCKOUT_NOTIFICATION_TITLE = 'アカウントがロックされました'
+
+function buildBody(lockedUntil: Date): string {
+  return `連続ログイン失敗により、アカウントを 15 分間ロックしました。解除予定: ${lockedUntil.toISOString()}`
+}
+
+class NotificationEmitterLockoutNotifier implements LockoutNotifier {
+  private readonly emitter: LockoutNotifierEmitterPort
+
+  constructor(deps: LockoutNotifierDeps) {
+    this.emitter = deps.emitter
+  }
+
+  async notifyLocked(params: {
+    readonly userId: string
+    readonly email: string
+    readonly lockedUntil: Date
+  }): Promise<void> {
+    await this.emitter.emit({
+      userId: params.userId,
+      category: 'SYSTEM',
+      title: LOCKOUT_NOTIFICATION_TITLE,
+      body: buildBody(params.lockedUntil),
+      payload: {
+        email: params.email,
+        lockedUntil: params.lockedUntil.toISOString(),
+      },
+    })
+  }
+}
+
+export function createNotificationEmitterLockoutNotifier(
+  deps: LockoutNotifierDeps,
+): LockoutNotifier {
+  return new NotificationEmitterLockoutNotifier(deps)
+}

--- a/src/lib/auth/lockout-store.ts
+++ b/src/lib/auth/lockout-store.ts
@@ -1,0 +1,222 @@
+/**
+ * Task 6.2 / Req 1.3: アカウントロックアウトストア
+ *
+ * 連続ログイン失敗を追跡し、規定回数に達したら一定時間ロックする。
+ * InMemory 実装 (テスト / ローカル dev) と Redis 実装 (本番) を提供する。
+ *
+ * AuthService からは optional で注入され、未指定時はロック無効 (後方互換)。
+ */
+import type { Redis } from 'ioredis'
+
+/** Req 1.3: 連続失敗の上限 */
+export const MAX_FAILED_LOGIN_ATTEMPTS = 5
+
+/** Req 1.3: ロック持続時間 (15 分) */
+export const LOCKOUT_DURATION_MS = 15 * 60 * 1000
+
+const LOCKOUT_KEY_PREFIX = 'auth:lockout:'
+
+function lockoutKey(userId: string): string {
+  return `${LOCKOUT_KEY_PREFIX}${userId}`
+}
+
+export interface LockoutStatus {
+  readonly userId: string
+  readonly failedCount: number
+  readonly lockedUntil: Date | null
+}
+
+export interface LockoutStore {
+  /**
+   * 現在のロック状態を返す。
+   * 既にロック期限が過ぎている場合は自動的に解除済み状態を返す。
+   */
+  get(userId: string, now: Date): Promise<LockoutStatus>
+  /**
+   * 失敗を 1 件記録し、更新後の状態を返す。
+   * - 現在ロック中の場合は status は変化しない (再度のカウントアップはしない)。
+   * - failedCount が maxAttempts に達した瞬間、lockedUntil = now + lockoutDurationMs を設定する。
+   */
+  recordFailure(userId: string, now: Date): Promise<LockoutStatus>
+  /** 成功ログインなどでカウンタとロックを完全リセットする */
+  reset(userId: string): Promise<void>
+}
+
+interface LockoutStoreOptions {
+  readonly maxAttempts?: number
+  readonly lockoutDurationMs?: number
+}
+
+function emptyStatus(userId: string): LockoutStatus {
+  return { userId, failedCount: 0, lockedUntil: null }
+}
+
+function isLocked(lockedUntil: Date | null, now: Date): boolean {
+  return lockedUntil !== null && lockedUntil.getTime() > now.getTime()
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// InMemory implementation
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface MutableEntry {
+  failedCount: number
+  lockedUntil: Date | null
+}
+
+class InMemoryLockoutStore implements LockoutStore {
+  private readonly store: Map<string, MutableEntry>
+  private readonly maxAttempts: number
+  private readonly lockoutDurationMs: number
+
+  constructor(opts?: LockoutStoreOptions) {
+    this.store = new Map()
+    this.maxAttempts = opts?.maxAttempts ?? MAX_FAILED_LOGIN_ATTEMPTS
+    this.lockoutDurationMs = opts?.lockoutDurationMs ?? LOCKOUT_DURATION_MS
+  }
+
+  async get(userId: string, now: Date): Promise<LockoutStatus> {
+    const entry = this.store.get(userId)
+    if (!entry) {
+      return emptyStatus(userId)
+    }
+    // ロック期限が過ぎていたら自動解除
+    if (entry.lockedUntil !== null && entry.lockedUntil.getTime() <= now.getTime()) {
+      this.store.delete(userId)
+      return emptyStatus(userId)
+    }
+    return {
+      userId,
+      failedCount: entry.failedCount,
+      lockedUntil: entry.lockedUntil ? new Date(entry.lockedUntil) : null,
+    }
+  }
+
+  async recordFailure(userId: string, now: Date): Promise<LockoutStatus> {
+    // 期限切れ反映済みの status を取得
+    const current = await this.get(userId, now)
+
+    // 現在ロック中は何もしない
+    if (isLocked(current.lockedUntil, now)) {
+      return current
+    }
+
+    const nextCount = current.failedCount + 1
+    const reachedThreshold = nextCount >= this.maxAttempts
+    const lockedUntil = reachedThreshold ? new Date(now.getTime() + this.lockoutDurationMs) : null
+
+    this.store.set(userId, { failedCount: nextCount, lockedUntil })
+    return { userId, failedCount: nextCount, lockedUntil }
+  }
+
+  async reset(userId: string): Promise<void> {
+    this.store.delete(userId)
+  }
+}
+
+export function createInMemoryLockoutStore(opts?: LockoutStoreOptions): LockoutStore {
+  return new InMemoryLockoutStore(opts)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Redis implementation
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface SerializedLockoutEntry {
+  readonly failedCount: number
+  /** ISO-8601 string or null */
+  readonly lockedUntil: string | null
+}
+
+function serializeEntry(entry: MutableEntry): string {
+  const payload: SerializedLockoutEntry = {
+    failedCount: entry.failedCount,
+    lockedUntil: entry.lockedUntil ? entry.lockedUntil.toISOString() : null,
+  }
+  return JSON.stringify(payload)
+}
+
+function deserializeEntry(raw: string): MutableEntry | null {
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    if (typeof parsed !== 'object' || parsed === null) return null
+    const obj = parsed as Record<string, unknown>
+    const failedCount = obj.failedCount
+    const lockedUntilRaw = obj.lockedUntil
+    if (typeof failedCount !== 'number' || !Number.isFinite(failedCount)) return null
+    if (lockedUntilRaw !== null && typeof lockedUntilRaw !== 'string') return null
+    let lockedUntil: Date | null = null
+    if (typeof lockedUntilRaw === 'string') {
+      const parsedDate = new Date(lockedUntilRaw)
+      if (Number.isNaN(parsedDate.getTime())) return null
+      lockedUntil = parsedDate
+    }
+    return { failedCount, lockedUntil }
+  } catch {
+    return null
+  }
+}
+
+export interface RedisLockoutStoreDeps {
+  readonly redis: Redis
+  readonly maxAttempts?: number
+  readonly lockoutDurationMs?: number
+}
+
+class RedisLockoutStore implements LockoutStore {
+  private readonly redis: Redis
+  private readonly maxAttempts: number
+  private readonly lockoutDurationMs: number
+
+  constructor(deps: RedisLockoutStoreDeps) {
+    this.redis = deps.redis
+    this.maxAttempts = deps.maxAttempts ?? MAX_FAILED_LOGIN_ATTEMPTS
+    this.lockoutDurationMs = deps.lockoutDurationMs ?? LOCKOUT_DURATION_MS
+  }
+
+  async get(userId: string, now: Date): Promise<LockoutStatus> {
+    const raw = await this.redis.get(lockoutKey(userId))
+    if (raw === null) return emptyStatus(userId)
+
+    const entry = deserializeEntry(raw)
+    if (!entry) {
+      // 破損ペイロードは削除して空を返す
+      await this.redis.del(lockoutKey(userId))
+      return emptyStatus(userId)
+    }
+
+    if (entry.lockedUntil !== null && entry.lockedUntil.getTime() <= now.getTime()) {
+      await this.redis.del(lockoutKey(userId))
+      return emptyStatus(userId)
+    }
+
+    return {
+      userId,
+      failedCount: entry.failedCount,
+      lockedUntil: entry.lockedUntil,
+    }
+  }
+
+  async recordFailure(userId: string, now: Date): Promise<LockoutStatus> {
+    const current = await this.get(userId, now)
+    if (isLocked(current.lockedUntil, now)) {
+      return current
+    }
+    const nextCount = current.failedCount + 1
+    const reachedThreshold = nextCount >= this.maxAttempts
+    const lockedUntil = reachedThreshold ? new Date(now.getTime() + this.lockoutDurationMs) : null
+    const serialized = serializeEntry({ failedCount: nextCount, lockedUntil })
+    // TTL は lockoutDurationMs ミリ秒 (秒単位に切り上げ)
+    const ttlSec = Math.max(1, Math.ceil(this.lockoutDurationMs / 1000))
+    await this.redis.set(lockoutKey(userId), serialized, 'EX', ttlSec)
+    return { userId, failedCount: nextCount, lockedUntil }
+  }
+
+  async reset(userId: string): Promise<void> {
+    await this.redis.del(lockoutKey(userId))
+  }
+}
+
+export function createRedisLockoutStore(deps: RedisLockoutStoreDeps): LockoutStore {
+  return new RedisLockoutStore(deps)
+}

--- a/src/lib/auth/password-history-repository.ts
+++ b/src/lib/auth/password-history-repository.ts
@@ -1,0 +1,101 @@
+/**
+ * Task 6.2 / Req 1.13: パスワード履歴リポジトリ
+ *
+ * 過去 N 世代のパスワードハッシュを保持し、ユーザー別・新しい順に取得できる。
+ * Prisma 実装は後続タスクで追加。ここでは narrow なインターフェースと
+ * テスト / ローカル開発向けの InMemory 実装のみを提供する。
+ */
+import { PASSWORD_HISTORY_SIZE } from './password-policy'
+
+/**
+ * パスワード履歴の 1 件。
+ *
+ * - hash: bcrypt によるハッシュ (平文は持たない)
+ * - createdAt: 設定された時刻 (並び替えの基準)
+ */
+export interface PasswordHistoryRecord {
+  readonly userId: string
+  readonly hash: string
+  readonly createdAt: Date
+}
+
+export interface PasswordHistoryRepository {
+  /**
+   * 指定ユーザーの履歴を新しい順 (createdAt 降順) で最大 limit 件返す。
+   * limit <= 0 のときは空配列。
+   */
+  listRecent(userId: string, limit: number): Promise<readonly PasswordHistoryRecord[]>
+
+  /**
+   * 履歴を 1 件追加する。
+   * 追加後、ユーザー単位で新しい順 PASSWORD_HISTORY_SIZE 件のみを保持するよう
+   * 古い履歴を内部で剪定する (Req 1.13)。
+   */
+  add(record: PasswordHistoryRecord): Promise<void>
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// InMemory implementation
+// ─────────────────────────────────────────────────────────────────────────────
+
+function cloneRecord(record: PasswordHistoryRecord): PasswordHistoryRecord {
+  return {
+    userId: record.userId,
+    hash: record.hash,
+    createdAt: new Date(record.createdAt),
+  }
+}
+
+/** createdAt 降順 (新しい順) で比較 */
+function byNewestFirst(a: PasswordHistoryRecord, b: PasswordHistoryRecord): number {
+  return b.createdAt.getTime() - a.createdAt.getTime()
+}
+
+class InMemoryPasswordHistoryRepository implements PasswordHistoryRepository {
+  private readonly byUser: Map<string, PasswordHistoryRecord[]>
+
+  constructor(seed?: readonly PasswordHistoryRecord[]) {
+    this.byUser = new Map()
+    if (seed) {
+      for (const record of seed) {
+        this.pushInternal(record)
+      }
+      for (const [userId] of this.byUser) {
+        this.pruneInternal(userId)
+      }
+    }
+  }
+
+  async listRecent(userId: string, limit: number): Promise<readonly PasswordHistoryRecord[]> {
+    if (limit <= 0) return []
+    const list = this.byUser.get(userId)
+    if (!list || list.length === 0) return []
+    const sorted = [...list].sort(byNewestFirst)
+    return sorted.slice(0, limit).map(cloneRecord)
+  }
+
+  async add(record: PasswordHistoryRecord): Promise<void> {
+    this.pushInternal(record)
+    this.pruneInternal(record.userId)
+  }
+
+  private pushInternal(record: PasswordHistoryRecord): void {
+    const existing = this.byUser.get(record.userId) ?? []
+    existing.push(cloneRecord(record))
+    this.byUser.set(record.userId, existing)
+  }
+
+  private pruneInternal(userId: string): void {
+    const list = this.byUser.get(userId)
+    if (!list) return
+    if (list.length <= PASSWORD_HISTORY_SIZE) return
+    const kept = [...list].sort(byNewestFirst).slice(0, PASSWORD_HISTORY_SIZE)
+    this.byUser.set(userId, kept)
+  }
+}
+
+export function createInMemoryPasswordHistoryRepository(
+  seed?: readonly PasswordHistoryRecord[],
+): PasswordHistoryRepository {
+  return new InMemoryPasswordHistoryRepository(seed)
+}

--- a/src/lib/auth/password-policy.ts
+++ b/src/lib/auth/password-policy.ts
@@ -1,0 +1,73 @@
+/**
+ * Task 6.2 / Req 1.12: パスワード強度ポリシー
+ *
+ * - 最低 12 文字 (PASSWORD_MIN_LENGTH)
+ * - 英大文字 / 英小文字 / 数字 / 記号のうち 3 種以上 (PASSWORD_REQUIRED_CHAR_CLASSES)
+ *
+ * 過去履歴チェック (Req 1.13) は password-history-repository / password-service 側に分離する。
+ * 本モジュールは文字列のみを見る純粋バリデータを提供する。
+ */
+import { PasswordPolicyViolationError } from './auth-types'
+
+/** Req 1.12: 最低パスワード長 */
+export const PASSWORD_MIN_LENGTH = 12
+
+/** Req 1.12: 4 種文字クラスのうち何種類以上を必須とするか (>= 3) */
+export const PASSWORD_REQUIRED_CHAR_CLASSES = 3
+
+/** Req 1.13: 過去世代のパスワード保持数 (= 世代数) */
+export const PASSWORD_HISTORY_SIZE = 5
+
+export type PasswordCharClass = 'UPPERCASE' | 'LOWERCASE' | 'DIGIT' | 'SYMBOL'
+
+// ASCII 記号のみを "SYMBOL" として扱う (Unicode 記号は含めない)
+//  - 0x21-0x2F  !"#$%&'()*+,-./
+//  - 0x3A-0x40  :;<=>?@
+//  - 0x5B-0x60  [\]^_`
+//  - 0x7B-0x7E  {|}~
+const UPPERCASE_RE = /[A-Z]/
+const LOWERCASE_RE = /[a-z]/
+const DIGIT_RE = /\d/
+const SYMBOL_RE = /[!-/:-@[-`{-~]/
+
+/**
+ * 含まれる文字クラスの集合を返す。
+ * 空文字は空集合。
+ */
+export function classifyPassword(password: string): ReadonlySet<PasswordCharClass> {
+  const classes = new Set<PasswordCharClass>()
+  if (UPPERCASE_RE.test(password)) classes.add('UPPERCASE')
+  if (LOWERCASE_RE.test(password)) classes.add('LOWERCASE')
+  if (DIGIT_RE.test(password)) classes.add('DIGIT')
+  if (SYMBOL_RE.test(password)) classes.add('SYMBOL')
+  return classes
+}
+
+/**
+ * true/false を返す純粋バリデータ。UI 層のヒント表示などで使用する想定。
+ */
+export function isPasswordStrong(password: string): boolean {
+  if (typeof password !== 'string') return false
+  if (password.length < PASSWORD_MIN_LENGTH) return false
+  const classes = classifyPassword(password)
+  return classes.size >= PASSWORD_REQUIRED_CHAR_CLASSES
+}
+
+/**
+ * 強度違反があれば PasswordPolicyViolationError を throw。
+ *
+ * 違反優先順位:
+ *   1. LENGTH  (最低長未満)
+ *   2. COMPLEXITY (クラス数不足)
+ *
+ * 過去履歴チェック (REUSED) は別関数で扱う。
+ */
+export function assertPasswordStrong(password: string): void {
+  if (typeof password !== 'string' || password.length < PASSWORD_MIN_LENGTH) {
+    throw new PasswordPolicyViolationError('LENGTH')
+  }
+  const classes = classifyPassword(password)
+  if (classes.size < PASSWORD_REQUIRED_CHAR_CLASSES) {
+    throw new PasswordPolicyViolationError('COMPLEXITY')
+  }
+}

--- a/src/lib/auth/password-service.ts
+++ b/src/lib/auth/password-service.ts
@@ -1,0 +1,99 @@
+/**
+ * Task 6.2 / Req 1.12, 1.13: パスワード変更ユースケース集約
+ *
+ * 責務:
+ *   1. ポリシー強度検証 (assertPasswordStrong)
+ *   2. 過去 PASSWORD_HISTORY_SIZE 世代との再利用チェック (Req 1.13)
+ *   3. bcrypt ハッシュ化
+ *   4. User レコードへの反映 (PasswordPersistencePort)
+ *   5. 履歴追加
+ *
+ * Prisma 実装層は PasswordPersistencePort / PasswordHistoryRepository を
+ * 後続タスクで差し替える。
+ */
+import { PasswordPolicyViolationError } from './auth-types'
+import type { PasswordHasher } from './password-hasher'
+import type { PasswordHistoryRepository } from './password-history-repository'
+import { PASSWORD_HISTORY_SIZE, assertPasswordStrong } from './password-policy'
+
+export interface ChangePasswordInput {
+  readonly userId: string
+  readonly newPassword: string
+}
+
+export interface ChangePasswordResult {
+  readonly newHash: string
+}
+
+export interface PasswordService {
+  /**
+   * ポリシー検証 + 過去履歴チェック + ハッシュ化 + 保存 + 履歴追加。
+   * 違反時は PasswordPolicyViolationError をそのまま throw し、永続化は行わない。
+   */
+  changePassword(input: ChangePasswordInput, now?: Date): Promise<ChangePasswordResult>
+}
+
+/**
+ * User レコードの passwordHash 更新を担うアダプタ。
+ * Prisma 実装は後続タスクで追加する。
+ */
+export interface PasswordPersistencePort {
+  updateUserPasswordHash(userId: string, newHash: string): Promise<void>
+}
+
+export interface PasswordServiceDeps {
+  readonly hasher: PasswordHasher
+  readonly history: PasswordHistoryRepository
+  readonly persist: PasswordPersistencePort
+  readonly clock?: () => Date
+}
+
+function defaultClock(): Date {
+  return new Date()
+}
+
+class PasswordServiceImpl implements PasswordService {
+  private readonly hasher: PasswordHasher
+  private readonly history: PasswordHistoryRepository
+  private readonly persist: PasswordPersistencePort
+  private readonly clock: () => Date
+
+  constructor(deps: PasswordServiceDeps) {
+    this.hasher = deps.hasher
+    this.history = deps.history
+    this.persist = deps.persist
+    this.clock = deps.clock ?? defaultClock
+  }
+
+  async changePassword(input: ChangePasswordInput, now?: Date): Promise<ChangePasswordResult> {
+    // 1. 強度ポリシー (LENGTH → COMPLEXITY)
+    assertPasswordStrong(input.newPassword)
+
+    // 2. 過去履歴を取得 (Req 1.13: 過去 5 世代)
+    const recent = await this.history.listRecent(input.userId, PASSWORD_HISTORY_SIZE)
+
+    // 3. 履歴のいずれかに一致したら再利用エラー
+    for (const record of recent) {
+      const isReused = await this.hasher.verify(input.newPassword, record.hash)
+      if (isReused) {
+        throw new PasswordPolicyViolationError('REUSED')
+      }
+    }
+
+    // 4. 新ハッシュを計算
+    const newHash = await this.hasher.hash(input.newPassword)
+
+    // 5. User レコードへ反映
+    await this.persist.updateUserPasswordHash(input.userId, newHash)
+
+    // 6. 履歴を追加 (内部で PASSWORD_HISTORY_SIZE を超える古いものは剪定される)
+    const createdAt = now ?? this.clock()
+    await this.history.add({ userId: input.userId, hash: newHash, createdAt })
+
+    return { newHash }
+  }
+}
+
+export function createPasswordService(deps: PasswordServiceDeps): PasswordService {
+  return new PasswordServiceImpl(deps)
+}

--- a/src/tests/auth/auth-service.test.ts
+++ b/src/tests/auth/auth-service.test.ts
@@ -1,18 +1,30 @@
 /**
  * Task 6.1: AuthService の単体テスト
+ * Task 6.2 で拡張: ロックアウト / ロック通知 / 監査ログの検証を追加
  *
- * Req 1.1, 1.2, 1.4, 1.5, 1.6, 1.11 相当の挙動を検証する。
+ * Req 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.11 相当の挙動を検証する。
  */
-import { describe, it, expect, beforeAll } from 'vitest'
+import { describe, it, expect, beforeAll, vi } from 'vitest'
 import { z } from 'zod'
-import { createAuthService } from '@/lib/auth/auth-service'
-import type { AuthService } from '@/lib/auth/auth-service'
 import {
+  createAuthService,
+  type AuthAuditLoggerPort,
+  type AuthService,
+} from '@/lib/auth/auth-service'
+import {
+  AccountLockedError,
   InvalidCredentialsError,
   SessionExpiredError,
   SessionIdleTimeoutError,
   SessionNotFoundError,
 } from '@/lib/auth/auth-types'
+import type { LockoutNotifier } from '@/lib/auth/lockout-notifier'
+import {
+  LOCKOUT_DURATION_MS,
+  MAX_FAILED_LOGIN_ATTEMPTS,
+  createInMemoryLockoutStore,
+  type LockoutStore,
+} from '@/lib/auth/lockout-store'
 import { createBcryptPasswordHasher } from '@/lib/auth/password-hasher'
 import {
   SESSION_ABSOLUTE_TTL_MS,
@@ -231,5 +243,256 @@ describe('createAuthService.logout / getSession / touchSession', () => {
     // さらに 25 分 → 直前の touch から 25 分経過 → idle 未超過
     const t2 = new Date(t1.getTime() + 25 * 60 * 1000)
     await expect(service.touchSession(session.id, t2)).resolves.toBeDefined()
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Task 6.2: Lockout + notification + audit log (Req 1.3)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** noUncheckedIndexedAccess 下でも安全に 0 番目の呼び出し引数を取り出す helper */
+function firstCallArg<T>(mockFn: unknown): T {
+  const mock = mockFn as { mock: { calls: unknown[][] } }
+  const call = mock.mock.calls[0]
+  if (!call) throw new Error('mock was not called')
+  const arg = call[0]
+  if (arg === undefined) throw new Error('mock call had no first argument')
+  return arg as T
+}
+
+interface LockoutHarnessOptions {
+  readonly users?: readonly AuthUserRecord[]
+  readonly now?: Date
+  readonly lockout?: LockoutStore
+  readonly notifier?: LockoutNotifier
+  readonly auditLogger?: AuthAuditLoggerPort
+}
+
+function buildLockoutHarness(opts: LockoutHarnessOptions): AuthService {
+  return createAuthService({
+    users: createInMemoryAuthUserRepository(opts.users ?? []),
+    sessions: createInMemorySessionStore(),
+    passwordHasher: createBcryptPasswordHasher({ cost: 12 }),
+    appSecret: APP_SECRET,
+    sessionIdFactory: () => 'sess-lockout',
+    clock: () => opts.now ?? new Date('2026-04-17T00:00:00.000Z'),
+    lockout: opts.lockout,
+    notifier: opts.notifier,
+    auditLogger: opts.auditLogger,
+  })
+}
+
+describe('createAuthService.login + lockout (Req 1.3)', () => {
+  it('lockout 未指定時は従来どおりロックアウト機能は動作しない (後方互換)', async () => {
+    const user = await buildUser()
+    const service = buildLockoutHarness({ users: [user] })
+    // 失敗を 10 回繰り返してもロックされない (bcrypt cost=12 のため時間を許容)
+    for (let i = 0; i < 10; i += 1) {
+      await expect(service.login({ email: VALID_EMAIL, password: 'wrong' })).rejects.toBeInstanceOf(
+        InvalidCredentialsError,
+      )
+    }
+    // 最後に正しいパスワードでログイン成功
+    const session = await service.login({ email: VALID_EMAIL, password: VALID_PASSWORD })
+    expect(session.userId).toBe(user.id)
+  }, 15000)
+
+  it('パスワード誤りで lockout.recordFailure が呼ばれる', async () => {
+    const user = await buildUser()
+    const lockout = createInMemoryLockoutStore()
+    const recordFailureSpy = vi.spyOn(lockout, 'recordFailure')
+    const service = buildLockoutHarness({ users: [user], lockout })
+
+    await expect(service.login({ email: VALID_EMAIL, password: 'wrong' })).rejects.toBeInstanceOf(
+      InvalidCredentialsError,
+    )
+
+    expect(recordFailureSpy).toHaveBeenCalledTimes(1)
+    const firstCall = recordFailureSpy.mock.calls[0]
+    if (!firstCall) throw new Error('recordFailure was not called')
+    expect(firstCall[0]).toBe(user.id)
+  })
+
+  it('ユーザー存在しない場合は lockout.recordFailure が呼ばれない (存在漏洩防止)', async () => {
+    const lockout = createInMemoryLockoutStore()
+    const recordFailureSpy = vi.spyOn(lockout, 'recordFailure')
+    const service = buildLockoutHarness({ users: [], lockout })
+
+    await expect(
+      service.login({ email: 'unknown@example.com', password: 'wrong' }),
+    ).rejects.toBeInstanceOf(InvalidCredentialsError)
+
+    expect(recordFailureSpy).not.toHaveBeenCalled()
+  })
+
+  it('ロック中のアカウントはパスワードが正しくても AccountLockedError', async () => {
+    const user = await buildUser()
+    const now = new Date('2026-04-17T00:00:00.000Z')
+    const lockout = createInMemoryLockoutStore()
+    // 事前に 5 回失敗させてロック状態を作る
+    for (let i = 0; i < MAX_FAILED_LOGIN_ATTEMPTS; i += 1) {
+      await lockout.recordFailure(user.id, now)
+    }
+
+    const service = buildLockoutHarness({ users: [user], now, lockout })
+
+    try {
+      await service.login({ email: VALID_EMAIL, password: VALID_PASSWORD }, undefined, now)
+      throw new Error('should have thrown')
+    } catch (error: unknown) {
+      expect(error).toBeInstanceOf(AccountLockedError)
+      if (error instanceof AccountLockedError) {
+        expect(error.lockedUntil.getTime()).toBe(now.getTime() + LOCKOUT_DURATION_MS)
+      }
+    }
+  })
+
+  it('5 回目の失敗で notifier.notifyLocked + auditLogger.emit が呼ばれる', async () => {
+    const user = await buildUser()
+    const now = new Date('2026-04-17T00:00:00.000Z')
+    const lockout = createInMemoryLockoutStore()
+    const notifier: LockoutNotifier = {
+      notifyLocked: vi.fn(async () => {}),
+    }
+    const auditLogger: AuthAuditLoggerPort = {
+      emit: vi.fn(async () => {}),
+    }
+    const service = buildLockoutHarness({
+      users: [user],
+      now,
+      lockout,
+      notifier,
+      auditLogger,
+    })
+
+    // 1..4 回目の失敗では通知/監査は呼ばれない
+    for (let i = 0; i < 4; i += 1) {
+      await expect(
+        service.login({ email: VALID_EMAIL, password: 'wrong' }, undefined, now),
+      ).rejects.toBeInstanceOf(InvalidCredentialsError)
+    }
+    expect(notifier.notifyLocked).not.toHaveBeenCalled()
+    expect(auditLogger.emit).not.toHaveBeenCalled()
+
+    // 5 回目で lockedUntil が設定され通知 + 監査が発火
+    await expect(
+      service.login({ email: VALID_EMAIL, password: 'wrong' }, undefined, now),
+    ).rejects.toBeInstanceOf(InvalidCredentialsError)
+
+    expect(notifier.notifyLocked).toHaveBeenCalledTimes(1)
+    const notifiedArg = firstCallArg<{
+      userId: string
+      email: string
+      lockedUntil: Date
+    }>(notifier.notifyLocked)
+    expect(notifiedArg.userId).toBe(user.id)
+    expect(notifiedArg.email).toBe(VALID_EMAIL)
+    expect(notifiedArg.lockedUntil.getTime()).toBe(now.getTime() + LOCKOUT_DURATION_MS)
+
+    expect(auditLogger.emit).toHaveBeenCalledTimes(1)
+    const auditArg = firstCallArg<Parameters<AuthAuditLoggerPort['emit']>[0]>(auditLogger.emit)
+    expect(auditArg.action).toBe('ACCOUNT_LOCKED')
+    expect(auditArg.resourceType).toBe('USER')
+    expect(auditArg.userId).toBe(user.id)
+    expect(auditArg.resourceId).toBe(user.id)
+    const after = auditArg.after
+    if (!after) throw new Error('auditArg.after missing')
+    expect(after.lockedUntil).toBe(new Date(now.getTime() + LOCKOUT_DURATION_MS).toISOString())
+    expect(after.failedCount).toBe(MAX_FAILED_LOGIN_ATTEMPTS)
+    expect(auditArg.before).toBeNull()
+  })
+
+  it('context の ipAddress/userAgent が監査ログへ渡る', async () => {
+    const user = await buildUser()
+    const now = new Date('2026-04-17T00:00:00.000Z')
+    const lockout = createInMemoryLockoutStore()
+    const auditLogger: AuthAuditLoggerPort = { emit: vi.fn(async () => {}) }
+    const service = buildLockoutHarness({ users: [user], now, lockout, auditLogger })
+
+    for (let i = 0; i < MAX_FAILED_LOGIN_ATTEMPTS; i += 1) {
+      await expect(
+        service.login(
+          { email: VALID_EMAIL, password: 'wrong' },
+          { ipAddress: '192.0.2.10', userAgent: 'agent-x/1.0' },
+          now,
+        ),
+      ).rejects.toBeInstanceOf(InvalidCredentialsError)
+    }
+    const auditArg = firstCallArg<Parameters<AuthAuditLoggerPort['emit']>[0]>(auditLogger.emit)
+    expect(auditArg.ipAddress).toBe('192.0.2.10')
+    expect(auditArg.userAgent).toBe('agent-x/1.0')
+  })
+
+  it('context 未指定時は ipAddress/userAgent が "unknown" になる', async () => {
+    const user = await buildUser()
+    const now = new Date('2026-04-17T00:00:00.000Z')
+    const lockout = createInMemoryLockoutStore()
+    const auditLogger: AuthAuditLoggerPort = { emit: vi.fn(async () => {}) }
+    const service = buildLockoutHarness({ users: [user], now, lockout, auditLogger })
+
+    for (let i = 0; i < MAX_FAILED_LOGIN_ATTEMPTS; i += 1) {
+      await expect(
+        service.login({ email: VALID_EMAIL, password: 'wrong' }, undefined, now),
+      ).rejects.toBeInstanceOf(InvalidCredentialsError)
+    }
+    const auditArg = firstCallArg<Parameters<AuthAuditLoggerPort['emit']>[0]>(auditLogger.emit)
+    expect(auditArg.ipAddress).toBe('unknown')
+    expect(auditArg.userAgent).toBe('unknown')
+  })
+
+  it('成功ログインで lockout.reset が呼ばれる', async () => {
+    const user = await buildUser()
+    const now = new Date('2026-04-17T00:00:00.000Z')
+    const lockout = createInMemoryLockoutStore()
+    // 数回失敗させてからカウンタを持たせる
+    await lockout.recordFailure(user.id, now)
+    await lockout.recordFailure(user.id, now)
+    const resetSpy = vi.spyOn(lockout, 'reset')
+
+    const service = buildLockoutHarness({ users: [user], now, lockout })
+    await service.login({ email: VALID_EMAIL, password: VALID_PASSWORD }, undefined, now)
+
+    expect(resetSpy).toHaveBeenCalledWith(user.id)
+    const status = await lockout.get(user.id, now)
+    expect(status.failedCount).toBe(0)
+  })
+
+  it('通知が失敗しても認証経路は影響を受けない (fire-and-forget)', async () => {
+    const user = await buildUser()
+    const now = new Date('2026-04-17T00:00:00.000Z')
+    const lockout = createInMemoryLockoutStore()
+    const notifier: LockoutNotifier = {
+      notifyLocked: vi.fn(async () => {
+        throw new Error('notification service down')
+      }),
+    }
+    const service = buildLockoutHarness({ users: [user], now, lockout, notifier })
+
+    for (let i = 0; i < MAX_FAILED_LOGIN_ATTEMPTS; i += 1) {
+      // 通知失敗は throw せず InvalidCredentialsError のみが外に出る
+      await expect(
+        service.login({ email: VALID_EMAIL, password: 'wrong' }, undefined, now),
+      ).rejects.toBeInstanceOf(InvalidCredentialsError)
+    }
+    expect(notifier.notifyLocked).toHaveBeenCalledTimes(1)
+  })
+
+  it('監査失敗しても認証経路は影響を受けない (fire-and-forget)', async () => {
+    const user = await buildUser()
+    const now = new Date('2026-04-17T00:00:00.000Z')
+    const lockout = createInMemoryLockoutStore()
+    const auditLogger: AuthAuditLoggerPort = {
+      emit: vi.fn(async () => {
+        throw new Error('audit log db down')
+      }),
+    }
+    const service = buildLockoutHarness({ users: [user], now, lockout, auditLogger })
+
+    for (let i = 0; i < MAX_FAILED_LOGIN_ATTEMPTS; i += 1) {
+      await expect(
+        service.login({ email: VALID_EMAIL, password: 'wrong' }, undefined, now),
+      ).rejects.toBeInstanceOf(InvalidCredentialsError)
+    }
+    expect(auditLogger.emit).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/tests/auth/lockout-notifier.test.ts
+++ b/src/tests/auth/lockout-notifier.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Task 6.2 / Req 1.3: LockoutNotifier の単体テスト
+ *
+ * NotificationEmitter 互換 port を経由して SYSTEM カテゴリの通知が送られることを検証する。
+ */
+import { describe, expect, it, vi } from 'vitest'
+import {
+  createNotificationEmitterLockoutNotifier,
+  type LockoutNotifierEmitterPort,
+} from '@/lib/auth/lockout-notifier'
+
+type EmittedEvent = Parameters<LockoutNotifierEmitterPort['emit']>[0]
+
+function createMockEmitter(): LockoutNotifierEmitterPort & {
+  readonly calls: EmittedEvent[]
+} {
+  const calls: EmittedEvent[] = []
+  return {
+    emit: vi.fn(async (event: EmittedEvent) => {
+      calls.push(event)
+    }),
+    get calls(): EmittedEvent[] {
+      return calls
+    },
+  }
+}
+
+function eventAt(calls: readonly EmittedEvent[], index: number): EmittedEvent {
+  const event = calls[index]
+  if (!event) throw new Error(`no emitted event at index ${index}`)
+  return event
+}
+
+describe('createNotificationEmitterLockoutNotifier', () => {
+  it('emit が category=SYSTEM / userId / payload.lockedUntil(ISO) を持つイベントで呼ばれる', async () => {
+    const emitter = createMockEmitter()
+    const notifier = createNotificationEmitterLockoutNotifier({ emitter })
+
+    const lockedUntil = new Date('2026-04-17T00:15:00.000Z')
+    await notifier.notifyLocked({
+      userId: 'user-42',
+      email: 'alice@example.com',
+      lockedUntil,
+    })
+
+    expect(emitter.calls).toHaveLength(1)
+    const event = eventAt(emitter.calls, 0)
+    expect(event.userId).toBe('user-42')
+    expect(event.category).toBe('SYSTEM')
+    expect(event.title).toBe('アカウントがロックされました')
+    expect(event.body).toContain('2026-04-17T00:15:00.000Z')
+    expect(event.payload).toBeDefined()
+    expect(event.payload?.email).toBe('alice@example.com')
+    expect(event.payload?.lockedUntil).toBe(lockedUntil.toISOString())
+  })
+
+  it('複数回呼び出すと emit も複数回呼ばれる', async () => {
+    const emitter = createMockEmitter()
+    const notifier = createNotificationEmitterLockoutNotifier({ emitter })
+
+    await notifier.notifyLocked({
+      userId: 'user-a',
+      email: 'a@example.com',
+      lockedUntil: new Date('2026-04-17T00:15:00.000Z'),
+    })
+    await notifier.notifyLocked({
+      userId: 'user-b',
+      email: 'b@example.com',
+      lockedUntil: new Date('2026-04-17T01:00:00.000Z'),
+    })
+
+    expect(emitter.calls).toHaveLength(2)
+    expect(eventAt(emitter.calls, 0).userId).toBe('user-a')
+    expect(eventAt(emitter.calls, 1).userId).toBe('user-b')
+  })
+
+  it('body には日本語の定型文と解除予定 ISO が含まれる', async () => {
+    const emitter = createMockEmitter()
+    const notifier = createNotificationEmitterLockoutNotifier({ emitter })
+    const lockedUntil = new Date('2026-04-17T12:34:56.000Z')
+
+    await notifier.notifyLocked({
+      userId: 'user-1',
+      email: 'bob@example.com',
+      lockedUntil,
+    })
+
+    const event = eventAt(emitter.calls, 0)
+    expect(event.body).toContain('連続ログイン失敗により')
+    expect(event.body).toContain('15 分間ロック')
+    expect(event.body).toContain(lockedUntil.toISOString())
+  })
+})

--- a/src/tests/auth/lockout-store.test.ts
+++ b/src/tests/auth/lockout-store.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Task 6.2 / Req 1.3: InMemoryLockoutStore の単体テスト
+ */
+import { describe, expect, it } from 'vitest'
+import {
+  LOCKOUT_DURATION_MS,
+  MAX_FAILED_LOGIN_ATTEMPTS,
+  createInMemoryLockoutStore,
+} from '@/lib/auth/lockout-store'
+
+const T0 = new Date('2026-04-17T00:00:00.000Z')
+const afterMs = (base: Date, ms: number): Date => new Date(base.getTime() + ms)
+
+describe('createInMemoryLockoutStore.get', () => {
+  it('記録のない userId は失敗数 0 / 未ロック', async () => {
+    const store = createInMemoryLockoutStore()
+    const status = await store.get('user-1', T0)
+    expect(status.failedCount).toBe(0)
+    expect(status.lockedUntil).toBeNull()
+  })
+
+  it('ロック期限を過ぎた後の get は自動解除 (failedCount=0)', async () => {
+    const store = createInMemoryLockoutStore()
+    // 5 回失敗でロックさせる
+    for (let i = 0; i < MAX_FAILED_LOGIN_ATTEMPTS; i += 1) {
+      await store.recordFailure('user-1', T0)
+    }
+    const lockedStatus = await store.get('user-1', T0)
+    expect(lockedStatus.lockedUntil).toBeInstanceOf(Date)
+
+    const afterExpire = afterMs(T0, LOCKOUT_DURATION_MS + 1000)
+    const expiredStatus = await store.get('user-1', afterExpire)
+    expect(expiredStatus.failedCount).toBe(0)
+    expect(expiredStatus.lockedUntil).toBeNull()
+  })
+})
+
+describe('createInMemoryLockoutStore.recordFailure', () => {
+  it('4 回失敗: failedCount=4, lockedUntil=null', async () => {
+    const store = createInMemoryLockoutStore()
+    for (let i = 1; i <= 4; i += 1) {
+      const status = await store.recordFailure('user-1', T0)
+      expect(status.failedCount).toBe(i)
+      expect(status.lockedUntil).toBeNull()
+    }
+  })
+
+  it('5 回目でロック (lockedUntil = now + 15min)', async () => {
+    const store = createInMemoryLockoutStore()
+    for (let i = 0; i < 4; i += 1) {
+      await store.recordFailure('user-1', T0)
+    }
+    const fifth = await store.recordFailure('user-1', T0)
+    expect(fifth.failedCount).toBe(MAX_FAILED_LOGIN_ATTEMPTS)
+    expect(fifth.lockedUntil).not.toBeNull()
+    expect(fifth.lockedUntil?.getTime()).toBe(T0.getTime() + LOCKOUT_DURATION_MS)
+  })
+
+  it('ロック中の recordFailure は status を変更しない (カウントアップしない)', async () => {
+    const store = createInMemoryLockoutStore()
+    for (let i = 0; i < MAX_FAILED_LOGIN_ATTEMPTS; i += 1) {
+      await store.recordFailure('user-1', T0)
+    }
+    const locked = await store.get('user-1', T0)
+    const duringLock = await store.recordFailure('user-1', afterMs(T0, 60_000))
+    expect(duringLock.failedCount).toBe(locked.failedCount)
+    expect(duringLock.lockedUntil?.getTime()).toBe(locked.lockedUntil?.getTime())
+  })
+
+  it('ユーザー毎にカウンタは独立', async () => {
+    const store = createInMemoryLockoutStore()
+    await store.recordFailure('user-a', T0)
+    await store.recordFailure('user-a', T0)
+    await store.recordFailure('user-b', T0)
+
+    const a = await store.get('user-a', T0)
+    const b = await store.get('user-b', T0)
+    expect(a.failedCount).toBe(2)
+    expect(b.failedCount).toBe(1)
+  })
+})
+
+describe('createInMemoryLockoutStore.reset', () => {
+  it('reset 後は failedCount=0 / lockedUntil=null', async () => {
+    const store = createInMemoryLockoutStore()
+    await store.recordFailure('user-1', T0)
+    await store.recordFailure('user-1', T0)
+    await store.reset('user-1')
+    const status = await store.get('user-1', T0)
+    expect(status.failedCount).toBe(0)
+    expect(status.lockedUntil).toBeNull()
+  })
+
+  it('ロック中のユーザーも reset で完全クリアされる', async () => {
+    const store = createInMemoryLockoutStore()
+    for (let i = 0; i < MAX_FAILED_LOGIN_ATTEMPTS; i += 1) {
+      await store.recordFailure('user-1', T0)
+    }
+    await store.reset('user-1')
+    const status = await store.get('user-1', T0)
+    expect(status.failedCount).toBe(0)
+    expect(status.lockedUntil).toBeNull()
+  })
+})
+
+describe('createInMemoryLockoutStore options override', () => {
+  it('maxAttempts を 3 に設定すると 3 回目でロック', async () => {
+    const store = createInMemoryLockoutStore({ maxAttempts: 3 })
+    await store.recordFailure('user-1', T0)
+    await store.recordFailure('user-1', T0)
+    const third = await store.recordFailure('user-1', T0)
+    expect(third.lockedUntil).not.toBeNull()
+  })
+
+  it('lockoutDurationMs を上書きできる', async () => {
+    const store = createInMemoryLockoutStore({ lockoutDurationMs: 60_000 })
+    for (let i = 0; i < MAX_FAILED_LOGIN_ATTEMPTS; i += 1) {
+      await store.recordFailure('user-1', T0)
+    }
+    const status = await store.get('user-1', T0)
+    expect(status.lockedUntil?.getTime()).toBe(T0.getTime() + 60_000)
+  })
+})

--- a/src/tests/auth/password-history-repository.test.ts
+++ b/src/tests/auth/password-history-repository.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Task 6.2 / Req 1.13: InMemoryPasswordHistoryRepository の単体テスト
+ */
+import { describe, expect, it } from 'vitest'
+import {
+  createInMemoryPasswordHistoryRepository,
+  type PasswordHistoryRecord,
+} from '@/lib/auth/password-history-repository'
+import { PASSWORD_HISTORY_SIZE } from '@/lib/auth/password-policy'
+
+function makeRecord(hash: string, createdAt: Date, userId = 'user-1'): PasswordHistoryRecord {
+  return { userId, hash, createdAt }
+}
+
+function recordAt(list: readonly PasswordHistoryRecord[], index: number): PasswordHistoryRecord {
+  const record = list[index]
+  if (!record) throw new Error(`no record at index ${index}`)
+  return record
+}
+
+describe('createInMemoryPasswordHistoryRepository', () => {
+  it('履歴がなければ listRecent は空配列', async () => {
+    const repo = createInMemoryPasswordHistoryRepository()
+    const recent = await repo.listRecent('user-1', PASSWORD_HISTORY_SIZE)
+    expect(recent).toEqual([])
+  })
+
+  it('limit <= 0 は空配列', async () => {
+    const repo = createInMemoryPasswordHistoryRepository([
+      makeRecord('hash-a', new Date('2026-04-17T00:00:00.000Z')),
+    ])
+    expect(await repo.listRecent('user-1', 0)).toEqual([])
+    expect(await repo.listRecent('user-1', -3)).toEqual([])
+  })
+
+  it('add で追加すると listRecent に反映される', async () => {
+    const repo = createInMemoryPasswordHistoryRepository()
+    await repo.add(makeRecord('hash-1', new Date('2026-04-17T00:00:00.000Z')))
+    const recent = await repo.listRecent('user-1', PASSWORD_HISTORY_SIZE)
+    expect(recent).toHaveLength(1)
+    expect(recordAt(recent, 0).hash).toBe('hash-1')
+  })
+
+  it('listRecent は新しい順 (createdAt 降順) で返す', async () => {
+    const repo = createInMemoryPasswordHistoryRepository()
+    await repo.add(makeRecord('hash-old', new Date('2026-01-01T00:00:00.000Z')))
+    await repo.add(makeRecord('hash-new', new Date('2026-03-01T00:00:00.000Z')))
+    await repo.add(makeRecord('hash-mid', new Date('2026-02-01T00:00:00.000Z')))
+    const recent = await repo.listRecent('user-1', PASSWORD_HISTORY_SIZE)
+    expect(recent.map((r) => r.hash)).toEqual(['hash-new', 'hash-mid', 'hash-old'])
+  })
+
+  it('PASSWORD_HISTORY_SIZE を超えたら古いものが内部で剪定される', async () => {
+    const repo = createInMemoryPasswordHistoryRepository()
+    // 7 件追加 (PASSWORD_HISTORY_SIZE = 5)
+    for (let i = 0; i < 7; i += 1) {
+      const createdAt = new Date(`2026-04-${String(10 + i).padStart(2, '0')}T00:00:00.000Z`)
+      await repo.add(makeRecord(`hash-${i}`, createdAt))
+    }
+    const recent = await repo.listRecent('user-1', 100)
+    expect(recent).toHaveLength(PASSWORD_HISTORY_SIZE)
+    // 最新 5 件 (hash-2..hash-6) が残っている
+    expect(recent.map((r) => r.hash)).toEqual(['hash-6', 'hash-5', 'hash-4', 'hash-3', 'hash-2'])
+  })
+
+  it('ユーザー毎に履歴が分離される', async () => {
+    const repo = createInMemoryPasswordHistoryRepository()
+    await repo.add(makeRecord('hash-a', new Date('2026-04-17T00:00:00.000Z'), 'user-A'))
+    await repo.add(makeRecord('hash-b', new Date('2026-04-17T00:01:00.000Z'), 'user-B'))
+    const aRecent = await repo.listRecent('user-A', PASSWORD_HISTORY_SIZE)
+    const bRecent = await repo.listRecent('user-B', PASSWORD_HISTORY_SIZE)
+    expect(aRecent).toHaveLength(1)
+    expect(recordAt(aRecent, 0).hash).toBe('hash-a')
+    expect(bRecent).toHaveLength(1)
+    expect(recordAt(bRecent, 0).hash).toBe('hash-b')
+  })
+
+  it('seed で初期化し、保持数超過分は剪定される', async () => {
+    const seed: PasswordHistoryRecord[] = []
+    for (let i = 0; i < 8; i += 1) {
+      seed.push(
+        makeRecord(
+          `seed-${i}`,
+          new Date(`2026-04-${String(1 + i).padStart(2, '0')}T00:00:00.000Z`),
+        ),
+      )
+    }
+    const repo = createInMemoryPasswordHistoryRepository(seed)
+    const recent = await repo.listRecent('user-1', 100)
+    expect(recent).toHaveLength(PASSWORD_HISTORY_SIZE)
+  })
+
+  it('listRecent は内部状態と独立なコピーを返す (不変)', async () => {
+    const repo = createInMemoryPasswordHistoryRepository()
+    await repo.add(makeRecord('hash-z', new Date('2026-04-17T00:00:00.000Z')))
+    const first = await repo.listRecent('user-1', PASSWORD_HISTORY_SIZE)
+    // 戻り値を破壊しても内部データには影響しない
+    recordAt(first, 0).createdAt.setFullYear(1900)
+    const second = await repo.listRecent('user-1', PASSWORD_HISTORY_SIZE)
+    expect(recordAt(second, 0).createdAt.getUTCFullYear()).toBe(2026)
+  })
+})

--- a/src/tests/auth/password-policy.test.ts
+++ b/src/tests/auth/password-policy.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Task 6.2 / Req 1.12: パスワード強度ポリシーの単体テスト
+ */
+import { describe, expect, it } from 'vitest'
+import { PasswordPolicyViolationError } from '@/lib/auth/auth-types'
+import {
+  PASSWORD_HISTORY_SIZE,
+  PASSWORD_MIN_LENGTH,
+  PASSWORD_REQUIRED_CHAR_CLASSES,
+  assertPasswordStrong,
+  classifyPassword,
+  isPasswordStrong,
+} from '@/lib/auth/password-policy'
+
+describe('password-policy constants', () => {
+  it('Req 1.12 / 1.13 の閾値が定数として公開されている', () => {
+    expect(PASSWORD_MIN_LENGTH).toBe(12)
+    expect(PASSWORD_REQUIRED_CHAR_CLASSES).toBe(3)
+    expect(PASSWORD_HISTORY_SIZE).toBe(5)
+  })
+})
+
+describe('classifyPassword', () => {
+  it('空文字は空集合', () => {
+    expect(classifyPassword('').size).toBe(0)
+  })
+
+  it('小文字のみは LOWERCASE のみ', () => {
+    const classes = classifyPassword('abcdefghijkl')
+    expect([...classes]).toEqual(['LOWERCASE'])
+  })
+
+  it('4 クラス全てを認識する', () => {
+    const classes = classifyPassword('Abcdefghij1!')
+    expect(classes.has('UPPERCASE')).toBe(true)
+    expect(classes.has('LOWERCASE')).toBe(true)
+    expect(classes.has('DIGIT')).toBe(true)
+    expect(classes.has('SYMBOL')).toBe(true)
+  })
+
+  it('Unicode 記号は SYMBOL に含めない (ASCII 記号のみ)', () => {
+    // 日本語の「！」(U+FF01) は ASCII 記号ではない
+    const classes = classifyPassword('Abcdefghij1！')
+    expect(classes.has('SYMBOL')).toBe(false)
+  })
+})
+
+describe('isPasswordStrong', () => {
+  it('空文字は false', () => {
+    expect(isPasswordStrong('')).toBe(false)
+  })
+
+  it("'Short1!' は長さ不足で false", () => {
+    expect(isPasswordStrong('Short1!')).toBe(false)
+  })
+
+  it("'abcdefghijkl' は 1 クラスのみで false", () => {
+    expect(isPasswordStrong('abcdefghijkl')).toBe(false)
+  })
+
+  it("'Abcdefghijkl' は 2 クラスで false", () => {
+    expect(isPasswordStrong('Abcdefghijkl')).toBe(false)
+  })
+
+  it("'Abcdefghijk1' は 3 クラスで true", () => {
+    expect(isPasswordStrong('Abcdefghijk1')).toBe(true)
+  })
+
+  it("'Abcdefghij1!' は 4 クラスで true", () => {
+    expect(isPasswordStrong('Abcdefghij1!')).toBe(true)
+  })
+})
+
+describe('assertPasswordStrong', () => {
+  it('長さ不足は PasswordPolicyViolationError(LENGTH)', () => {
+    try {
+      assertPasswordStrong('Short1!')
+      throw new Error('should have thrown')
+    } catch (error: unknown) {
+      expect(error).toBeInstanceOf(PasswordPolicyViolationError)
+      if (error instanceof PasswordPolicyViolationError) {
+        expect(error.rule).toBe('LENGTH')
+      }
+    }
+  })
+
+  it('クラス不足は PasswordPolicyViolationError(COMPLEXITY)', () => {
+    try {
+      assertPasswordStrong('Abcdefghijkl') // 12 文字, 2 クラス
+      throw new Error('should have thrown')
+    } catch (error: unknown) {
+      expect(error).toBeInstanceOf(PasswordPolicyViolationError)
+      if (error instanceof PasswordPolicyViolationError) {
+        expect(error.rule).toBe('COMPLEXITY')
+      }
+    }
+  })
+
+  it('12 文字未満は COMPLEXITY より LENGTH が優先される', () => {
+    try {
+      assertPasswordStrong('Ab1!')
+      throw new Error('should have thrown')
+    } catch (error: unknown) {
+      expect(error).toBeInstanceOf(PasswordPolicyViolationError)
+      if (error instanceof PasswordPolicyViolationError) {
+        expect(error.rule).toBe('LENGTH')
+      }
+    }
+  })
+
+  it('強度を満たす場合は例外を出さない', () => {
+    expect(() => assertPasswordStrong('Abcdefghijk1')).not.toThrow()
+    expect(() => assertPasswordStrong('Abcdefghij1!')).not.toThrow()
+  })
+})

--- a/src/tests/auth/password-service.test.ts
+++ b/src/tests/auth/password-service.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Task 6.2 / Req 1.12, 1.13: PasswordService.changePassword の単体テスト
+ *
+ * 依存はフェイクに差し替えて呼び出し順序と失敗経路を厳密に検証する。
+ */
+import { describe, expect, it, vi } from 'vitest'
+import { PasswordPolicyViolationError } from '@/lib/auth/auth-types'
+import type { PasswordHasher } from '@/lib/auth/password-hasher'
+import {
+  createInMemoryPasswordHistoryRepository,
+  type PasswordHistoryRepository,
+} from '@/lib/auth/password-history-repository'
+import { createPasswordService, type PasswordPersistencePort } from '@/lib/auth/password-service'
+
+const VALID_PASSWORD = 'Abcdefghij1!' // 12 文字 / 4 クラス
+
+interface TrackingPersist extends PasswordPersistencePort {
+  readonly calls: ReadonlyArray<readonly [string, string]>
+}
+
+function createTrackingPersist(): TrackingPersist {
+  const calls: Array<readonly [string, string]> = []
+  return {
+    async updateUserPasswordHash(userId: string, newHash: string): Promise<void> {
+      calls.push([userId, newHash])
+    },
+    get calls(): ReadonlyArray<readonly [string, string]> {
+      return calls
+    },
+  }
+}
+
+function createFakeHasher(): PasswordHasher {
+  return {
+    hash: vi.fn(async (plain: string) => `hashed(${plain})`),
+    verify: vi.fn(async (plain: string, hash: string) => hash === `hashed(${plain})`),
+  }
+}
+
+describe('createPasswordService.changePassword', () => {
+  it('正常変更: listRecent → hash → persist → history.add の順で newHash を返す', async () => {
+    const callLog: string[] = []
+    const hasher: PasswordHasher = {
+      hash: vi.fn(async (plain: string) => {
+        callLog.push('hash')
+        return `hashed(${plain})`
+      }),
+      verify: vi.fn(async () => {
+        callLog.push('verify')
+        return false
+      }),
+    }
+    const history: PasswordHistoryRepository = {
+      listRecent: vi.fn(async () => {
+        callLog.push('listRecent')
+        return []
+      }),
+      add: vi.fn(async () => {
+        callLog.push('add')
+      }),
+    }
+    const persist: PasswordPersistencePort = {
+      updateUserPasswordHash: vi.fn(async () => {
+        callLog.push('persist')
+      }),
+    }
+
+    const service = createPasswordService({
+      hasher,
+      history,
+      persist,
+      clock: () => new Date('2026-04-17T00:00:00.000Z'),
+    })
+
+    const result = await service.changePassword({
+      userId: 'user-1',
+      newPassword: VALID_PASSWORD,
+    })
+
+    expect(result.newHash).toBe(`hashed(${VALID_PASSWORD})`)
+    // 履歴が空なので verify は呼ばれない
+    expect(callLog).toEqual(['listRecent', 'hash', 'persist', 'add'])
+  })
+
+  it('LENGTH 違反時は persist / history.add / hash を呼ばない', async () => {
+    const hasher = createFakeHasher()
+    const history = createInMemoryPasswordHistoryRepository()
+    const historyAddSpy = vi.spyOn(history, 'add')
+    const persist = createTrackingPersist()
+    const service = createPasswordService({ hasher, history, persist })
+
+    await expect(
+      service.changePassword({ userId: 'user-1', newPassword: 'Short1!' }),
+    ).rejects.toMatchObject({ name: 'PasswordPolicyViolationError', rule: 'LENGTH' })
+
+    expect(persist.calls).toHaveLength(0)
+    expect(historyAddSpy).not.toHaveBeenCalled()
+    expect(hasher.hash).not.toHaveBeenCalled()
+  })
+
+  it('COMPLEXITY 違反時は persist / history.add / hash を呼ばない', async () => {
+    const hasher = createFakeHasher()
+    const history = createInMemoryPasswordHistoryRepository()
+    const historyAddSpy = vi.spyOn(history, 'add')
+    const persist = createTrackingPersist()
+    const service = createPasswordService({ hasher, history, persist })
+
+    try {
+      await service.changePassword({ userId: 'user-1', newPassword: 'abcdefghijklmn' })
+      throw new Error('should have thrown')
+    } catch (error: unknown) {
+      expect(error).toBeInstanceOf(PasswordPolicyViolationError)
+      if (error instanceof PasswordPolicyViolationError) {
+        expect(error.rule).toBe('COMPLEXITY')
+      }
+    }
+
+    expect(persist.calls).toHaveLength(0)
+    expect(historyAddSpy).not.toHaveBeenCalled()
+    expect(hasher.hash).not.toHaveBeenCalled()
+  })
+
+  it('過去履歴と一致したら REUSED で拒否 (persist / add は呼ばれない)', async () => {
+    const history = createInMemoryPasswordHistoryRepository([
+      {
+        userId: 'user-1',
+        hash: `hashed(${VALID_PASSWORD})`,
+        createdAt: new Date('2026-04-01T00:00:00.000Z'),
+      },
+    ])
+    const historyAddSpy = vi.spyOn(history, 'add')
+    const hasher = createFakeHasher()
+    const persist = createTrackingPersist()
+    const service = createPasswordService({ hasher, history, persist })
+
+    try {
+      await service.changePassword({ userId: 'user-1', newPassword: VALID_PASSWORD })
+      throw new Error('should have thrown')
+    } catch (error: unknown) {
+      expect(error).toBeInstanceOf(PasswordPolicyViolationError)
+      if (error instanceof PasswordPolicyViolationError) {
+        expect(error.rule).toBe('REUSED')
+      }
+    }
+
+    expect(persist.calls).toHaveLength(0)
+    expect(historyAddSpy).not.toHaveBeenCalled()
+    // verify は最低 1 回呼ばれている (履歴チェック)
+    expect(hasher.verify).toHaveBeenCalled()
+  })
+
+  it('履歴が空なら verify スキップ, 正常変更が成立', async () => {
+    const hasher = createFakeHasher()
+    const history = createInMemoryPasswordHistoryRepository()
+    const persist = createTrackingPersist()
+    const service = createPasswordService({ hasher, history, persist })
+
+    await service.changePassword({ userId: 'user-1', newPassword: VALID_PASSWORD })
+
+    expect(hasher.verify).not.toHaveBeenCalled()
+    expect(hasher.hash).toHaveBeenCalledTimes(1)
+    expect(persist.calls).toHaveLength(1)
+  })
+
+  it('履歴にあるが一致しないものはスキップされ、正常変更が成立する', async () => {
+    const history = createInMemoryPasswordHistoryRepository([
+      {
+        userId: 'user-1',
+        hash: 'hashed(OldPassw0rd!!!)',
+        createdAt: new Date('2026-03-01T00:00:00.000Z'),
+      },
+    ])
+    const historyAddSpy = vi.spyOn(history, 'add')
+    const hasher = createFakeHasher()
+    const persist = createTrackingPersist()
+    const service = createPasswordService({ hasher, history, persist })
+
+    const result = await service.changePassword({
+      userId: 'user-1',
+      newPassword: VALID_PASSWORD,
+    })
+    expect(result.newHash).toBe(`hashed(${VALID_PASSWORD})`)
+    expect(persist.calls).toEqual([['user-1', `hashed(${VALID_PASSWORD})`]])
+    expect(historyAddSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('clock 未指定でも例外なく完了する (Date.now() フォールバック)', async () => {
+    const hasher = createFakeHasher()
+    const history = createInMemoryPasswordHistoryRepository()
+    const persist = createTrackingPersist()
+    const service = createPasswordService({ hasher, history, persist })
+    await expect(
+      service.changePassword({ userId: 'user-1', newPassword: VALID_PASSWORD }),
+    ).resolves.toBeDefined()
+  })
+})


### PR DESCRIPTION
Closes #20

## サマリ
Task 6.2 を実装します。パスワード強度ポリシー、過去世代の再利用防止、5 回連続失敗でのアカウントロック・通知を `AuthService` に追加しました。

UI 画面 / Prisma 実装 / NextAuth ルート配線は**後続タスク**のスコープです。本 PR は純粋なドメインロジックと In-memory / Redis / port 定義までを扱います。

## 要件マッピング

| 要件 | 実装 |
|-----|------|
| **Req 1.3** 5 回連続失敗で 15 分ロックし通知 | `LockoutStore` (InMemory + Redis)、`LockoutNotifier`、`AuthService.login` への配線、`ACCOUNT_LOCKED` 監査ログ |
| **Req 1.12** 最低 12 文字 / 4 種中 3 種以上 | `password-policy.ts` (`assertPasswordStrong`, `isPasswordStrong`, `classifyPassword`) |
| **Req 1.13** 過去 5 世代の再利用拒否 | `PasswordHistoryRepository` (InMemory) と `PasswordService.changePassword` での `PasswordPolicyViolationError('REUSED')` |

## 変更ファイル

### 新規
- `src/lib/auth/password-policy.ts` — 純粋な強度ポリシー (`PASSWORD_MIN_LENGTH=12`, `PASSWORD_REQUIRED_CHAR_CLASSES=3`)
- `src/lib/auth/password-history-repository.ts` — InMemory 実装 (`PASSWORD_HISTORY_SIZE=5` で自動剪定)
- `src/lib/auth/password-service.ts` — `changePassword` (assert → history check → hash → persist → history.add)
- `src/lib/auth/lockout-store.ts` — InMemory + Redis (`MAX_FAILED_LOGIN_ATTEMPTS=5`, `LOCKOUT_DURATION_MS=15min`)
- `src/lib/auth/lockout-notifier.ts` — SYSTEM 通知 emitter への narrow port
- 新規テスト 5 本: `password-policy.test.ts`, `password-history-repository.test.ts`, `password-service.test.ts`, `lockout-store.test.ts`, `lockout-notifier.test.ts`

### 変更
- `src/lib/auth/auth-types.ts` — `PasswordPolicyViolationError(rule)`, `AccountLockedError(lockedUntil)` を追加 (既存例外は非改変)
- `src/lib/auth/auth-service.ts` — `createAuthService` に `lockout? / notifier? / auditLogger?` を optional で追加、`login` を拡張
- `src/tests/auth/auth-service.test.ts` — 新規テスト 9 本を追加 (既存テスト 15 本はそのまま)

## 設計メモ
- `lockout / notifier / auditLogger` はすべて `AuthService.deps` に **optional で注入**。未指定時は従来通り動作 (後方互換)。
- 通知失敗 / 監査失敗は **fire-and-forget** — 認証フローを止めない。
- 既にロック中のアカウントでパスワード誤り入力を受けても再通知は起きない (`AccountLockedError` で先に弾かれるため)。
- ユーザーが存在しない場合は `lockout.recordFailure` を**呼ばない** (存在漏洩防止)。
- 監査ポート (`AuthAuditLoggerPort`) は既存 `AuditLogEmitter.emit` と構造互換な narrow port。Prisma 接続は後続タスク。
- Prisma 実装 / NextAuth ルート配線 / UI 画面 / Req 1.10 (招待メール) は**スコープ外**。

## テスト結果

```
Test Files  64 passed (64)
     Tests  711 passed (711)
```

本 PR で追加した 67 テストはすべてグリーン。既存 644 テストもすべて通過。

- `pnpm lint` — No ESLint warnings or errors
- `pnpm type-check` — 新規 / 変更ファイル 0 エラー (pre-existing な Prisma client 未生成等の既存エラーは無関係)
- `pnpm test` — 711/711 passing

## Test plan
- [x] `src/tests/auth/password-policy.test.ts` — LENGTH / COMPLEXITY の境界ケース、4 クラス判定、Unicode 記号除外
- [x] `src/tests/auth/password-history-repository.test.ts` — InMemory 追加・新しい順・剪定・ユーザー独立・seed 上限超過
- [x] `src/tests/auth/password-service.test.ts` — 正常順序・LENGTH/COMPLEXITY/REUSED で persist/add 未呼び出し・空履歴でスキップ
- [x] `src/tests/auth/lockout-store.test.ts` — 4 失敗 / 5 失敗ロック / ロック中は据え置き / 15min 後自動解除 / reset / option override
- [x] `src/tests/auth/lockout-notifier.test.ts` — category=SYSTEM, payload.lockedUntil(ISO), タイトル/本文
- [x] `src/tests/auth/auth-service.test.ts` (新規ケース) — 後方互換 / recordFailure 呼び出し / ユーザー不在で未呼び出し / AccountLockedError / 5 回目で通知+監査 1 回 / context 伝搬 / unknown fallback / 成功で reset / 通知&監査の fire-and-forget