### PR TITLE
feat(rbac): Task 6.3 — ロールベースアクセス制御 (RBAC) middleware

### DIFF
--- a/src/lib/audit/audit-log-types.ts
+++ b/src/lib/audit/audit-log-types.ts
@@ -29,6 +29,8 @@ export const AUDIT_ACTIONS = [
   'DATA_EXPORT',
   // Custom broadcast notification events (Requirement 15.8)
   'CUSTOM_BROADCAST_SENT',
+  // Access denied events (Requirements 1.8, 1.9 / Task 6.3)
+  'ACCESS_DENIED',
 ] as const
 
 export type AuditAction = (typeof AUDIT_ACTIONS)[number]

--- a/src/lib/rbac/authorizer.ts
+++ b/src/lib/rbac/authorizer.ts
@@ -1,0 +1,201 @@
+/**
+ * RBAC Authorizer
+ *
+ * Task 6.3 — 認可ルールの純粋な判定 (`decide`) と、
+ * 拒否時に監査ログを残して例外 throw する強制実行 (`enforce`) を提供する。
+ *
+ * narrow port (AuditLoggerPort) を注入する設計により、
+ * 実体の `AuditLogEmitter` (Prisma 依存) に直接依存せずテスト容易性を保つ。
+ *
+ * 関連要件:
+ * - Req 1.8: HR_MANAGER は人事データの読み取り
+ * - Req 1.9: 他者の個人評価アクセス拒否 + 監査ログ記録
+ */
+import { DEFAULT_POLICY_RULES } from './policy'
+import {
+  ForbiddenError,
+  type Action,
+  type AuthSubject,
+  type AuthorizationDecision,
+  type AuthorizationReason,
+  type PolicyRule,
+  type ResourceRef,
+} from './rbac-types'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// narrow port — 外部の監査ログ基盤へ書き出す抽象 (AuditLogEmitter 互換 shape)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** 認可拒否ログ 1 件。実装は Prisma / memory / Null 等で差し替え可能 */
+export interface AccessDeniedLogEntry {
+  readonly userId: string | null
+  readonly action: string
+  readonly resourceType: string
+  readonly resourceId: string | null
+  readonly ipAddress: string
+  readonly userAgent: string
+  readonly before: Record<string, unknown> | null
+  readonly after: Record<string, unknown> | null
+}
+
+/**
+ * narrow port。`@/lib/audit/audit-log-emitter` の AuditLogEmitter と互換。
+ * audit-log-types への直接依存を避け、shape だけを要求する。
+ */
+export interface AuditLoggerPort {
+  emit(entry: AccessDeniedLogEntry): Promise<void>
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 公開 API
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface Authorizer {
+  /** 副作用のない純粋判定 */
+  decide(subject: AuthSubject, action: Action, resource: ResourceRef): AuthorizationDecision
+
+  /** 拒否時は auditLogger で記録した上で ForbiddenError を throw */
+  enforce(
+    subject: AuthSubject,
+    action: Action,
+    resource: ResourceRef,
+    context?: RequestContext,
+  ): Promise<void>
+}
+
+export interface RequestContext {
+  readonly ipAddress?: string
+  readonly userAgent?: string
+}
+
+export interface CreateAuthorizerOptions {
+  /** 未指定時は DEFAULT_POLICY_RULES を使用 */
+  readonly rules?: readonly PolicyRule[]
+  /** 未指定時は拒否ログを記録しない (ForbiddenError の throw は変わらない) */
+  readonly auditLogger?: AuditLoggerPort
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 内部ヘルパ
+// ─────────────────────────────────────────────────────────────────────────────
+
+function findMatchingRule(
+  rules: readonly PolicyRule[],
+  resourceType: string,
+  action: Action,
+): PolicyRule | undefined {
+  return rules.find((rule) => rule.resourceType === resourceType && rule.action === action)
+}
+
+function isRoleAllowed(rule: PolicyRule, subject: AuthSubject): boolean {
+  return rule.allowedRoles.includes(subject.role)
+}
+
+function isOwner(rule: PolicyRule, subject: AuthSubject, resource: ResourceRef): boolean {
+  return rule.ownerCanAccess === true && resource.ownerId === subject.userId
+}
+
+/**
+ * decide() の本体。純粋関数。
+ *
+ * - ルール未ヒット: DENIED_NO_RULE
+ * - ロール許可: ALLOWED_BY_ROLE
+ * - 所有者許可: ALLOWED_AS_OWNER
+ * - ownerCanAccess あり + ownerId 不一致: DENIED_NOT_OWNER
+ * - それ以外: DENIED_INSUFFICIENT_ROLE
+ */
+function decideWithRules(
+  rules: readonly PolicyRule[],
+  subject: AuthSubject,
+  action: Action,
+  resource: ResourceRef,
+): AuthorizationDecision {
+  const rule = findMatchingRule(rules, resource.type, action)
+  if (!rule) {
+    return { allowed: false, reason: 'DENIED_NO_RULE' }
+  }
+
+  if (isRoleAllowed(rule, subject)) {
+    return { allowed: true, reason: 'ALLOWED_BY_ROLE' }
+  }
+
+  if (isOwner(rule, subject, resource)) {
+    return { allowed: true, reason: 'ALLOWED_AS_OWNER' }
+  }
+
+  // ownerCanAccess=true かつ ownerId が指定されていて本人ではない場合は NOT_OWNER
+  if (rule.ownerCanAccess === true && resource.ownerId !== undefined) {
+    return { allowed: false, reason: 'DENIED_NOT_OWNER' }
+  }
+
+  return { allowed: false, reason: 'DENIED_INSUFFICIENT_ROLE' }
+}
+
+function buildAccessDeniedEntry(
+  subject: AuthSubject,
+  action: Action,
+  resource: ResourceRef,
+  reason: AuthorizationReason,
+  context: RequestContext | undefined,
+): AccessDeniedLogEntry {
+  return {
+    userId: subject.userId,
+    action: 'ACCESS_DENIED',
+    resourceType: resource.type,
+    resourceId: resource.id,
+    ipAddress: context?.ipAddress ?? '',
+    userAgent: context?.userAgent ?? '',
+    before: null,
+    after: {
+      reason,
+      requestedAction: action,
+      subjectRole: subject.role,
+    },
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 実装
+// ─────────────────────────────────────────────────────────────────────────────
+
+class AuthorizerImpl implements Authorizer {
+  private readonly rules: readonly PolicyRule[]
+  private readonly auditLogger: AuditLoggerPort | undefined
+
+  constructor(rules: readonly PolicyRule[], auditLogger: AuditLoggerPort | undefined) {
+    this.rules = rules
+    this.auditLogger = auditLogger
+  }
+
+  decide(subject: AuthSubject, action: Action, resource: ResourceRef): AuthorizationDecision {
+    return decideWithRules(this.rules, subject, action, resource)
+  }
+
+  async enforce(
+    subject: AuthSubject,
+    action: Action,
+    resource: ResourceRef,
+    context?: RequestContext,
+  ): Promise<void> {
+    const decision = this.decide(subject, action, resource)
+    if (decision.allowed) {
+      return
+    }
+
+    if (this.auditLogger !== undefined) {
+      const entry = buildAccessDeniedEntry(subject, action, resource, decision.reason, context)
+      await this.auditLogger.emit(entry)
+    }
+
+    throw new ForbiddenError(resource.type, action, decision.reason)
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Factory
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function createAuthorizer(opts: CreateAuthorizerOptions): Authorizer {
+  const rules = opts.rules ?? DEFAULT_POLICY_RULES
+  return new AuthorizerImpl(rules, opts.auditLogger)
+}

--- a/src/lib/rbac/next-middleware.ts
+++ b/src/lib/rbac/next-middleware.ts
@@ -1,0 +1,188 @@
+/**
+ * Next.js middleware 向け ルートガードヘルパ
+ *
+ * Task 6.3 — URL ルート単位でロール判定を行う「多層防御の第 1 層」。
+ * 実際の `src/middleware.ts` への組み込みは後続タスクで行う。ここでは
+ * フレームワーク非依存なヘルパ (Request/Response Fetch API) のみを提供する。
+ *
+ * 関連要件:
+ * - Req 1.7: 4 ロール管理
+ * - Req 1.9: 他者の個人評価へのアクセスは 403 拒否 + 監査ログ記録
+ */
+import type { AuditLoggerPort } from './authorizer'
+import type { AuthSubject } from './rbac-types'
+import type { UserRole } from '@/lib/notification/notification-types'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 公開型
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface RoutePolicy {
+  /** 対象パスの正規表現 (pathname に対してマッチ) */
+  readonly pathPattern: RegExp
+  /** このパスへのアクセスを許可するロール */
+  readonly allowedRoles: readonly UserRole[]
+  /** 拒否ログに乗せるリソース識別子 (省略時は 'ROUTE') */
+  readonly resourceType?: string
+}
+
+/**
+ * Next.js Request から認証済み Subject を解決するためのポート。
+ * NextAuth / セッションストアの具体実装を抽象化してテスト容易性を確保する。
+ * (require-role.ts の SubjectProvider と同一形状だが、モジュール独立性のため個別定義)
+ */
+export interface SubjectProvider {
+  getSubject(request: Request): Promise<AuthSubject | null>
+}
+
+export interface RouteGuardDeps {
+  readonly policies: readonly RoutePolicy[]
+  readonly subjectProvider: SubjectProvider
+  readonly auditLogger?: AuditLoggerPort
+}
+
+export interface RouteGuard {
+  /** 通過するなら null / 停止するなら Response (401 or 403) を返す */
+  guard(request: Request): Promise<Response | null>
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 定数
+// ─────────────────────────────────────────────────────────────────────────────
+
+const DEFAULT_RESOURCE_TYPE = 'ROUTE'
+const ROLE_ONLY_DENIED_REASON = 'DENIED_INSUFFICIENT_ROLE'
+const ROUTE_REQUESTED_ACTION = 'READ'
+const JSON_CONTENT_TYPE = 'application/json'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ポリシーマッチャ
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * policies の先頭から順に pathPattern.test(pathname) を試し、
+ * 最初にマッチした RoutePolicy を返す。どれにもマッチしなければ null。
+ */
+export function matchRoutePolicy(
+  pathname: string,
+  policies: readonly RoutePolicy[],
+): RoutePolicy | null {
+  for (const policy of policies) {
+    if (policy.pathPattern.test(pathname)) {
+      return policy
+    }
+  }
+  return null
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Response ヘルパ
+// ─────────────────────────────────────────────────────────────────────────────
+
+function jsonResponse(status: number, body: Record<string, unknown>): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': JSON_CONTENT_TYPE },
+  })
+}
+
+function unauthorizedResponse(): Response {
+  return jsonResponse(401, { error: 'Unauthorized' })
+}
+
+function forbiddenResponse(resourceType: string): Response {
+  return jsonResponse(403, { error: 'Forbidden', resourceType })
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// コンテキスト抽出
+// ─────────────────────────────────────────────────────────────────────────────
+
+function extractIpAddress(request: Request): string {
+  const xff = request.headers.get('x-forwarded-for')
+  if (xff !== null && xff.length > 0) {
+    // 先頭の IP のみ採用 (X-Forwarded-For: client, proxy1, proxy2)
+    const firstIp = xff.split(',')[0]
+    return firstIp !== undefined ? firstIp.trim() : ''
+  }
+  return request.headers.get('x-real-ip') ?? ''
+}
+
+function extractUserAgent(request: Request): string {
+  return request.headers.get('user-agent') ?? ''
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Guard 実装
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function emitAccessDenied(
+  auditLogger: AuditLoggerPort | undefined,
+  subject: AuthSubject,
+  policy: RoutePolicy,
+  request: Request,
+): Promise<void> {
+  if (auditLogger === undefined) {
+    return
+  }
+  const resourceType = policy.resourceType ?? DEFAULT_RESOURCE_TYPE
+  await auditLogger.emit({
+    userId: subject.userId,
+    action: 'ACCESS_DENIED',
+    resourceType,
+    resourceId: null,
+    ipAddress: extractIpAddress(request),
+    userAgent: extractUserAgent(request),
+    before: null,
+    after: {
+      reason: ROLE_ONLY_DENIED_REASON,
+      requestedAction: ROUTE_REQUESTED_ACTION,
+      subjectRole: subject.role,
+      allowedRoles: [...policy.allowedRoles],
+      path: new URL(request.url).pathname,
+    },
+  })
+}
+
+function isRoleAllowed(subject: AuthSubject, policy: RoutePolicy): boolean {
+  return policy.allowedRoles.includes(subject.role)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Factory
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Next.js middleware から呼び出すためのガード factory。
+ *
+ * 戻り値 guard(request) は:
+ * - policy 未マッチ → null (通過)
+ * - subject 解決失敗 → 401 Response
+ * - subject.role が許可ロール → null (通過)
+ * - そうでない → 403 Response (+ 監査ログ emit)
+ */
+export function createRouteGuard(deps: RouteGuardDeps): RouteGuard {
+  const { policies, subjectProvider, auditLogger } = deps
+
+  return {
+    async guard(request: Request): Promise<Response | null> {
+      const pathname = new URL(request.url).pathname
+      const policy = matchRoutePolicy(pathname, policies)
+      if (policy === null) {
+        return null
+      }
+
+      const subject = await subjectProvider.getSubject(request)
+      if (subject === null) {
+        return unauthorizedResponse()
+      }
+
+      if (isRoleAllowed(subject, policy)) {
+        return null
+      }
+
+      await emitAccessDenied(auditLogger, subject, policy, request)
+      return forbiddenResponse(policy.resourceType ?? DEFAULT_RESOURCE_TYPE)
+    },
+  }
+}

--- a/src/lib/rbac/policy.ts
+++ b/src/lib/rbac/policy.ts
@@ -1,0 +1,141 @@
+/**
+ * デフォルト RBAC ポリシー
+ *
+ * Task 6.3 — HR 人事管理システムの主要リソースに対するデフォルト認可ルール。
+ * 新規リソースタイプはここに追加する。
+ *
+ * 関連要件:
+ * - Req 1.8: HR_MANAGER ロールは全社員の評価・配置・目標データへの読み取り権限
+ * - Req 1.9: EMPLOYEE ロールは他の社員の個人評価データへアクセスすると 403
+ */
+import type { PolicyRule } from './rbac-types'
+
+/**
+ * 本プロダクトのデフォルトポリシー。
+ *
+ * 方針:
+ * - ADMIN は全操作を許可 (明示的に allowedRoles に含める)
+ * - HR_MANAGER は人事データの READ/UPDATE を広く許可、DELETE は ADMIN のみ
+ * - MANAGER は 1on1 など部下向け操作のみ
+ * - EMPLOYEE は自分のデータへの READ/UPDATE を `ownerCanAccess: true` で許可
+ *
+ * 新しいリソースを追加する際は、EMPLOYEE が自分のデータを操作できるかを
+ * 最初に検討し、必要なら ownerCanAccess を true にすること。
+ */
+export const DEFAULT_POLICY_RULES: readonly PolicyRule[] = [
+  // ─── EVALUATION (評価) — Req 1.8 / 1.9 ──────────────────────────────────
+  // READ: ADMIN / HR_MANAGER は全件、本人は自分の分のみ
+  {
+    resourceType: 'EVALUATION',
+    action: 'READ',
+    allowedRoles: ['ADMIN', 'HR_MANAGER'],
+    ownerCanAccess: true,
+  },
+  // CREATE: 全ロールが自分の評価を作成可能
+  {
+    resourceType: 'EVALUATION',
+    action: 'CREATE',
+    allowedRoles: ['ADMIN', 'HR_MANAGER', 'MANAGER', 'EMPLOYEE'],
+  },
+  // UPDATE: ADMIN / HR_MANAGER は全件、本人は自分の分のみ
+  {
+    resourceType: 'EVALUATION',
+    action: 'UPDATE',
+    allowedRoles: ['ADMIN', 'HR_MANAGER'],
+    ownerCanAccess: true,
+  },
+  // DELETE: ADMIN のみ
+  {
+    resourceType: 'EVALUATION',
+    action: 'DELETE',
+    allowedRoles: ['ADMIN'],
+  },
+
+  // ─── GOAL (目標) — Req 1.8 ───────────────────────────────────────────────
+  {
+    resourceType: 'GOAL',
+    action: 'READ',
+    allowedRoles: ['ADMIN', 'HR_MANAGER'],
+    ownerCanAccess: true,
+  },
+  {
+    resourceType: 'GOAL',
+    action: 'CREATE',
+    allowedRoles: ['ADMIN', 'HR_MANAGER', 'MANAGER', 'EMPLOYEE'],
+  },
+  {
+    resourceType: 'GOAL',
+    action: 'UPDATE',
+    allowedRoles: ['ADMIN', 'HR_MANAGER'],
+    ownerCanAccess: true,
+  },
+  {
+    resourceType: 'GOAL',
+    action: 'DELETE',
+    allowedRoles: ['ADMIN', 'HR_MANAGER'],
+    ownerCanAccess: true,
+  },
+
+  // ─── POSITION (配置) — Req 1.8 ───────────────────────────────────────────
+  {
+    resourceType: 'POSITION',
+    action: 'READ',
+    allowedRoles: ['ADMIN', 'HR_MANAGER'],
+  },
+
+  // ─── PROFILE (プロフィール) ─────────────────────────────────────────────
+  {
+    resourceType: 'PROFILE',
+    action: 'READ',
+    allowedRoles: ['ADMIN', 'HR_MANAGER', 'MANAGER'],
+    ownerCanAccess: true,
+  },
+  {
+    resourceType: 'PROFILE',
+    action: 'UPDATE',
+    allowedRoles: ['ADMIN', 'HR_MANAGER'],
+    ownerCanAccess: true,
+  },
+
+  // ─── ONE_ON_ONE (1on1) — 上長 + HR + ADMIN ─────────────────────────────
+  {
+    resourceType: 'ONE_ON_ONE',
+    action: 'READ',
+    allowedRoles: ['ADMIN', 'HR_MANAGER', 'MANAGER'],
+    ownerCanAccess: true,
+  },
+  {
+    resourceType: 'ONE_ON_ONE',
+    action: 'CREATE',
+    allowedRoles: ['ADMIN', 'HR_MANAGER', 'MANAGER'],
+  },
+  {
+    resourceType: 'ONE_ON_ONE',
+    action: 'UPDATE',
+    allowedRoles: ['ADMIN', 'HR_MANAGER', 'MANAGER'],
+  },
+
+  // ─── マスタデータ / 組織 ─────────────────────────────────────────────
+  {
+    resourceType: 'MASTER_DATA',
+    action: 'MANAGE',
+    allowedRoles: ['ADMIN', 'HR_MANAGER'],
+  },
+  {
+    resourceType: 'ORGANIZATION',
+    action: 'MANAGE',
+    allowedRoles: ['ADMIN', 'HR_MANAGER'],
+  },
+
+  // ─── 監査ログ / システム設定 (ADMIN のみ) ───────────────────────────
+  {
+    resourceType: 'AUDIT_LOG',
+    action: 'READ',
+    allowedRoles: ['ADMIN'],
+  },
+  {
+    resourceType: 'SYSTEM_CONFIG',
+    action: 'MANAGE',
+    allowedRoles: ['ADMIN'],
+  },
+] as const

--- a/src/lib/rbac/rbac-types.ts
+++ b/src/lib/rbac/rbac-types.ts
@@ -1,0 +1,102 @@
+/**
+ * RBAC (Role-Based Access Control) 共通型
+ *
+ * Task 6.3 — ADMIN / HR_MANAGER / MANAGER / EMPLOYEE の 4 ロールを軸に、
+ * 「誰が (Subject)・何を (Resource)・どう操作できるか (Action)」を表現する。
+ *
+ * 関連要件:
+ * - Req 1.7: 4 ロールで権限を管理
+ * - Req 1.8: HR_MANAGER は全社員の評価・配置・目標を読める
+ * - Req 1.9: EMPLOYEE は他者の個人評価へアクセスすると 403
+ */
+import type { UserRole } from '@/lib/notification/notification-types'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Subject / Resource
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** 認証済みプリンシパル (セッション相当) */
+export interface AuthSubject {
+  readonly userId: string
+  readonly role: UserRole
+}
+
+/**
+ * リソース参照。所有権判定 (ownerCanAccess) のためのヒントを含む。
+ * type は 'EVALUATION' | 'GOAL' | ... を想定するが、ポリシーで自由に拡張できるよう
+ * string として扱う (DEFAULT_POLICY_RULES と同じ識別子を使うのが前提)。
+ */
+export interface ResourceRef {
+  readonly type: string
+  readonly id: string
+  /** リソースの所有者 userId。未指定時は所有権チェック不可 */
+  readonly ownerId?: string
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Action
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const ACTIONS = ['READ', 'CREATE', 'UPDATE', 'DELETE', 'MANAGE'] as const
+export type Action = (typeof ACTIONS)[number]
+
+export function isAction(value: unknown): value is Action {
+  return typeof value === 'string' && (ACTIONS as readonly string[]).includes(value)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Policy
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * 認可ルール。
+ * - allowedRoles: このアクションを許可するロールの集合
+ * - ownerCanAccess: true の場合、ロールに含まれないユーザーでも
+ *   resource.ownerId === subject.userId なら許可する (本人アクセス)
+ */
+export interface PolicyRule {
+  readonly resourceType: string
+  readonly action: Action
+  readonly allowedRoles: readonly UserRole[]
+  readonly ownerCanAccess?: boolean
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 認可判定結果
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** 認可決定の理由コード (UI/audit ログで分析可能にするため文字列で公開) */
+export type AuthorizationReason =
+  | 'ALLOWED_BY_ROLE'
+  | 'ALLOWED_AS_OWNER'
+  | 'DENIED_NO_RULE'
+  | 'DENIED_INSUFFICIENT_ROLE'
+  | 'DENIED_NOT_OWNER'
+
+export interface AuthorizationDecision {
+  readonly allowed: boolean
+  readonly reason: AuthorizationReason
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ドメイン例外
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * 認可拒否例外。
+ * - resourceType / action / reason を保持し、呼び出し側で 403 応答や監査ログの
+ *   分岐に使えるようにする
+ */
+export class ForbiddenError extends Error {
+  public readonly resourceType: string
+  public readonly action: Action
+  public readonly reason: AuthorizationReason
+
+  constructor(resourceType: string, action: Action, reason: AuthorizationReason) {
+    super(`Forbidden: ${action} on ${resourceType} (${reason})`)
+    this.name = 'ForbiddenError'
+    this.resourceType = resourceType
+    this.action = action
+    this.reason = reason
+  }
+}

--- a/src/lib/rbac/require-role.ts
+++ b/src/lib/rbac/require-role.ts
@@ -1,0 +1,99 @@
+/**
+ * requireRole — サービス層/API ルート向けロール強制ヘルパ
+ *
+ * Task 6.3 — 「このロールのいずれかでないと処理を継続させない」を
+ * 1 行で表現するための薄いラッパ。内部では Authorizer のルール機構を使わず、
+ * 直接 allowedRoles を判定する (role-only の早期拒否)。
+ *
+ * 拒否時は ForbiddenError を throw し、auditLogger が注入されていれば
+ * action='ACCESS_DENIED' の監査ログを記録する。
+ */
+import type { AuditLoggerPort } from './authorizer'
+import { ForbiddenError, type AuthSubject } from './rbac-types'
+import type { UserRole } from '@/lib/notification/notification-types'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 型
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface RequireRoleOptions {
+  /** 監査ログに乗せるリソース識別子のヒント (省略時は resourceType='ROUTE') */
+  readonly resourceHint?: {
+    readonly type: string
+    readonly id?: string
+  }
+  /** HTTP コンテキスト (IP / UA) */
+  readonly context?: {
+    readonly ipAddress?: string
+    readonly userAgent?: string
+  }
+  /** 拒否時に監査ログを記録するためのポート */
+  readonly auditLogger?: AuditLoggerPort
+}
+
+/**
+ * Next.js Request から認証済み Subject を解決するためのポート。
+ * NextAuth / セッションストアの具体実装を抽象化してテスト容易性を確保する。
+ */
+export interface SubjectProvider {
+  getSubject(request: Request): Promise<AuthSubject | null>
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 定数
+// ─────────────────────────────────────────────────────────────────────────────
+
+const DEFAULT_RESOURCE_TYPE = 'ROUTE'
+/** requireRole は純粋なロール判定なので、決定理由は常にこれで固定 */
+const ROLE_ONLY_DENIED_REASON = 'DENIED_INSUFFICIENT_ROLE'
+/** requireRole は HTTP メソッドに非依存なので、拒否時の "要求アクション" は READ 相当で記録 */
+const ROLE_CHECK_REQUESTED_ACTION = 'READ'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ヘルパ
+// ─────────────────────────────────────────────────────────────────────────────
+
+function isAllowedRole(subject: AuthSubject, allowedRoles: readonly UserRole[]): boolean {
+  return allowedRoles.includes(subject.role)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 公開 API
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * subject.role が allowedRoles のいずれかと一致することを要求する。
+ * 一致しない場合は ForbiddenError を throw し、auditLogger があれば ACCESS_DENIED を emit。
+ */
+export async function requireRole(
+  subject: AuthSubject,
+  allowedRoles: readonly UserRole[],
+  opts: RequireRoleOptions = {},
+): Promise<void> {
+  if (isAllowedRole(subject, allowedRoles)) {
+    return
+  }
+
+  const resourceType = opts.resourceHint?.type ?? DEFAULT_RESOURCE_TYPE
+  const resourceId = opts.resourceHint?.id ?? null
+
+  if (opts.auditLogger !== undefined) {
+    await opts.auditLogger.emit({
+      userId: subject.userId,
+      action: 'ACCESS_DENIED',
+      resourceType,
+      resourceId,
+      ipAddress: opts.context?.ipAddress ?? '',
+      userAgent: opts.context?.userAgent ?? '',
+      before: null,
+      after: {
+        reason: ROLE_ONLY_DENIED_REASON,
+        requestedAction: ROLE_CHECK_REQUESTED_ACTION,
+        subjectRole: subject.role,
+        allowedRoles: [...allowedRoles],
+      },
+    })
+  }
+
+  throw new ForbiddenError(resourceType, ROLE_CHECK_REQUESTED_ACTION, ROLE_ONLY_DENIED_REASON)
+}

--- a/src/tests/audit/audit-log-types.test.ts
+++ b/src/tests/audit/audit-log-types.test.ts
@@ -37,6 +37,10 @@ describe('AuditAction', () => {
   it('should include custom broadcast notification events (Req 15.8)', () => {
     expect(AUDIT_ACTIONS).toContain('CUSTOM_BROADCAST_SENT')
   })
+
+  it('should include access denied events (Req 1.8, 1.9 / Task 6.3)', () => {
+    expect(AUDIT_ACTIONS).toContain('ACCESS_DENIED')
+  })
 })
 
 describe('AuditResourceType', () => {

--- a/src/tests/rbac/authorizer.test.ts
+++ b/src/tests/rbac/authorizer.test.ts
@@ -1,0 +1,304 @@
+import { describe, it, expect, vi } from 'vitest'
+
+import { createAuthorizer, type AuditLoggerPort } from '@/lib/rbac/authorizer'
+import { DEFAULT_POLICY_RULES } from '@/lib/rbac/policy'
+import {
+  ForbiddenError,
+  type Action,
+  type AuthSubject,
+  type PolicyRule,
+  type ResourceRef,
+} from '@/lib/rbac/rbac-types'
+import type { UserRole } from '@/lib/notification/notification-types'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fixtures
+// ─────────────────────────────────────────────────────────────────────────────
+
+function subject(userId: string, role: UserRole): AuthSubject {
+  return { userId, role }
+}
+
+function resource(type: string, id: string, ownerId?: string): ResourceRef {
+  return { type, id, ownerId }
+}
+
+interface AuditSpy extends AuditLoggerPort {
+  readonly emit: ReturnType<typeof vi.fn>
+}
+
+function makeAuditSpy(): AuditSpy {
+  const emit = vi.fn(async () => {})
+  return { emit } as AuditSpy
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// decide() — デフォルトポリシー
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('Authorizer.decide() with DEFAULT_POLICY_RULES', () => {
+  const authz = createAuthorizer({})
+
+  // --- ADMIN is allowed across the board ---
+  it.each<[Action]>([['READ'], ['UPDATE'], ['DELETE']])(
+    'ADMIN is allowed for EVALUATION %s',
+    (action) => {
+      const d = authz.decide(subject('admin-1', 'ADMIN'), action, resource('EVALUATION', 'e1'))
+      expect(d.allowed).toBe(true)
+      expect(d.reason).toBe('ALLOWED_BY_ROLE')
+    },
+  )
+
+  it('ADMIN is allowed for AUDIT_LOG READ', () => {
+    const d = authz.decide(subject('a1', 'ADMIN'), 'READ', resource('AUDIT_LOG', 'l1'))
+    expect(d.allowed).toBe(true)
+    expect(d.reason).toBe('ALLOWED_BY_ROLE')
+  })
+
+  it('ADMIN is allowed for SYSTEM_CONFIG MANAGE', () => {
+    const d = authz.decide(subject('a1', 'ADMIN'), 'MANAGE', resource('SYSTEM_CONFIG', 's1'))
+    expect(d.allowed).toBe(true)
+  })
+
+  // --- HR_MANAGER ---
+  it('HR_MANAGER can READ any EVALUATION', () => {
+    const d = authz.decide(
+      subject('hr-1', 'HR_MANAGER'),
+      'READ',
+      resource('EVALUATION', 'e1', 'someone-else'),
+    )
+    expect(d.allowed).toBe(true)
+    expect(d.reason).toBe('ALLOWED_BY_ROLE')
+  })
+
+  it('HR_MANAGER can UPDATE any EVALUATION', () => {
+    const d = authz.decide(
+      subject('hr-1', 'HR_MANAGER'),
+      'UPDATE',
+      resource('EVALUATION', 'e1', 'someone-else'),
+    )
+    expect(d.allowed).toBe(true)
+  })
+
+  it('HR_MANAGER cannot DELETE EVALUATION (ADMIN only)', () => {
+    const d = authz.decide(subject('hr-1', 'HR_MANAGER'), 'DELETE', resource('EVALUATION', 'e1'))
+    expect(d.allowed).toBe(false)
+    expect(d.reason).toBe('DENIED_INSUFFICIENT_ROLE')
+  })
+
+  it('HR_MANAGER cannot READ AUDIT_LOG', () => {
+    const d = authz.decide(subject('hr-1', 'HR_MANAGER'), 'READ', resource('AUDIT_LOG', 'l1'))
+    expect(d.allowed).toBe(false)
+  })
+
+  // --- MANAGER ---
+  it('MANAGER can READ their own EVALUATION (as owner)', () => {
+    const d = authz.decide(subject('m-1', 'MANAGER'), 'READ', resource('EVALUATION', 'e1', 'm-1'))
+    expect(d.allowed).toBe(true)
+    expect(d.reason).toBe('ALLOWED_AS_OWNER')
+  })
+
+  it('MANAGER cannot UPDATE another employee EVALUATION', () => {
+    const d = authz.decide(
+      subject('m-1', 'MANAGER'),
+      'UPDATE',
+      resource('EVALUATION', 'e1', 'someone-else'),
+    )
+    expect(d.allowed).toBe(false)
+    expect(d.reason).toBe('DENIED_NOT_OWNER')
+  })
+
+  it('MANAGER can READ PROFILE as allowed role', () => {
+    const d = authz.decide(
+      subject('m-1', 'MANAGER'),
+      'READ',
+      resource('PROFILE', 'p1', 'someone-else'),
+    )
+    expect(d.allowed).toBe(true)
+    expect(d.reason).toBe('ALLOWED_BY_ROLE')
+  })
+
+  // --- EMPLOYEE ---
+  it('EMPLOYEE can CREATE EVALUATION', () => {
+    const d = authz.decide(subject('e-1', 'EMPLOYEE'), 'CREATE', resource('EVALUATION', 'e1'))
+    expect(d.allowed).toBe(true)
+    expect(d.reason).toBe('ALLOWED_BY_ROLE')
+  })
+
+  it('EMPLOYEE cannot READ another employee EVALUATION (Req 1.9)', () => {
+    const d = authz.decide(
+      subject('e-1', 'EMPLOYEE'),
+      'READ',
+      resource('EVALUATION', 'e1', 'other-employee'),
+    )
+    expect(d.allowed).toBe(false)
+    expect(d.reason).toBe('DENIED_NOT_OWNER')
+  })
+
+  it('EMPLOYEE can READ their own EVALUATION (as owner)', () => {
+    const d = authz.decide(subject('e-1', 'EMPLOYEE'), 'READ', resource('EVALUATION', 'e1', 'e-1'))
+    expect(d.allowed).toBe(true)
+    expect(d.reason).toBe('ALLOWED_AS_OWNER')
+  })
+
+  it('EMPLOYEE can UPDATE their own GOAL (as owner)', () => {
+    const d = authz.decide(subject('e-1', 'EMPLOYEE'), 'UPDATE', resource('GOAL', 'g1', 'e-1'))
+    expect(d.allowed).toBe(true)
+    expect(d.reason).toBe('ALLOWED_AS_OWNER')
+  })
+
+  it('EMPLOYEE cannot UPDATE another employee GOAL', () => {
+    const d = authz.decide(
+      subject('e-1', 'EMPLOYEE'),
+      'UPDATE',
+      resource('GOAL', 'g1', 'other-employee'),
+    )
+    expect(d.allowed).toBe(false)
+    expect(d.reason).toBe('DENIED_NOT_OWNER')
+  })
+
+  it('EMPLOYEE cannot READ AUDIT_LOG', () => {
+    const d = authz.decide(subject('e-1', 'EMPLOYEE'), 'READ', resource('AUDIT_LOG', 'l1'))
+    expect(d.allowed).toBe(false)
+    expect(d.reason).toBe('DENIED_INSUFFICIENT_ROLE')
+  })
+
+  // --- No matching rule ---
+  it('returns DENIED_NO_RULE when no matching rule exists', () => {
+    const d = authz.decide(subject('a-1', 'ADMIN'), 'READ', resource('UNKNOWN_RESOURCE', 'x'))
+    expect(d.allowed).toBe(false)
+    expect(d.reason).toBe('DENIED_NO_RULE')
+  })
+
+  // --- ownerCanAccess without ownerId ---
+  it('falls back to DENIED_INSUFFICIENT_ROLE when ownerCanAccess rule has no ownerId', () => {
+    const d = authz.decide(
+      subject('e-1', 'EMPLOYEE'),
+      'READ',
+      resource('EVALUATION', 'e1'), // ownerId undefined
+    )
+    expect(d.allowed).toBe(false)
+    expect(d.reason).toBe('DENIED_INSUFFICIENT_ROLE')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// decide() — カスタムルール注入
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('Authorizer.decide() with custom rules', () => {
+  it('uses injected rules instead of defaults', () => {
+    const customRules: readonly PolicyRule[] = [
+      { resourceType: 'WIDGET', action: 'READ', allowedRoles: ['EMPLOYEE'] },
+    ]
+    const authz = createAuthorizer({ rules: customRules })
+    const d = authz.decide(subject('e-1', 'EMPLOYEE'), 'READ', resource('WIDGET', 'w1'))
+    expect(d.allowed).toBe(true)
+    expect(d.reason).toBe('ALLOWED_BY_ROLE')
+  })
+
+  it('EVALUATION rules are absent when custom rules override', () => {
+    const customRules: readonly PolicyRule[] = [
+      { resourceType: 'WIDGET', action: 'READ', allowedRoles: ['ADMIN'] },
+    ]
+    const authz = createAuthorizer({ rules: customRules })
+    const d = authz.decide(subject('a-1', 'ADMIN'), 'READ', resource('EVALUATION', 'e1'))
+    expect(d.allowed).toBe(false)
+    expect(d.reason).toBe('DENIED_NO_RULE')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// enforce()
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('Authorizer.enforce()', () => {
+  it('resolves silently when decide returns allowed=true', async () => {
+    const audit = makeAuditSpy()
+    const authz = createAuthorizer({ auditLogger: audit })
+    await expect(
+      authz.enforce(subject('a-1', 'ADMIN'), 'READ', resource('EVALUATION', 'e1')),
+    ).resolves.toBeUndefined()
+    expect(audit.emit).not.toHaveBeenCalled()
+  })
+
+  it('throws ForbiddenError and emits ACCESS_DENIED when denied', async () => {
+    const audit = makeAuditSpy()
+    const authz = createAuthorizer({ auditLogger: audit })
+    await expect(
+      authz.enforce(
+        subject('e-1', 'EMPLOYEE'),
+        'READ',
+        resource('EVALUATION', 'e1', 'other-employee'),
+        { ipAddress: '10.0.0.1', userAgent: 'Mozilla/5.0' },
+      ),
+    ).rejects.toBeInstanceOf(ForbiddenError)
+
+    expect(audit.emit).toHaveBeenCalledTimes(1)
+    const entry = audit.emit.mock.calls[0]?.[0]
+    expect(entry).toMatchObject({
+      userId: 'e-1',
+      action: 'ACCESS_DENIED',
+      resourceType: 'EVALUATION',
+      resourceId: 'e1',
+      ipAddress: '10.0.0.1',
+      userAgent: 'Mozilla/5.0',
+      before: null,
+    })
+    expect(entry?.after).toMatchObject({
+      reason: 'DENIED_NOT_OWNER',
+      requestedAction: 'READ',
+      subjectRole: 'EMPLOYEE',
+    })
+  })
+
+  it('uses empty strings for ipAddress / userAgent when context omitted', async () => {
+    const audit = makeAuditSpy()
+    const authz = createAuthorizer({ auditLogger: audit })
+    await expect(
+      authz.enforce(subject('e-1', 'EMPLOYEE'), 'DELETE', resource('EVALUATION', 'e1', 'e-1')),
+    ).rejects.toBeInstanceOf(ForbiddenError)
+    const entry = audit.emit.mock.calls[0]?.[0]
+    expect(entry?.ipAddress).toBe('')
+    expect(entry?.userAgent).toBe('')
+  })
+
+  it('still throws ForbiddenError when no auditLogger is injected', async () => {
+    const authz = createAuthorizer({})
+    await expect(
+      authz.enforce(
+        subject('e-1', 'EMPLOYEE'),
+        'READ',
+        resource('EVALUATION', 'e1', 'other-employee'),
+      ),
+    ).rejects.toBeInstanceOf(ForbiddenError)
+  })
+
+  it('records DENIED_NO_RULE when an unknown resource is enforced', async () => {
+    const audit = makeAuditSpy()
+    const authz = createAuthorizer({ auditLogger: audit })
+    await expect(
+      authz.enforce(subject('a-1', 'ADMIN'), 'READ', resource('UNKNOWN_X', 'x1')),
+    ).rejects.toBeInstanceOf(ForbiddenError)
+    expect(audit.emit.mock.calls[0]?.[0]?.after).toMatchObject({ reason: 'DENIED_NO_RULE' })
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// DEFAULT_POLICY_RULES sanity
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('DEFAULT_POLICY_RULES', () => {
+  it('exposes EVALUATION/GOAL/POSITION/PROFILE/ONE_ON_ONE/AUDIT_LOG rules', () => {
+    const types = new Set(DEFAULT_POLICY_RULES.map((r) => r.resourceType))
+    expect(types.has('EVALUATION')).toBe(true)
+    expect(types.has('GOAL')).toBe(true)
+    expect(types.has('POSITION')).toBe(true)
+    expect(types.has('PROFILE')).toBe(true)
+    expect(types.has('ONE_ON_ONE')).toBe(true)
+    expect(types.has('AUDIT_LOG')).toBe(true)
+    expect(types.has('SYSTEM_CONFIG')).toBe(true)
+    expect(types.has('MASTER_DATA')).toBe(true)
+    expect(types.has('ORGANIZATION')).toBe(true)
+  })
+})

--- a/src/tests/rbac/next-middleware.test.ts
+++ b/src/tests/rbac/next-middleware.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi } from 'vitest'
+
+import type { AuditLoggerPort } from '@/lib/rbac/authorizer'
+import {
+  createRouteGuard,
+  matchRoutePolicy,
+  type RoutePolicy,
+  type SubjectProvider,
+} from '@/lib/rbac/next-middleware'
+import type { AuthSubject } from '@/lib/rbac/rbac-types'
+import type { UserRole } from '@/lib/notification/notification-types'
+
+function subject(userId: string, role: UserRole): AuthSubject {
+  return { userId, role }
+}
+
+interface AuditSpy extends AuditLoggerPort {
+  readonly emit: ReturnType<typeof vi.fn>
+}
+
+function makeAuditSpy(): AuditSpy {
+  const emit = vi.fn(async () => {})
+  return { emit } as AuditSpy
+}
+
+function makeSubjectProvider(value: AuthSubject | null): SubjectProvider {
+  return {
+    getSubject: vi.fn(async () => value),
+  }
+}
+
+function req(pathname: string): Request {
+  return new Request(`http://localhost${pathname}`, {
+    headers: { 'x-forwarded-for': '10.0.0.9', 'user-agent': 'jest-test' },
+  })
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// matchRoutePolicy()
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('matchRoutePolicy()', () => {
+  const policies: readonly RoutePolicy[] = [
+    { pathPattern: /^\/admin(\/.*)?$/, allowedRoles: ['ADMIN'], resourceType: 'SYSTEM_CONFIG' },
+    { pathPattern: /^\/hr(\/.*)?$/, allowedRoles: ['ADMIN', 'HR_MANAGER'] },
+    { pathPattern: /^\/.*$/, allowedRoles: ['ADMIN', 'HR_MANAGER', 'MANAGER', 'EMPLOYEE'] },
+  ]
+
+  it('returns the first matching policy', () => {
+    const policy = matchRoutePolicy('/admin/users', policies)
+    expect(policy?.allowedRoles).toEqual(['ADMIN'])
+    expect(policy?.resourceType).toBe('SYSTEM_CONFIG')
+  })
+
+  it('returns a later policy when earlier ones do not match', () => {
+    const policy = matchRoutePolicy('/hr/employees', policies)
+    expect(policy?.allowedRoles).toEqual(['ADMIN', 'HR_MANAGER'])
+  })
+
+  it('returns null when no policy matches', () => {
+    const emptyPolicies: readonly RoutePolicy[] = [
+      { pathPattern: /^\/admin(\/.*)?$/, allowedRoles: ['ADMIN'] },
+    ]
+    expect(matchRoutePolicy('/public/home', emptyPolicies)).toBeNull()
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// createRouteGuard().guard()
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('createRouteGuard().guard()', () => {
+  const policies: readonly RoutePolicy[] = [
+    { pathPattern: /^\/admin(\/.*)?$/, allowedRoles: ['ADMIN'], resourceType: 'SYSTEM_CONFIG' },
+  ]
+
+  it('returns null when no policy matches (unprotected path)', async () => {
+    const subjectProvider = makeSubjectProvider(subject('e-1', 'EMPLOYEE'))
+    const audit = makeAuditSpy()
+    const { guard } = createRouteGuard({ policies, subjectProvider, auditLogger: audit })
+    const result = await guard(req('/public/home'))
+    expect(result).toBeNull()
+    expect(audit.emit).not.toHaveBeenCalled()
+  })
+
+  it('returns 401 when subjectProvider yields null on a protected path', async () => {
+    const subjectProvider = makeSubjectProvider(null)
+    const audit = makeAuditSpy()
+    const { guard } = createRouteGuard({ policies, subjectProvider, auditLogger: audit })
+    const result = await guard(req('/admin/settings'))
+    expect(result).toBeInstanceOf(Response)
+    expect(result?.status).toBe(401)
+    expect(audit.emit).not.toHaveBeenCalled()
+  })
+
+  it('returns null when subject role is allowed', async () => {
+    const subjectProvider = makeSubjectProvider(subject('a-1', 'ADMIN'))
+    const audit = makeAuditSpy()
+    const { guard } = createRouteGuard({ policies, subjectProvider, auditLogger: audit })
+    const result = await guard(req('/admin/users'))
+    expect(result).toBeNull()
+    expect(audit.emit).not.toHaveBeenCalled()
+  })
+
+  it('returns 403 and emits ACCESS_DENIED when subject role is not allowed', async () => {
+    const subjectProvider = makeSubjectProvider(subject('e-1', 'EMPLOYEE'))
+    const audit = makeAuditSpy()
+    const { guard } = createRouteGuard({ policies, subjectProvider, auditLogger: audit })
+    const result = await guard(req('/admin/users'))
+    expect(result).toBeInstanceOf(Response)
+    expect(result?.status).toBe(403)
+
+    expect(audit.emit).toHaveBeenCalledTimes(1)
+    const entry = audit.emit.mock.calls[0]?.[0]
+    expect(entry).toMatchObject({
+      userId: 'e-1',
+      action: 'ACCESS_DENIED',
+      resourceType: 'SYSTEM_CONFIG',
+    })
+    expect(entry?.after).toMatchObject({
+      reason: 'DENIED_INSUFFICIENT_ROLE',
+      subjectRole: 'EMPLOYEE',
+    })
+  })
+
+  it('uses ROUTE as fallback resourceType when policy has no resourceType', async () => {
+    const noTypePolicies: readonly RoutePolicy[] = [
+      { pathPattern: /^\/secret$/, allowedRoles: ['ADMIN'] },
+    ]
+    const subjectProvider = makeSubjectProvider(subject('e-1', 'EMPLOYEE'))
+    const audit = makeAuditSpy()
+    const { guard } = createRouteGuard({
+      policies: noTypePolicies,
+      subjectProvider,
+      auditLogger: audit,
+    })
+    const result = await guard(req('/secret'))
+    expect(result?.status).toBe(403)
+    const entry = audit.emit.mock.calls[0]?.[0]
+    expect(entry?.resourceType).toBe('ROUTE')
+  })
+
+  it('returns 403 even when no auditLogger is injected', async () => {
+    const subjectProvider = makeSubjectProvider(subject('e-1', 'EMPLOYEE'))
+    const { guard } = createRouteGuard({ policies, subjectProvider })
+    const result = await guard(req('/admin/users'))
+    expect(result?.status).toBe(403)
+  })
+})

--- a/src/tests/rbac/rbac-types.test.ts
+++ b/src/tests/rbac/rbac-types.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest'
+
+import { ACTIONS, ForbiddenError, isAction, type Action } from '@/lib/rbac/rbac-types'
+
+describe('ACTIONS', () => {
+  it('exposes READ / CREATE / UPDATE / DELETE / MANAGE in that order', () => {
+    expect(ACTIONS).toEqual(['READ', 'CREATE', 'UPDATE', 'DELETE', 'MANAGE'])
+  })
+
+  it('infers Action as a literal union of the enum members', () => {
+    const values: readonly Action[] = ['READ', 'CREATE', 'UPDATE', 'DELETE', 'MANAGE']
+    expect(values).toHaveLength(5)
+  })
+})
+
+describe('isAction()', () => {
+  it('returns true for a valid action literal', () => {
+    expect(isAction('READ')).toBe(true)
+    expect(isAction('CREATE')).toBe(true)
+    expect(isAction('UPDATE')).toBe(true)
+    expect(isAction('DELETE')).toBe(true)
+    expect(isAction('MANAGE')).toBe(true)
+  })
+
+  it('returns false for unknown strings', () => {
+    expect(isAction('EXECUTE')).toBe(false)
+    expect(isAction('read')).toBe(false)
+    expect(isAction('')).toBe(false)
+  })
+
+  it('returns false for non-string values', () => {
+    expect(isAction(null)).toBe(false)
+    expect(isAction(undefined)).toBe(false)
+    expect(isAction(1)).toBe(false)
+    expect(isAction({})).toBe(false)
+  })
+})
+
+describe('ForbiddenError', () => {
+  it('captures resourceType, action, and reason as readonly fields', () => {
+    const err = new ForbiddenError('EVALUATION', 'READ', 'DENIED_INSUFFICIENT_ROLE')
+    expect(err).toBeInstanceOf(Error)
+    expect(err.name).toBe('ForbiddenError')
+    expect(err.resourceType).toBe('EVALUATION')
+    expect(err.action).toBe('READ')
+    expect(err.reason).toBe('DENIED_INSUFFICIENT_ROLE')
+    expect(err.message).toContain('EVALUATION')
+    expect(err.message).toContain('READ')
+    expect(err.message).toContain('DENIED_INSUFFICIENT_ROLE')
+  })
+
+  it('supports DENIED_NOT_OWNER reason', () => {
+    const err = new ForbiddenError('GOAL', 'UPDATE', 'DENIED_NOT_OWNER')
+    expect(err.reason).toBe('DENIED_NOT_OWNER')
+  })
+
+  it('supports DENIED_NO_RULE reason', () => {
+    const err = new ForbiddenError('UNKNOWN', 'READ', 'DENIED_NO_RULE')
+    expect(err.reason).toBe('DENIED_NO_RULE')
+  })
+})

--- a/src/tests/rbac/require-role.test.ts
+++ b/src/tests/rbac/require-role.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi } from 'vitest'
+
+import type { AuditLoggerPort } from '@/lib/rbac/authorizer'
+import { requireRole } from '@/lib/rbac/require-role'
+import { ForbiddenError, type AuthSubject } from '@/lib/rbac/rbac-types'
+import type { UserRole } from '@/lib/notification/notification-types'
+
+function subject(userId: string, role: UserRole): AuthSubject {
+  return { userId, role }
+}
+
+interface AuditSpy extends AuditLoggerPort {
+  readonly emit: ReturnType<typeof vi.fn>
+}
+
+function makeAuditSpy(): AuditSpy {
+  const emit = vi.fn(async () => {})
+  return { emit } as AuditSpy
+}
+
+describe('requireRole()', () => {
+  it('resolves silently when subject role is in allowedRoles', async () => {
+    const audit = makeAuditSpy()
+    await expect(
+      requireRole(subject('a-1', 'ADMIN'), ['ADMIN', 'HR_MANAGER'], {
+        auditLogger: audit,
+      }),
+    ).resolves.toBeUndefined()
+    expect(audit.emit).not.toHaveBeenCalled()
+  })
+
+  it('throws ForbiddenError when subject role is not in allowedRoles', async () => {
+    const audit = makeAuditSpy()
+    await expect(
+      requireRole(subject('e-1', 'EMPLOYEE'), ['ADMIN', 'HR_MANAGER'], {
+        resourceHint: { type: 'EVALUATION', id: 'e1' },
+        context: { ipAddress: '10.0.0.1', userAgent: 'Mozilla/5.0' },
+        auditLogger: audit,
+      }),
+    ).rejects.toBeInstanceOf(ForbiddenError)
+
+    expect(audit.emit).toHaveBeenCalledTimes(1)
+    const entry = audit.emit.mock.calls[0]?.[0]
+    expect(entry).toMatchObject({
+      userId: 'e-1',
+      action: 'ACCESS_DENIED',
+      resourceType: 'EVALUATION',
+      resourceId: 'e1',
+      ipAddress: '10.0.0.1',
+      userAgent: 'Mozilla/5.0',
+    })
+    expect(entry?.after).toMatchObject({
+      reason: 'DENIED_INSUFFICIENT_ROLE',
+      subjectRole: 'EMPLOYEE',
+    })
+  })
+
+  it('works without resourceHint (defaults resourceType / resourceId)', async () => {
+    const audit = makeAuditSpy()
+    await expect(
+      requireRole(subject('e-1', 'EMPLOYEE'), ['ADMIN'], { auditLogger: audit }),
+    ).rejects.toBeInstanceOf(ForbiddenError)
+    const entry = audit.emit.mock.calls[0]?.[0]
+    expect(entry?.resourceType).toBe('ROUTE')
+    expect(entry?.resourceId).toBeNull()
+  })
+
+  it('works without auditLogger (still throws ForbiddenError)', async () => {
+    await expect(requireRole(subject('e-1', 'EMPLOYEE'), ['ADMIN'])).rejects.toBeInstanceOf(
+      ForbiddenError,
+    )
+  })
+
+  it('accepts a single-role allowedRoles list', async () => {
+    await expect(
+      requireRole(subject('hr-1', 'HR_MANAGER'), ['HR_MANAGER']),
+    ).resolves.toBeUndefined()
+  })
+})


### PR DESCRIPTION
Closes #21

## Summary

Task 6.3 の多層防御の第 1〜2 層を実装する。URL ルート単位 (middleware 層) と
サービス層で ADMIN / HR_MANAGER / MANAGER / EMPLOYEE の 4 ロールを判定し、
拒否時には ACCESS_DENIED の監査ログを記録する基盤を追加した。

- **middleware 層 (URL)**: `createRouteGuard` で RegExp ベースの `RoutePolicy` を
  評価し、401/403 Response を返却
- **service 層**: `Authorizer.enforce` + `requireRole` で処理開始前に認可を強制
- **DB 層**: 別タスク (Prisma RLS 相当) でフォローアップ予定

## Requirements マッピング

- **Req 1.7** (4 ロール管理): `AuthSubject.role: UserRole` と `PolicyRule.allowedRoles`
  で 4 ロールを一貫して扱う
- **Req 1.8** (HR_MANAGER は全社員の評価・配置・目標を読取可): `DEFAULT_POLICY_RULES`
  で EVALUATION/GOAL/POSITION の READ に HR_MANAGER を含める
- **Req 1.9** (EMPLOYEE による他者 EVALUATION アクセス → 403): `ownerCanAccess: true` +
  `ownerId` 不一致で `DENIED_NOT_OWNER` 判定 → `ForbiddenError` + ACCESS_DENIED audit log

## 主な変更点

- `src/lib/rbac/rbac-types.ts` — `AuthSubject` / `ResourceRef` / `Action` /
  `PolicyRule` / `AuthorizationDecision` / `ForbiddenError` を集約
- `src/lib/rbac/policy.ts` — 本プロダクトの `DEFAULT_POLICY_RULES`
- `src/lib/rbac/authorizer.ts` — 純粋判定 `decide` + 強制 `enforce`。narrow
  `AuditLoggerPort` で audit 基盤の実体から疎結合化
- `src/lib/rbac/require-role.ts` — 早期ロール拒否のための薄いヘルパ
- `src/lib/rbac/next-middleware.ts` — `matchRoutePolicy` / `createRouteGuard` ヘルパ
- `src/lib/audit/audit-log-types.ts` — `AUDIT_ACTIONS` に `ACCESS_DENIED` を追加
  (既存順序は温存)

## 設計メモ

- narrow port `AuditLoggerPort` を導入し、`@/lib/audit/audit-log-emitter` の
  実装 (Prisma / 既存の重複 import) に直接依存しない設計とした。shape だけ互換。
- 既存の `AIDashboardForbiddenError` / `BroadcastForbiddenError` は本 PR では統合しない
  (各ドメインサービスで独自例外を維持。統合は後続タスクで行う)。
- `src/middleware.ts` への実配線 (`createRouteGuard` を Next.js に差し込む) は
  本 PR のスコープ外。ヘルパとしての完成度のみ担保する。
- DB 層 (Prisma クエリに userId を必ず含める) は別タスクで対応。

## スコープ外

- 実 Next.js middleware ファイル (`src/middleware.ts`) への配線
- Prisma RLS / ownerId 制限の自動注入
- 既存ドメイン例外 (`AIDashboardForbiddenError` 等) の統合

## Test plan

- [x] `pnpm test` で 68 test files / 762 tests green (既存 695 + 新規 67)
- [x] `pnpm test -- src/tests/rbac` で RBAC 全 50 ケースが green
- [x] `pnpm test:coverage -- src/tests/rbac` で `src/lib/rbac` coverage 99.69% lines,
      96% branches, 100% functions
- [x] `pnpm lint` でエラーなし
- [x] `pnpm type-check` — 新規ファイルに関する型エラーなし
      (既存の Prisma まわりの pre-existing エラーは対象外。タスク指示に従い
      `src/lib/audit/audit-log-emitter.ts` の重複 import は修正していない)

## 要件カバレッジテスト例

- `EMPLOYEE cannot READ another employee EVALUATION (Req 1.9)` → `DENIED_NOT_OWNER`
- `HR_MANAGER can READ any EVALUATION` (Req 1.8) → `ALLOWED_BY_ROLE`
- `HR_MANAGER cannot DELETE EVALUATION (ADMIN only)` → `DENIED_INSUFFICIENT_ROLE`
- `EMPLOYEE can UPDATE their own GOAL (as owner)` → `ALLOWED_AS_OWNER`