### PR TITLE
feat: [Task 6.4] セッション一覧と手動失効機能

### DIFF
--- a/src/app/api/auth/sessions/[sessionId]/route.ts
+++ b/src/app/api/auth/sessions/[sessionId]/route.ts
@@ -1,0 +1,72 @@
+/**
+ * Task 6.4 / Req 1.15: セッション手動失効 API
+ *
+ * DELETE /api/auth/sessions/:sessionId
+ * - 認証済みユーザーが指定セッションを失効させる
+ * - 自分のセッションのみ失効可能 (他ユーザーのセッションは 404)
+ * - 成功: 204 No Content
+ * - 未所有 / 存在しない: 404
+ */
+import { z } from 'zod'
+import { getServerSession } from 'next-auth'
+import { type NextRequest, NextResponse } from 'next/server'
+import { SessionNotFoundError } from '@/lib/auth/auth-types'
+import type { AuthService } from '@/lib/auth/auth-service'
+
+/** パスパラメータのバリデーションスキーマ */
+const sessionIdParamSchema = z.object({
+  sessionId: z.string().min(1, 'sessionId must be a non-empty string'),
+})
+
+/**
+ * 依存注入用ファクトリ。テスト時に差し替え可能。
+ * プロダクションでは実際の authService インスタンスを使う。
+ */
+let _authService: AuthService | null = null
+
+export function setAuthServiceForTesting(svc: AuthService): void {
+  _authService = svc
+}
+
+function getAuthService(): AuthService {
+  if (_authService) return _authService
+  throw new Error('AuthService is not configured. Use setAuthServiceForTesting or wire DI.')
+}
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ sessionId: string }> },
+): Promise<NextResponse> {
+  const serverSession = await getServerSession()
+  if (!serverSession?.user?.email) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const userId: string | undefined = (
+    serverSession as Record<string, unknown> & { user?: { id?: string } }
+  ).user?.id
+
+  if (!userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  // Zod によるパスパラメータ検証
+  const rawParams = await params
+  const parsed = sessionIdParamSchema.safeParse(rawParams)
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid sessionId' }, { status: 400 })
+  }
+
+  const { sessionId } = parsed.data
+
+  try {
+    const authService = getAuthService()
+    await authService.revokeSession(userId, sessionId)
+    return new NextResponse(null, { status: 204 })
+  } catch (error: unknown) {
+    if (error instanceof SessionNotFoundError) {
+      return NextResponse.json({ error: 'Session not found' }, { status: 404 })
+    }
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/api/auth/sessions/[sessionId]/route.ts
+++ b/src/app/api/auth/sessions/[sessionId]/route.ts
@@ -11,27 +11,14 @@ import { z } from 'zod'
 import { getServerSession } from 'next-auth'
 import { type NextRequest, NextResponse } from 'next/server'
 import { SessionNotFoundError } from '@/lib/auth/auth-types'
-import type { AuthService } from '@/lib/auth/auth-service'
+import { getAuthService } from '@/lib/auth/auth-service-di'
 
-/** パスパラメータのバリデーションスキーマ */
+export { setAuthServiceForTesting, clearAuthServiceForTesting } from '@/lib/auth/auth-service-di'
+
+/** UUID 形式を強制してパス・トラバーサル等の不正値を早期排除する */
 const sessionIdParamSchema = z.object({
-  sessionId: z.string().min(1, 'sessionId must be a non-empty string'),
+  sessionId: z.string().uuid('sessionId must be a valid UUID'),
 })
-
-/**
- * 依存注入用ファクトリ。テスト時に差し替え可能。
- * プロダクションでは実際の authService インスタンスを使う。
- */
-let _authService: AuthService | null = null
-
-export function setAuthServiceForTesting(svc: AuthService): void {
-  _authService = svc
-}
-
-function getAuthService(): AuthService {
-  if (_authService) return _authService
-  throw new Error('AuthService is not configured. Use setAuthServiceForTesting or wire DI.')
-}
 
 export async function DELETE(
   _request: NextRequest,
@@ -42,15 +29,14 @@ export async function DELETE(
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
-  const userId: string | undefined = (
-    serverSession as Record<string, unknown> & { user?: { id?: string } }
-  ).user?.id
+  // next-auth-config.ts の session コールバックがトップレベルに設定する
+  const sess = serverSession as Record<string, unknown>
+  const userId = typeof sess.userId === 'string' ? sess.userId : undefined
 
   if (!userId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
-  // Zod によるパスパラメータ検証
   const rawParams = await params
   const parsed = sessionIdParamSchema.safeParse(rawParams)
   if (!parsed.success) {
@@ -60,8 +46,7 @@ export async function DELETE(
   const { sessionId } = parsed.data
 
   try {
-    const authService = getAuthService()
-    await authService.revokeSession(userId, sessionId)
+    await getAuthService().revokeSession(userId, sessionId)
     return new NextResponse(null, { status: 204 })
   } catch (error: unknown) {
     if (error instanceof SessionNotFoundError) {

--- a/src/app/api/auth/sessions/route.ts
+++ b/src/app/api/auth/sessions/route.ts
@@ -8,7 +8,9 @@
 import { getServerSession } from 'next-auth'
 import { type NextRequest, NextResponse } from 'next/server'
 import type { Session } from '@/lib/auth/auth-types'
-import type { AuthService } from '@/lib/auth/auth-service'
+import { getAuthService } from '@/lib/auth/auth-service-di'
+
+export { setAuthServiceForTesting, clearAuthServiceForTesting } from '@/lib/auth/auth-service-di'
 
 /**
  * セッションレスポンス型。
@@ -18,44 +20,23 @@ export interface SessionResponse extends Session {
   readonly isCurrent: boolean
 }
 
-/**
- * 依存注入用ファクトリ。テスト時に差し替え可能。
- * プロダクションでは実際の authService インスタンスを使う。
- */
-let _authService: AuthService | null = null
-
-export function setAuthServiceForTesting(svc: AuthService): void {
-  _authService = svc
-}
-
-function getAuthService(): AuthService {
-  if (_authService) return _authService
-  // プロダクション用: 本来はDIコンテナやシングルトンから取得する
-  throw new Error('AuthService is not configured. Use setAuthServiceForTesting or wire DI.')
-}
-
 export async function GET(_request: NextRequest): Promise<NextResponse> {
   const serverSession = await getServerSession()
   if (!serverSession?.user?.email) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
-  // NextAuth の JWT から userId と sessionId を取得する
-  // next-auth-config.ts の JWT コールバックで設定されている想定
-  const userId: string | undefined = (
-    serverSession as Record<string, unknown> & { user?: { id?: string } }
-  ).user?.id
-  const currentSessionId: string | undefined = (
-    serverSession as Record<string, unknown> & { sessionId?: string }
-  ).sessionId as string | undefined
+  // next-auth-config.ts の session コールバックがトップレベルに設定する
+  const sess = serverSession as Record<string, unknown>
+  const userId = typeof sess.userId === 'string' ? sess.userId : undefined
+  const currentSessionId = typeof sess.sessionId === 'string' ? sess.sessionId : undefined
 
   if (!userId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
   try {
-    const authService = getAuthService()
-    const sessions = await authService.listSessions(userId)
+    const sessions = await getAuthService().listSessions(userId)
     const response: SessionResponse[] = sessions.map((s) => ({
       ...s,
       isCurrent: s.id === currentSessionId,

--- a/src/app/api/auth/sessions/route.ts
+++ b/src/app/api/auth/sessions/route.ts
@@ -1,0 +1,67 @@
+/**
+ * Task 6.4 / Req 1.14: セッション一覧 API
+ *
+ * GET /api/auth/sessions
+ * - 認証済みユーザーのアクティブセッション一覧を返す
+ * - 現在のセッションには isCurrent: true を付与
+ */
+import { getServerSession } from 'next-auth'
+import { type NextRequest, NextResponse } from 'next/server'
+import type { Session } from '@/lib/auth/auth-types'
+import type { AuthService } from '@/lib/auth/auth-service'
+
+/**
+ * セッションレスポンス型。
+ * isCurrent フィールドで現在のセッションを識別できるよう拡張する。
+ */
+export interface SessionResponse extends Session {
+  readonly isCurrent: boolean
+}
+
+/**
+ * 依存注入用ファクトリ。テスト時に差し替え可能。
+ * プロダクションでは実際の authService インスタンスを使う。
+ */
+let _authService: AuthService | null = null
+
+export function setAuthServiceForTesting(svc: AuthService): void {
+  _authService = svc
+}
+
+function getAuthService(): AuthService {
+  if (_authService) return _authService
+  // プロダクション用: 本来はDIコンテナやシングルトンから取得する
+  throw new Error('AuthService is not configured. Use setAuthServiceForTesting or wire DI.')
+}
+
+export async function GET(_request: NextRequest): Promise<NextResponse> {
+  const serverSession = await getServerSession()
+  if (!serverSession?.user?.email) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  // NextAuth の JWT から userId と sessionId を取得する
+  // next-auth-config.ts の JWT コールバックで設定されている想定
+  const userId: string | undefined = (
+    serverSession as Record<string, unknown> & { user?: { id?: string } }
+  ).user?.id
+  const currentSessionId: string | undefined = (
+    serverSession as Record<string, unknown> & { sessionId?: string }
+  ).sessionId as string | undefined
+
+  if (!userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  try {
+    const authService = getAuthService()
+    const sessions = await authService.listSessions(userId)
+    const response: SessionResponse[] = sessions.map((s) => ({
+      ...s,
+      isCurrent: s.id === currentSessionId,
+    }))
+    return NextResponse.json({ sessions: response })
+  } catch {
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/lib/auth/auth-service-di.ts
+++ b/src/lib/auth/auth-service-di.ts
@@ -1,0 +1,29 @@
+/**
+ * AuthService のシングルトン DI モジュール。
+ * - テスト: setAuthServiceForTesting / clearAuthServiceForTesting で差し替え
+ * - プロダクション: アプリ起動時に initAuthService を呼んで初期化
+ */
+import type { AuthService } from './auth-service'
+
+let _authService: AuthService | null = null
+
+export function setAuthServiceForTesting(svc: AuthService): void {
+  _authService = svc
+}
+
+export function clearAuthServiceForTesting(): void {
+  _authService = null
+}
+
+export function getAuthService(): AuthService {
+  if (_authService) return _authService
+  throw new Error(
+    'AuthService is not initialized. ' +
+      'テストでは setAuthServiceForTesting() を呼んでください。' +
+      'プロダクションではサーバー起動前に initAuthService() を呼んでください。',
+  )
+}
+
+export function initAuthService(svc: AuthService): void {
+  _authService = svc
+}

--- a/src/lib/auth/auth-service.ts
+++ b/src/lib/auth/auth-service.ts
@@ -16,6 +16,7 @@ import { computeEmailHash } from '@/lib/shared/crypto'
 import {
   AccountLockedError,
   InvalidCredentialsError,
+  SessionNotFoundError,
   loginInputSchema,
   type LoginInput,
   type Session,
@@ -41,6 +42,13 @@ export interface AuthService {
   getSession(sessionId: string, now?: Date): Promise<Session>
   /** 有効性確認したうえで lastAccessAt を更新する */
   touchSession(sessionId: string, now?: Date): Promise<Session>
+  /** ユーザーの全セッションを createdAt 降順で返す (Req 1.14) */
+  listSessions(userId: string): Promise<readonly Session[]>
+  /**
+   * 指定セッションを失効させる (Req 1.15)。
+   * requesterId と一致しない or 存在しない場合は SessionNotFoundError。
+   */
+  revokeSession(requesterId: string, sessionId: string): Promise<void>
 }
 
 /**
@@ -233,6 +241,19 @@ class AuthServiceImpl implements AuthService {
 
   async touchSession(sessionId: string, now?: Date): Promise<Session> {
     return this.sessions.touch(sessionId, now ?? this.clock())
+  }
+
+  async listSessions(userId: string): Promise<readonly Session[]> {
+    return this.sessions.listByUser(userId)
+  }
+
+  async revokeSession(requesterId: string, sessionId: string): Promise<void> {
+    const sessions = await this.sessions.listByUser(requesterId)
+    const owned = sessions.find((s) => s.id === sessionId)
+    if (!owned) {
+      throw new SessionNotFoundError(sessionId)
+    }
+    await this.sessions.delete(sessionId)
   }
 }
 

--- a/src/lib/auth/auth-service.ts
+++ b/src/lib/auth/auth-service.ts
@@ -16,7 +16,6 @@ import { computeEmailHash } from '@/lib/shared/crypto'
 import {
   AccountLockedError,
   InvalidCredentialsError,
-  SessionNotFoundError,
   loginInputSchema,
   type LoginInput,
   type Session,
@@ -248,12 +247,7 @@ class AuthServiceImpl implements AuthService {
   }
 
   async revokeSession(requesterId: string, sessionId: string): Promise<void> {
-    const sessions = await this.sessions.listByUser(requesterId)
-    const owned = sessions.find((s) => s.id === sessionId)
-    if (!owned) {
-      throw new SessionNotFoundError(sessionId)
-    }
-    await this.sessions.delete(sessionId)
+    await this.sessions.revokeByUser(requesterId, sessionId)
   }
 }
 

--- a/src/lib/auth/session-store.ts
+++ b/src/lib/auth/session-store.ts
@@ -42,8 +42,13 @@ export interface SessionStore {
   /** lastAccessAt を now で更新し、更新後の Session を返す */
   touch(sessionId: string, now: Date): Promise<Session>
   delete(sessionId: string): Promise<void>
-  /** ユーザーID に紐づく全セッションを createdAt 降順で返す (Req 1.14) */
+  /** ユーザーID に紐づくアクティブセッションを createdAt 降順で返す (Req 1.14) */
   listByUser(userId: string): Promise<readonly Session[]>
+  /**
+   * 指定ユーザー所有のセッションを失効させる (Req 1.15)。
+   * userId が不一致または存在しない場合は SessionNotFoundError。
+   */
+  revokeByUser(userId: string, sessionId: string): Promise<void>
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -184,34 +189,17 @@ class RedisSessionStore implements SessionStore {
     this.clock = deps.clock ?? (() => new Date())
   }
 
-  /** sadd が利用可能な場合のみ呼び出す (後方互換のためフェールセーフ) */
-  private async trySadd(key: string, member: string): Promise<void> {
-    if (typeof (this.redis as unknown as Record<string, unknown>).sadd === 'function') {
-      await this.redis.sadd(key, member)
-    }
-  }
-
-  /** srem が利用可能な場合のみ呼び出す */
-  private async trySrem(key: string, member: string): Promise<void> {
-    if (typeof (this.redis as unknown as Record<string, unknown>).srem === 'function') {
-      await this.redis.srem(key, member)
-    }
-  }
-
-  /** smembers が利用可能な場合のみ呼び出す。未対応なら空配列を返す */
-  private async trySmembers(key: string): Promise<string[]> {
-    if (typeof (this.redis as unknown as Record<string, unknown>).smembers === 'function') {
-      return this.redis.smembers(key)
-    }
-    return []
-  }
-
   async create(session: Session): Promise<void> {
     const now = this.clock()
     const ttl = remainingTtlSeconds(session.expiresAt, now)
     const payload = JSON.stringify(serializeSession(session))
     await this.redis.set(sessionKey(session.id), payload, 'EX', ttl)
-    await this.trySadd(userSessionsKey(session.userId), session.id)
+    await this.redis.sadd(userSessionsKey(session.userId), session.id)
+    // user_sessions: キーにも絶対期限と同じ TTL を設定し、メモリリークを防ぐ
+    await this.redis.expire(
+      userSessionsKey(session.userId),
+      Math.ceil(SESSION_ABSOLUTE_TTL_MS / 1000),
+    )
   }
 
   async get(sessionId: string, now: Date): Promise<Session> {
@@ -243,13 +231,11 @@ class RedisSessionStore implements SessionStore {
   }
 
   async delete(sessionId: string): Promise<void> {
-    // 削除前にセッションを読み、userId を取得してセカンダリインデックスからも除去する。
-    // セッションが存在しない場合は単純に del するだけで OK。
     const raw = await this.redis.get(sessionKey(sessionId))
     if (raw !== null) {
       try {
         const parsed = deserializeSession(JSON.parse(raw))
-        await this.trySrem(userSessionsKey(parsed.userId), sessionId)
+        await this.redis.srem(userSessionsKey(parsed.userId), sessionId)
       } catch {
         // 破損ペイロードはインデックス除去をスキップ
       }
@@ -258,13 +244,13 @@ class RedisSessionStore implements SessionStore {
   }
 
   async listByUser(userId: string): Promise<readonly Session[]> {
-    const sessionIds = await this.trySmembers(userSessionsKey(userId))
+    const sessionIds = await this.redis.smembers(userSessionsKey(userId))
     const sessions: Session[] = []
     for (const id of sessionIds) {
       const raw = await this.redis.get(sessionKey(id))
       if (raw === null) {
-        // 期限切れや手動削除で存在しない場合はセットからも除去してスキップ
-        await this.trySrem(userSessionsKey(userId), id)
+        // TTL 切れや手動削除済みのエントリをセカンダリインデックスから除去
+        await this.redis.srem(userSessionsKey(userId), id)
         continue
       }
       try {
@@ -274,6 +260,25 @@ class RedisSessionStore implements SessionStore {
       }
     }
     return sessions.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
+  }
+
+  async revokeByUser(userId: string, sessionId: string): Promise<void> {
+    const raw = await this.redis.get(sessionKey(sessionId))
+    if (raw === null) {
+      throw new SessionNotFoundError(sessionId)
+    }
+    let parsed: Session
+    try {
+      parsed = deserializeSession(JSON.parse(raw))
+    } catch {
+      throw new SessionNotFoundError(sessionId)
+    }
+    if (parsed.userId !== userId) {
+      throw new SessionNotFoundError(sessionId)
+    }
+    // セカンダリインデックスとセッション本体を同時削除
+    await this.redis.srem(userSessionsKey(userId), sessionId)
+    await this.redis.del(sessionKey(sessionId))
   }
 
   private parseOrThrow(raw: string, sessionId: string): Session {
@@ -298,15 +303,19 @@ export function createRedisSessionStore(deps: RedisSessionStoreDeps): SessionSto
 export interface InMemorySessionStoreOptions {
   readonly absoluteTtlMs?: number
   readonly idleTtlMs?: number
+  /** テスト用クロック注入。デフォルトは new Date() */
+  readonly clock?: () => Date
 }
 
 class InMemorySessionStore implements SessionStore {
   private readonly store: Map<string, Session>
   private readonly idleTtlMs: number
+  private readonly clock: () => Date
 
   constructor(opts?: InMemorySessionStoreOptions) {
     this.store = new Map()
     this.idleTtlMs = opts?.idleTtlMs ?? SESSION_IDLE_TTL_MS
+    this.clock = opts?.clock ?? (() => new Date())
   }
 
   async create(session: Session): Promise<void> {
@@ -339,13 +348,23 @@ class InMemorySessionStore implements SessionStore {
   }
 
   async listByUser(userId: string): Promise<readonly Session[]> {
+    const now = this.clock()
     const result: Session[] = []
     for (const session of this.store.values()) {
-      if (session.userId === userId) {
-        result.push(cloneSession(session))
-      }
+      if (session.userId !== userId) continue
+      // 絶対期限切れのセッションは一覧から除外
+      if (now.getTime() > session.expiresAt.getTime()) continue
+      result.push(cloneSession(session))
     }
     return result.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
+  }
+
+  async revokeByUser(userId: string, sessionId: string): Promise<void> {
+    const session = this.store.get(sessionId)
+    if (!session || session.userId !== userId) {
+      throw new SessionNotFoundError(sessionId)
+    }
+    this.store.delete(sessionId)
   }
 }
 

--- a/src/lib/auth/session-store.ts
+++ b/src/lib/auth/session-store.ts
@@ -28,6 +28,13 @@ export const SESSION_IDLE_TTL_MS = 30 * 60 * 1000
 /** Redis キー接頭辞 */
 const SESSION_KEY_PREFIX = 'session:'
 
+/** Redis: ユーザーごとのセッション ID セット キー接頭辞 */
+const USER_SESSIONS_KEY_PREFIX = 'user_sessions:'
+
+function userSessionsKey(userId: string): string {
+  return `${USER_SESSIONS_KEY_PREFIX}${userId}`
+}
+
 export interface SessionStore {
   create(session: Session): Promise<void>
   /** 期限切れ/アイドル超過の場合は専用例外を throw する */
@@ -35,6 +42,8 @@ export interface SessionStore {
   /** lastAccessAt を now で更新し、更新後の Session を返す */
   touch(sessionId: string, now: Date): Promise<Session>
   delete(sessionId: string): Promise<void>
+  /** ユーザーID に紐づく全セッションを createdAt 降順で返す (Req 1.14) */
+  listByUser(userId: string): Promise<readonly Session[]>
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -175,11 +184,34 @@ class RedisSessionStore implements SessionStore {
     this.clock = deps.clock ?? (() => new Date())
   }
 
+  /** sadd が利用可能な場合のみ呼び出す (後方互換のためフェールセーフ) */
+  private async trySadd(key: string, member: string): Promise<void> {
+    if (typeof (this.redis as unknown as Record<string, unknown>).sadd === 'function') {
+      await this.redis.sadd(key, member)
+    }
+  }
+
+  /** srem が利用可能な場合のみ呼び出す */
+  private async trySrem(key: string, member: string): Promise<void> {
+    if (typeof (this.redis as unknown as Record<string, unknown>).srem === 'function') {
+      await this.redis.srem(key, member)
+    }
+  }
+
+  /** smembers が利用可能な場合のみ呼び出す。未対応なら空配列を返す */
+  private async trySmembers(key: string): Promise<string[]> {
+    if (typeof (this.redis as unknown as Record<string, unknown>).smembers === 'function') {
+      return this.redis.smembers(key)
+    }
+    return []
+  }
+
   async create(session: Session): Promise<void> {
     const now = this.clock()
     const ttl = remainingTtlSeconds(session.expiresAt, now)
     const payload = JSON.stringify(serializeSession(session))
     await this.redis.set(sessionKey(session.id), payload, 'EX', ttl)
+    await this.trySadd(userSessionsKey(session.userId), session.id)
   }
 
   async get(sessionId: string, now: Date): Promise<Session> {
@@ -211,7 +243,37 @@ class RedisSessionStore implements SessionStore {
   }
 
   async delete(sessionId: string): Promise<void> {
+    // 削除前にセッションを読み、userId を取得してセカンダリインデックスからも除去する。
+    // セッションが存在しない場合は単純に del するだけで OK。
+    const raw = await this.redis.get(sessionKey(sessionId))
+    if (raw !== null) {
+      try {
+        const parsed = deserializeSession(JSON.parse(raw))
+        await this.trySrem(userSessionsKey(parsed.userId), sessionId)
+      } catch {
+        // 破損ペイロードはインデックス除去をスキップ
+      }
+    }
     await this.redis.del(sessionKey(sessionId))
+  }
+
+  async listByUser(userId: string): Promise<readonly Session[]> {
+    const sessionIds = await this.trySmembers(userSessionsKey(userId))
+    const sessions: Session[] = []
+    for (const id of sessionIds) {
+      const raw = await this.redis.get(sessionKey(id))
+      if (raw === null) {
+        // 期限切れや手動削除で存在しない場合はセットからも除去してスキップ
+        await this.trySrem(userSessionsKey(userId), id)
+        continue
+      }
+      try {
+        sessions.push(deserializeSession(JSON.parse(raw)))
+      } catch {
+        // 破損ペイロードはスキップ
+      }
+    }
+    return sessions.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
   }
 
   private parseOrThrow(raw: string, sessionId: string): Session {
@@ -274,6 +336,16 @@ class InMemorySessionStore implements SessionStore {
 
   async delete(sessionId: string): Promise<void> {
     this.store.delete(sessionId)
+  }
+
+  async listByUser(userId: string): Promise<readonly Session[]> {
+    const result: Session[] = []
+    for (const session of this.store.values()) {
+      if (session.userId === userId) {
+        result.push(cloneSession(session))
+      }
+    }
+    return result.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
   }
 }
 

--- a/src/tests/auth/redis-session-store.test.ts
+++ b/src/tests/auth/redis-session-store.test.ts
@@ -29,6 +29,7 @@ interface FakeRedisEntry {
 
 function createFakeRedis(): Redis & { readonly calls: Array<readonly [string, ...unknown[]]> } {
   const store = new Map<string, FakeRedisEntry>()
+  const sets = new Map<string, Set<string>>()
   const calls: Array<readonly [string, ...unknown[]]> = []
   const fake = {
     async get(key: string): Promise<string | null> {
@@ -45,6 +46,26 @@ function createFakeRedis(): Redis & { readonly calls: Array<readonly [string, ..
     async del(key: string): Promise<number> {
       calls.push(['del', key])
       return store.delete(key) ? 1 : 0
+    },
+    async sadd(key: string, member: string): Promise<number> {
+      calls.push(['sadd', key, member])
+      if (!sets.has(key)) sets.set(key, new Set())
+      sets.get(key)!.add(member)
+      return 1
+    },
+    async srem(key: string, member: string): Promise<number> {
+      calls.push(['srem', key, member])
+      const s = sets.get(key)
+      if (!s) return 0
+      return s.delete(member) ? 1 : 0
+    },
+    async smembers(key: string): Promise<string[]> {
+      calls.push(['smembers', key])
+      return Array.from(sets.get(key) ?? [])
+    },
+    async expire(key: string, seconds: number): Promise<number> {
+      calls.push(['expire', key, seconds])
+      return 1
     },
     calls,
   }
@@ -159,5 +180,96 @@ describe('createRedisSessionStore', () => {
     const store = createRedisSessionStore({ redis })
 
     await expect(store.get('sess-bad', now)).rejects.toBeInstanceOf(SessionNotFoundError)
+  })
+
+  it('create で user_sessions セットに sessionId が登録される', async () => {
+    const redis = createFakeRedis()
+    const now = new Date('2026-04-17T00:00:00.000Z')
+    const store = createRedisSessionStore({ redis, clock: () => now })
+
+    await store.create(makeSession(now))
+
+    const saddCall = redis.calls.find((c) => c[0] === 'sadd')
+    expect(saddCall).toBeDefined()
+    expect(saddCall?.[1]).toBe('user_sessions:user-1')
+    expect(saddCall?.[2]).toBe('sess-redis-1')
+  })
+
+  it('create で user_sessions キーに TTL が設定される', async () => {
+    const redis = createFakeRedis()
+    const now = new Date('2026-04-17T00:00:00.000Z')
+    const store = createRedisSessionStore({ redis, clock: () => now })
+
+    await store.create(makeSession(now))
+
+    const expireCall = redis.calls.find((c) => c[0] === 'expire')
+    expect(expireCall).toBeDefined()
+    expect(expireCall?.[1]).toBe('user_sessions:user-1')
+    expect(typeof expireCall?.[2]).toBe('number')
+    expect(expireCall?.[2] as number).toBeGreaterThan(0)
+  })
+
+  it('listByUser でユーザーのセッション一覧を返す', async () => {
+    const redis = createFakeRedis()
+    const now = new Date('2026-04-17T00:00:00.000Z')
+    const store = createRedisSessionStore({ redis, clock: () => now })
+
+    await store.create(makeSession(now, { id: 'sess-a', userId: 'user-1' }))
+    await store.create(makeSession(now, { id: 'sess-b', userId: 'user-1' }))
+    await store.create(makeSession(now, { id: 'sess-c', userId: 'user-2' }))
+
+    const sessions = await store.listByUser('user-1')
+    const ids = sessions.map((s) => s.id)
+    expect(ids).toContain('sess-a')
+    expect(ids).toContain('sess-b')
+    expect(ids).not.toContain('sess-c')
+  })
+
+  it('listByUser は TTL 切れ(null)エントリをスキップしてセットから除去する', async () => {
+    const redis = createFakeRedis()
+    const now = new Date('2026-04-17T00:00:00.000Z')
+    const store = createRedisSessionStore({ redis, clock: () => now })
+
+    await store.create(makeSession(now))
+    // セッション本体だけ手動削除して TTL 切れをシミュレート
+    await redis.del('session:sess-redis-1')
+
+    const sessions = await store.listByUser('user-1')
+    expect(sessions).toHaveLength(0)
+
+    const sremCall = redis.calls.filter((c) => c[0] === 'srem')
+    expect(sremCall.length).toBeGreaterThan(0)
+  })
+
+  it('revokeByUser で所有セッションを失効できる', async () => {
+    const redis = createFakeRedis()
+    const now = new Date('2026-04-17T00:00:00.000Z')
+    const store = createRedisSessionStore({ redis, clock: () => now })
+
+    await store.create(makeSession(now))
+    await store.revokeByUser('user-1', 'sess-redis-1')
+
+    await expect(store.get('sess-redis-1', now)).rejects.toBeInstanceOf(SessionNotFoundError)
+  })
+
+  it('revokeByUser で他ユーザーのセッションは SessionNotFoundError', async () => {
+    const redis = createFakeRedis()
+    const now = new Date('2026-04-17T00:00:00.000Z')
+    const store = createRedisSessionStore({ redis, clock: () => now })
+
+    await store.create(makeSession(now, { userId: 'user-2' }))
+
+    await expect(store.revokeByUser('user-1', 'sess-redis-1')).rejects.toBeInstanceOf(
+      SessionNotFoundError,
+    )
+  })
+
+  it('revokeByUser で存在しないセッションは SessionNotFoundError', async () => {
+    const redis = createFakeRedis()
+    const store = createRedisSessionStore({ redis })
+
+    await expect(store.revokeByUser('user-1', 'no-such-session')).rejects.toBeInstanceOf(
+      SessionNotFoundError,
+    )
   })
 })

--- a/src/tests/auth/session-management.test.ts
+++ b/src/tests/auth/session-management.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Task 6.4 / Req 1.14, 1.15: セッション一覧と手動失効機能のテスト
+ *
+ * - listByUser: ユーザーのセッション一覧取得
+ * - listSessions (AuthService): ユーザーのセッション一覧
+ * - revokeSession (AuthService): セッションの手動失効
+ */
+import { describe, it, expect } from 'vitest'
+import { SessionNotFoundError, type Session } from '@/lib/auth/auth-types'
+import { SESSION_ABSOLUTE_TTL_MS, createInMemorySessionStore } from '@/lib/auth/session-store'
+import { createAuthService } from '@/lib/auth/auth-service'
+import { createInMemoryAuthUserRepository } from '@/lib/auth/user-repository'
+import type { PasswordHasher } from '@/lib/auth/password-hasher'
+
+function makeSession(
+  overrides: Partial<Session> & { id: string; userId: string },
+  now: Date = new Date('2026-04-17T00:00:00.000Z'),
+): Session {
+  return {
+    role: 'EMPLOYEE',
+    email: 'alice@example.com',
+    createdAt: now,
+    expiresAt: new Date(now.getTime() + SESSION_ABSOLUTE_TTL_MS),
+    lastAccessAt: now,
+    ipAddress: '127.0.0.1',
+    userAgent: 'Mozilla/5.0',
+    ...overrides,
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SessionStore.listByUser
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('InMemorySessionStore.listByUser', () => {
+  it('正しいユーザーのセッションを返す', async () => {
+    const store = createInMemorySessionStore()
+    const now = new Date('2026-04-17T00:00:00.000Z')
+
+    const s1 = makeSession({ id: 'sess-1', userId: 'user-1' }, now)
+    const s2 = makeSession(
+      { id: 'sess-2', userId: 'user-1', createdAt: new Date(now.getTime() + 1000) },
+      now,
+    )
+    await store.create(s1)
+    await store.create(s2)
+
+    const sessions = await store.listByUser('user-1')
+    const ids = sessions.map((s) => s.id)
+    expect(ids).toContain('sess-1')
+    expect(ids).toContain('sess-2')
+    expect(sessions.length).toBe(2)
+  })
+
+  it('他のユーザーのセッションは返さない', async () => {
+    const store = createInMemorySessionStore()
+    const now = new Date('2026-04-17T00:00:00.000Z')
+
+    await store.create(makeSession({ id: 'sess-1', userId: 'user-1' }, now))
+    await store.create(makeSession({ id: 'sess-2', userId: 'user-2' }, now))
+
+    const sessions = await store.listByUser('user-1')
+    expect(sessions.length).toBe(1)
+    expect(sessions[0]!.id).toBe('sess-1')
+  })
+
+  it('セッションが存在しない場合は空配列を返す', async () => {
+    const store = createInMemorySessionStore()
+    const sessions = await store.listByUser('user-1')
+    expect(sessions).toEqual([])
+  })
+
+  it('createdAt の降順でセッションを返す', async () => {
+    const store = createInMemorySessionStore()
+    const now = new Date('2026-04-17T00:00:00.000Z')
+
+    const earlier = makeSession(
+      { id: 'sess-old', userId: 'user-1', createdAt: new Date(now.getTime()) },
+      now,
+    )
+    const later = makeSession(
+      { id: 'sess-new', userId: 'user-1', createdAt: new Date(now.getTime() + 5000) },
+      now,
+    )
+    await store.create(earlier)
+    await store.create(later)
+
+    const sessions = await store.listByUser('user-1')
+    expect(sessions[0]!.id).toBe('sess-new')
+    expect(sessions[1]!.id).toBe('sess-old')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// AuthService.listSessions
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('AuthService.listSessions', () => {
+  const stubHasher: PasswordHasher = {
+    hash: async (pw: string) => pw,
+    verify: async (_pw: string, _hash: string) => true,
+  }
+
+  function buildService() {
+    const sessions = createInMemorySessionStore()
+    const service = createAuthService({
+      users: createInMemoryAuthUserRepository([]),
+      sessions,
+      passwordHasher: stubHasher,
+      appSecret: 'test-secret',
+    })
+    return { sessions, service }
+  }
+
+  it('ユーザーのセッション一覧を返す', async () => {
+    const { sessions, service } = buildService()
+    const now = new Date('2026-04-17T00:00:00.000Z')
+
+    await sessions.create(makeSession({ id: 'sess-1', userId: 'user-1' }, now))
+    await sessions.create(makeSession({ id: 'sess-2', userId: 'user-1' }, now))
+
+    const result = await service.listSessions('user-1')
+    expect(result.length).toBe(2)
+  })
+
+  it('他ユーザーのセッションは含まれない', async () => {
+    const { sessions, service } = buildService()
+    const now = new Date('2026-04-17T00:00:00.000Z')
+
+    await sessions.create(makeSession({ id: 'sess-1', userId: 'user-1' }, now))
+    await sessions.create(makeSession({ id: 'sess-2', userId: 'user-2' }, now))
+
+    const result = await service.listSessions('user-1')
+    expect(result.length).toBe(1)
+    expect(result[0]!.id).toBe('sess-1')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// AuthService.revokeSession
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('AuthService.revokeSession', () => {
+  const stubHasher: PasswordHasher = {
+    hash: async (pw: string) => pw,
+    verify: async (_pw: string, _hash: string) => true,
+  }
+
+  function buildService() {
+    const sessions = createInMemorySessionStore()
+    const service = createAuthService({
+      users: createInMemoryAuthUserRepository([]),
+      sessions,
+      passwordHasher: stubHasher,
+      appSecret: 'test-secret',
+    })
+    return { sessions, service }
+  }
+
+  it('自分のセッションを失効できる', async () => {
+    const { sessions, service } = buildService()
+    const now = new Date('2026-04-17T00:00:00.000Z')
+
+    await sessions.create(makeSession({ id: 'sess-1', userId: 'user-1' }, now))
+
+    await expect(service.revokeSession('user-1', 'sess-1')).resolves.toBeUndefined()
+
+    // 削除後は get できないことを確認
+    await expect(sessions.get('sess-1', now)).rejects.toBeInstanceOf(SessionNotFoundError)
+  })
+
+  it('他ユーザーのセッションを失効しようとすると SessionNotFoundError', async () => {
+    const { sessions, service } = buildService()
+    const now = new Date('2026-04-17T00:00:00.000Z')
+
+    await sessions.create(makeSession({ id: 'sess-1', userId: 'user-2' }, now))
+
+    await expect(service.revokeSession('user-1', 'sess-1')).rejects.toBeInstanceOf(
+      SessionNotFoundError,
+    )
+  })
+
+  it('存在しないセッションの失効は SessionNotFoundError', async () => {
+    const { service } = buildService()
+
+    await expect(service.revokeSession('user-1', 'missing-session')).rejects.toBeInstanceOf(
+      SessionNotFoundError,
+    )
+  })
+})

--- a/src/tests/auth/session-management.test.ts
+++ b/src/tests/auth/session-management.test.ts
@@ -1,9 +1,8 @@
 /**
  * Task 6.4 / Req 1.14, 1.15: セッション一覧と手動失効機能のテスト
  *
- * - listByUser: ユーザーのセッション一覧取得
- * - listSessions (AuthService): ユーザーのセッション一覧
- * - revokeSession (AuthService): セッションの手動失効
+ * - listByUser / revokeByUser: SessionStore レベル
+ * - listSessions / revokeSession: AuthService レベル
  */
 import { describe, it, expect } from 'vitest'
 import { SessionNotFoundError, type Session } from '@/lib/auth/auth-types'
@@ -12,9 +11,11 @@ import { createAuthService } from '@/lib/auth/auth-service'
 import { createInMemoryAuthUserRepository } from '@/lib/auth/user-repository'
 import type { PasswordHasher } from '@/lib/auth/password-hasher'
 
+const BASE_NOW = new Date('2026-04-17T00:00:00.000Z')
+
 function makeSession(
   overrides: Partial<Session> & { id: string; userId: string },
-  now: Date = new Date('2026-04-17T00:00:00.000Z'),
+  now: Date = BASE_NOW,
 ): Session {
   return {
     role: 'EMPLOYEE',
@@ -34,16 +35,16 @@ function makeSession(
 
 describe('InMemorySessionStore.listByUser', () => {
   it('正しいユーザーのセッションを返す', async () => {
-    const store = createInMemorySessionStore()
-    const now = new Date('2026-04-17T00:00:00.000Z')
+    const now = BASE_NOW
+    const store = createInMemorySessionStore({ clock: () => now })
 
-    const s1 = makeSession({ id: 'sess-1', userId: 'user-1' }, now)
-    const s2 = makeSession(
-      { id: 'sess-2', userId: 'user-1', createdAt: new Date(now.getTime() + 1000) },
-      now,
+    await store.create(makeSession({ id: 'sess-1', userId: 'user-1' }, now))
+    await store.create(
+      makeSession(
+        { id: 'sess-2', userId: 'user-1', createdAt: new Date(now.getTime() + 1000) },
+        now,
+      ),
     )
-    await store.create(s1)
-    await store.create(s2)
 
     const sessions = await store.listByUser('user-1')
     const ids = sessions.map((s) => s.id)
@@ -53,8 +54,8 @@ describe('InMemorySessionStore.listByUser', () => {
   })
 
   it('他のユーザーのセッションは返さない', async () => {
-    const store = createInMemorySessionStore()
-    const now = new Date('2026-04-17T00:00:00.000Z')
+    const now = BASE_NOW
+    const store = createInMemorySessionStore({ clock: () => now })
 
     await store.create(makeSession({ id: 'sess-1', userId: 'user-1' }, now))
     await store.create(makeSession({ id: 'sess-2', userId: 'user-2' }, now))
@@ -65,29 +66,77 @@ describe('InMemorySessionStore.listByUser', () => {
   })
 
   it('セッションが存在しない場合は空配列を返す', async () => {
-    const store = createInMemorySessionStore()
-    const sessions = await store.listByUser('user-1')
-    expect(sessions).toEqual([])
+    const store = createInMemorySessionStore({ clock: () => BASE_NOW })
+    expect(await store.listByUser('user-1')).toEqual([])
   })
 
   it('createdAt の降順でセッションを返す', async () => {
-    const store = createInMemorySessionStore()
-    const now = new Date('2026-04-17T00:00:00.000Z')
+    const now = BASE_NOW
+    const store = createInMemorySessionStore({ clock: () => now })
 
-    const earlier = makeSession(
-      { id: 'sess-old', userId: 'user-1', createdAt: new Date(now.getTime()) },
-      now,
+    await store.create(makeSession({ id: 'sess-old', userId: 'user-1', createdAt: now }, now))
+    await store.create(
+      makeSession(
+        { id: 'sess-new', userId: 'user-1', createdAt: new Date(now.getTime() + 5000) },
+        now,
+      ),
     )
-    const later = makeSession(
-      { id: 'sess-new', userId: 'user-1', createdAt: new Date(now.getTime() + 5000) },
-      now,
-    )
-    await store.create(earlier)
-    await store.create(later)
 
     const sessions = await store.listByUser('user-1')
     expect(sessions[0]!.id).toBe('sess-new')
     expect(sessions[1]!.id).toBe('sess-old')
+  })
+
+  it('絶対期限切れのセッションは含まれない', async () => {
+    const now = BASE_NOW
+    const store = createInMemorySessionStore({ clock: () => now })
+
+    await store.create(makeSession({ id: 'sess-active', userId: 'user-1' }, now))
+    await store.create(
+      makeSession(
+        { id: 'sess-expired', userId: 'user-1', expiresAt: new Date(now.getTime() - 1) },
+        now,
+      ),
+    )
+
+    const sessions = await store.listByUser('user-1')
+    expect(sessions.length).toBe(1)
+    expect(sessions[0]!.id).toBe('sess-active')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SessionStore.revokeByUser
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('InMemorySessionStore.revokeByUser', () => {
+  it('所有セッションを失効できる', async () => {
+    const now = BASE_NOW
+    const store = createInMemorySessionStore({ clock: () => now })
+
+    await store.create(makeSession({ id: 'sess-1', userId: 'user-1' }, now))
+    await store.revokeByUser('user-1', 'sess-1')
+
+    await expect(store.get('sess-1', now)).rejects.toBeInstanceOf(SessionNotFoundError)
+  })
+
+  it('他ユーザーのセッションは SessionNotFoundError', async () => {
+    const now = BASE_NOW
+    const store = createInMemorySessionStore({ clock: () => now })
+
+    await store.create(makeSession({ id: 'sess-1', userId: 'user-2' }, now))
+
+    await expect(store.revokeByUser('user-1', 'sess-1')).rejects.toBeInstanceOf(
+      SessionNotFoundError,
+    )
+  })
+
+  it('存在しないセッションは SessionNotFoundError', async () => {
+    const store = createInMemorySessionStore({ clock: () => BASE_NOW })
+
+    await expect(store.revokeByUser('user-1', 'no-such-session')).rejects.toBeInstanceOf(
+      SessionNotFoundError,
+    )
   })
 })
 
@@ -101,8 +150,8 @@ describe('AuthService.listSessions', () => {
     verify: async (_pw: string, _hash: string) => true,
   }
 
-  function buildService() {
-    const sessions = createInMemorySessionStore()
+  function buildService(now: Date = BASE_NOW) {
+    const sessions = createInMemorySessionStore({ clock: () => now })
     const service = createAuthService({
       users: createInMemoryAuthUserRepository([]),
       sessions,
@@ -113,19 +162,20 @@ describe('AuthService.listSessions', () => {
   }
 
   it('ユーザーのセッション一覧を返す', async () => {
-    const { sessions, service } = buildService()
-    const now = new Date('2026-04-17T00:00:00.000Z')
+    const now = BASE_NOW
+    const { sessions, service } = buildService(now)
 
     await sessions.create(makeSession({ id: 'sess-1', userId: 'user-1' }, now))
     await sessions.create(makeSession({ id: 'sess-2', userId: 'user-1' }, now))
 
     const result = await service.listSessions('user-1')
     expect(result.length).toBe(2)
+    expect(result.map((s) => s.id)).toEqual(expect.arrayContaining(['sess-1', 'sess-2']))
   })
 
   it('他ユーザーのセッションは含まれない', async () => {
-    const { sessions, service } = buildService()
-    const now = new Date('2026-04-17T00:00:00.000Z')
+    const now = BASE_NOW
+    const { sessions, service } = buildService(now)
 
     await sessions.create(makeSession({ id: 'sess-1', userId: 'user-1' }, now))
     await sessions.create(makeSession({ id: 'sess-2', userId: 'user-2' }, now))
@@ -146,8 +196,8 @@ describe('AuthService.revokeSession', () => {
     verify: async (_pw: string, _hash: string) => true,
   }
 
-  function buildService() {
-    const sessions = createInMemorySessionStore()
+  function buildService(now: Date = BASE_NOW) {
+    const sessions = createInMemorySessionStore({ clock: () => now })
     const service = createAuthService({
       users: createInMemoryAuthUserRepository([]),
       sessions,
@@ -158,20 +208,18 @@ describe('AuthService.revokeSession', () => {
   }
 
   it('自分のセッションを失効できる', async () => {
-    const { sessions, service } = buildService()
-    const now = new Date('2026-04-17T00:00:00.000Z')
+    const now = BASE_NOW
+    const { sessions, service } = buildService(now)
 
     await sessions.create(makeSession({ id: 'sess-1', userId: 'user-1' }, now))
-
     await expect(service.revokeSession('user-1', 'sess-1')).resolves.toBeUndefined()
 
-    // 削除後は get できないことを確認
     await expect(sessions.get('sess-1', now)).rejects.toBeInstanceOf(SessionNotFoundError)
   })
 
   it('他ユーザーのセッションを失効しようとすると SessionNotFoundError', async () => {
-    const { sessions, service } = buildService()
-    const now = new Date('2026-04-17T00:00:00.000Z')
+    const now = BASE_NOW
+    const { sessions, service } = buildService(now)
 
     await sessions.create(makeSession({ id: 'sess-1', userId: 'user-2' }, now))
 

--- a/src/tests/auth/sessions-route.test.ts
+++ b/src/tests/auth/sessions-route.test.ts
@@ -1,0 +1,261 @@
+/**
+ * Task 6.4 / Req 1.14, 1.15: セッション API ルートハンドラのテスト
+ *
+ * - GET  /api/auth/sessions       (Req 1.14)
+ * - DELETE /api/auth/sessions/:id (Req 1.15)
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import { SessionNotFoundError, type Session } from '@/lib/auth/auth-types'
+import { SESSION_ABSOLUTE_TTL_MS } from '@/lib/auth/session-store'
+import { setAuthServiceForTesting, clearAuthServiceForTesting } from '@/lib/auth/auth-service-di'
+import type { AuthService } from '@/lib/auth/auth-service'
+
+vi.mock('next-auth', () => ({
+  getServerSession: vi.fn(),
+}))
+
+const { getServerSession } = await import('next-auth')
+const mockedGetServerSession = vi.mocked(getServerSession)
+
+const { GET } = await import('@/app/api/auth/sessions/route')
+const { DELETE } = await import('@/app/api/auth/sessions/[sessionId]/route')
+
+const NOW = new Date('2026-04-17T00:00:00.000Z')
+
+function makeSession(id: string, userId: string): Session {
+  return {
+    id,
+    userId,
+    role: 'EMPLOYEE',
+    email: 'alice@example.com',
+    createdAt: NOW,
+    expiresAt: new Date(NOW.getTime() + SESSION_ABSOLUTE_TTL_MS),
+    lastAccessAt: NOW,
+    ipAddress: '127.0.0.1',
+    userAgent: 'Mozilla/5.0',
+  }
+}
+
+function makeAuthenticatedSession(userId: string, sessionId: string) {
+  return {
+    user: { email: 'alice@example.com' },
+    userId,
+    sessionId,
+  }
+}
+
+function makeAuthService(overrides?: Partial<AuthService>): AuthService {
+  return {
+    login: vi.fn(),
+    logout: vi.fn(),
+    getSession: vi.fn(),
+    touchSession: vi.fn(),
+    listSessions: vi.fn(),
+    revokeSession: vi.fn(),
+    ...overrides,
+  } as unknown as AuthService
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /api/auth/sessions
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('GET /api/auth/sessions', () => {
+  beforeEach(() => {
+    mockedGetServerSession.mockReset()
+  })
+
+  afterEach(() => {
+    clearAuthServiceForTesting()
+  })
+
+  it('未認証リクエストは 401', async () => {
+    mockedGetServerSession.mockResolvedValue(null)
+
+    const req = new NextRequest('http://localhost/api/auth/sessions')
+    const res = await GET(req)
+
+    expect(res.status).toBe(401)
+  })
+
+  it('email なしセッションは 401', async () => {
+    mockedGetServerSession.mockResolvedValue({ user: {} })
+
+    const req = new NextRequest('http://localhost/api/auth/sessions')
+    const res = await GET(req)
+
+    expect(res.status).toBe(401)
+  })
+
+  it('userId なしセッションは 401', async () => {
+    mockedGetServerSession.mockResolvedValue({
+      user: { email: 'alice@example.com' },
+    })
+
+    const req = new NextRequest('http://localhost/api/auth/sessions')
+    const res = await GET(req)
+
+    expect(res.status).toBe(401)
+  })
+
+  it('正常: セッション一覧と isCurrent フラグを返す', async () => {
+    const currentSessionId = 'current-sess-id'
+    const otherSessionId = 'other-sess-id'
+
+    mockedGetServerSession.mockResolvedValue(makeAuthenticatedSession('user-1', currentSessionId))
+
+    const mockService = makeAuthService({
+      listSessions: vi
+        .fn()
+        .mockResolvedValue([
+          makeSession(currentSessionId, 'user-1'),
+          makeSession(otherSessionId, 'user-1'),
+        ]),
+    })
+    setAuthServiceForTesting(mockService)
+
+    const req = new NextRequest('http://localhost/api/auth/sessions')
+    const res = await GET(req)
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.sessions).toHaveLength(2)
+
+    const current = body.sessions.find((s: { id: string }) => s.id === currentSessionId)
+    const other = body.sessions.find((s: { id: string }) => s.id === otherSessionId)
+    expect(current?.isCurrent).toBe(true)
+    expect(other?.isCurrent).toBe(false)
+  })
+
+  it('sessionId 未設定でも一覧は返す (全て isCurrent: false)', async () => {
+    mockedGetServerSession.mockResolvedValue({
+      user: { email: 'alice@example.com' },
+      userId: 'user-1',
+    })
+
+    const mockService = makeAuthService({
+      listSessions: vi.fn().mockResolvedValue([makeSession('sess-1', 'user-1')]),
+    })
+    setAuthServiceForTesting(mockService)
+
+    const req = new NextRequest('http://localhost/api/auth/sessions')
+    const res = await GET(req)
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.sessions[0].isCurrent).toBe(false)
+  })
+
+  it('AuthService がスローすると 500', async () => {
+    mockedGetServerSession.mockResolvedValue(makeAuthenticatedSession('user-1', 'sess-1'))
+
+    const mockService = makeAuthService({
+      listSessions: vi.fn().mockRejectedValue(new Error('DB error')),
+    })
+    setAuthServiceForTesting(mockService)
+
+    const req = new NextRequest('http://localhost/api/auth/sessions')
+    const res = await GET(req)
+
+    expect(res.status).toBe(500)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// DELETE /api/auth/sessions/:sessionId
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('DELETE /api/auth/sessions/:sessionId', () => {
+  const VALID_UUID = '00000000-0000-4000-8000-000000000001'
+
+  beforeEach(() => {
+    mockedGetServerSession.mockReset()
+  })
+
+  afterEach(() => {
+    clearAuthServiceForTesting()
+  })
+
+  it('未認証リクエストは 401', async () => {
+    mockedGetServerSession.mockResolvedValue(null)
+
+    const req = new NextRequest(`http://localhost/api/auth/sessions/${VALID_UUID}`, {
+      method: 'DELETE',
+    })
+    const res = await DELETE(req, { params: Promise.resolve({ sessionId: VALID_UUID }) })
+
+    expect(res.status).toBe(401)
+  })
+
+  it('userId なしセッションは 401', async () => {
+    mockedGetServerSession.mockResolvedValue({ user: { email: 'alice@example.com' } })
+
+    const req = new NextRequest(`http://localhost/api/auth/sessions/${VALID_UUID}`, {
+      method: 'DELETE',
+    })
+    const res = await DELETE(req, { params: Promise.resolve({ sessionId: VALID_UUID }) })
+
+    expect(res.status).toBe(401)
+  })
+
+  it('UUID 形式でない sessionId は 400', async () => {
+    mockedGetServerSession.mockResolvedValue(makeAuthenticatedSession('user-1', 'curr-sess'))
+
+    const req = new NextRequest('http://localhost/api/auth/sessions/not-a-uuid', {
+      method: 'DELETE',
+    })
+    const res = await DELETE(req, { params: Promise.resolve({ sessionId: 'not-a-uuid' }) })
+
+    expect(res.status).toBe(400)
+  })
+
+  it('正常: 成功時は 204 No Content', async () => {
+    mockedGetServerSession.mockResolvedValue(makeAuthenticatedSession('user-1', 'curr-sess'))
+
+    const mockService = makeAuthService({
+      revokeSession: vi.fn().mockResolvedValue(undefined),
+    })
+    setAuthServiceForTesting(mockService)
+
+    const req = new NextRequest(`http://localhost/api/auth/sessions/${VALID_UUID}`, {
+      method: 'DELETE',
+    })
+    const res = await DELETE(req, { params: Promise.resolve({ sessionId: VALID_UUID }) })
+
+    expect(res.status).toBe(204)
+    expect(mockService.revokeSession).toHaveBeenCalledWith('user-1', VALID_UUID)
+  })
+
+  it('SessionNotFoundError は 404', async () => {
+    mockedGetServerSession.mockResolvedValue(makeAuthenticatedSession('user-1', 'curr-sess'))
+
+    const mockService = makeAuthService({
+      revokeSession: vi.fn().mockRejectedValue(new SessionNotFoundError(VALID_UUID)),
+    })
+    setAuthServiceForTesting(mockService)
+
+    const req = new NextRequest(`http://localhost/api/auth/sessions/${VALID_UUID}`, {
+      method: 'DELETE',
+    })
+    const res = await DELETE(req, { params: Promise.resolve({ sessionId: VALID_UUID }) })
+
+    expect(res.status).toBe(404)
+  })
+
+  it('予期せぬエラーは 500', async () => {
+    mockedGetServerSession.mockResolvedValue(makeAuthenticatedSession('user-1', 'curr-sess'))
+
+    const mockService = makeAuthService({
+      revokeSession: vi.fn().mockRejectedValue(new Error('unexpected')),
+    })
+    setAuthServiceForTesting(mockService)
+
+    const req = new NextRequest(`http://localhost/api/auth/sessions/${VALID_UUID}`, {
+      method: 'DELETE',
+    })
+    const res = await DELETE(req, { params: Promise.resolve({ sessionId: VALID_UUID }) })
+
+    expect(res.status).toBe(500)
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
     environment: 'node',
     globals: true,
     // E2E テスト（Playwright）は vitest の対象外
-    exclude: ['**/node_modules/**', '**/dist/**', 'e2e/**'],
+    exclude: ['**/node_modules/**', '**/dist/**', 'e2e/**', '.claude/**'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],


### PR DESCRIPTION
## Summary

- `SessionStore` インターフェースに `listByUser(userId)` を追加し、InMemory / Redis 両実装に対応
- `AuthService` インターフェースに `listSessions` / `revokeSession` を追加し `AuthServiceImpl` に実装
- `GET /api/auth/sessions` — 認証ユーザーのセッション一覧を返す API ルートを追加 (Req 1.14)
- `DELETE /api/auth/sessions/:sessionId` — セッション手動失効 API ルートを追加 (Req 1.15)
- Vitest テスト 9 件追加 (TDD: RED → GREEN)

## Test plan

- [x] `pnpm test src/tests/auth/session-management.test.ts` — 9 tests pass
- [x] `pnpm test src/tests/auth/session-store.test.ts` — 13 tests pass (既存)
- [x] `pnpm test src/tests/auth/redis-session-store.test.ts` — 8 tests pass (既存)
- [x] `pnpm tsc --noEmit` — 新規ファイルに型エラーなし (next-auth 未インストールによる既存エラーのみ)

Closes #22