### PR TITLE
fix: [Task 6.4] listByUser idle timeout 考慮 (Issue #108)

### DIFF
--- a/src/lib/auth/auth-service.ts
+++ b/src/lib/auth/auth-service.ts
@@ -243,7 +243,7 @@ class AuthServiceImpl implements AuthService {
   }
 
   async listSessions(userId: string): Promise<readonly Session[]> {
-    return this.sessions.listByUser(userId)
+    return this.sessions.listByUser(userId, this.clock())
   }
 
   async revokeSession(requesterId: string, sessionId: string): Promise<void> {

--- a/src/lib/auth/session-store.ts
+++ b/src/lib/auth/session-store.ts
@@ -42,8 +42,12 @@ export interface SessionStore {
   /** lastAccessAt を now で更新し、更新後の Session を返す */
   touch(sessionId: string, now: Date): Promise<Session>
   delete(sessionId: string): Promise<void>
-  /** ユーザーID に紐づくアクティブセッションを createdAt 降順で返す (Req 1.14) */
-  listByUser(userId: string): Promise<readonly Session[]>
+  /**
+   * ユーザーID に紐づくアクティブセッションを createdAt 降順で返す (Req 1.14)。
+   * `now` 時点で絶対期限切れ / idle timeout 超過のセッションは除外する
+   * (SessionStore.get の assertSessionLive と同じ生存判定)。
+   */
+  listByUser(userId: string, now: Date): Promise<readonly Session[]>
   /**
    * 指定ユーザー所有のセッションを失効させる (Req 1.15)。
    * userId が不一致または存在しない場合は SessionNotFoundError。
@@ -160,6 +164,17 @@ function assertSessionLive(session: Session, now: Date, idleTtlMs: number): void
   }
 }
 
+/**
+ * 期限 / アイドル判定 (例外を投げないバージョン)。
+ * listByUser で複数セッションを並行判定する用途で使用する。
+ * `assertSessionLive` と同じルールで、生存なら true を返す。
+ */
+function isSessionLive(session: Session, now: Date, idleTtlMs: number): boolean {
+  if (now.getTime() > session.expiresAt.getTime()) return false
+  if (now.getTime() - session.lastAccessAt.getTime() > idleTtlMs) return false
+  return true
+}
+
 /** Redis EXPIRE に渡す残り秒 (最小 1 秒) */
 function remainingTtlSeconds(expiresAt: Date, now: Date): number {
   const remainingMs = expiresAt.getTime() - now.getTime()
@@ -243,7 +258,7 @@ class RedisSessionStore implements SessionStore {
     await this.redis.del(sessionKey(sessionId))
   }
 
-  async listByUser(userId: string): Promise<readonly Session[]> {
+  async listByUser(userId: string, now: Date): Promise<readonly Session[]> {
     const sessionIds = await this.redis.smembers(userSessionsKey(userId))
     const sessions: Session[] = []
     for (const id of sessionIds) {
@@ -253,11 +268,22 @@ class RedisSessionStore implements SessionStore {
         await this.redis.srem(userSessionsKey(userId), id)
         continue
       }
+      let parsed: Session
       try {
-        sessions.push(deserializeSession(JSON.parse(raw)))
+        parsed = deserializeSession(JSON.parse(raw))
       } catch {
         // 破損ペイロードはスキップ
+        continue
       }
+      // SessionStore.get の assertSessionLive と同じ生存判定
+      // (絶対期限切れ or idle timeout 超過のセッションは一覧から除外)
+      if (!isSessionLive(parsed, now, this.idleTtlMs)) {
+        // 掃除: セッション本体とセカンダリインデックスの両方を除去
+        await this.redis.srem(userSessionsKey(userId), id)
+        await this.redis.del(sessionKey(id))
+        continue
+      }
+      sessions.push(parsed)
     }
     return sessions.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
   }
@@ -303,19 +329,20 @@ export function createRedisSessionStore(deps: RedisSessionStoreDeps): SessionSto
 export interface InMemorySessionStoreOptions {
   readonly absoluteTtlMs?: number
   readonly idleTtlMs?: number
-  /** テスト用クロック注入。デフォルトは new Date() */
+  /**
+   * テスト用クロック注入 (後方互換のため受け入れるが、現行実装では参照しない)。
+   * 生存判定用の `now` は `get` / `touch` / `listByUser` の引数で受け取る。
+   */
   readonly clock?: () => Date
 }
 
 class InMemorySessionStore implements SessionStore {
   private readonly store: Map<string, Session>
   private readonly idleTtlMs: number
-  private readonly clock: () => Date
 
   constructor(opts?: InMemorySessionStoreOptions) {
     this.store = new Map()
     this.idleTtlMs = opts?.idleTtlMs ?? SESSION_IDLE_TTL_MS
-    this.clock = opts?.clock ?? (() => new Date())
   }
 
   async create(session: Session): Promise<void> {
@@ -347,13 +374,13 @@ class InMemorySessionStore implements SessionStore {
     this.store.delete(sessionId)
   }
 
-  async listByUser(userId: string): Promise<readonly Session[]> {
-    const now = this.clock()
+  async listByUser(userId: string, now: Date): Promise<readonly Session[]> {
     const result: Session[] = []
     for (const session of this.store.values()) {
       if (session.userId !== userId) continue
-      // 絶対期限切れのセッションは一覧から除外
-      if (now.getTime() > session.expiresAt.getTime()) continue
+      // SessionStore.get の assertSessionLive と同じ生存判定
+      // (絶対期限切れ or idle timeout 超過のセッションは一覧から除外)
+      if (!isSessionLive(session, now, this.idleTtlMs)) continue
       result.push(cloneSession(session))
     }
     return result.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())

--- a/src/tests/auth/redis-session-store.test.ts
+++ b/src/tests/auth/redis-session-store.test.ts
@@ -218,7 +218,7 @@ describe('createRedisSessionStore', () => {
     await store.create(makeSession(now, { id: 'sess-b', userId: 'user-1' }))
     await store.create(makeSession(now, { id: 'sess-c', userId: 'user-2' }))
 
-    const sessions = await store.listByUser('user-1')
+    const sessions = await store.listByUser('user-1', now)
     const ids = sessions.map((s) => s.id)
     expect(ids).toContain('sess-a')
     expect(ids).toContain('sess-b')
@@ -234,11 +234,87 @@ describe('createRedisSessionStore', () => {
     // セッション本体だけ手動削除して TTL 切れをシミュレート
     await redis.del('session:sess-redis-1')
 
-    const sessions = await store.listByUser('user-1')
+    const sessions = await store.listByUser('user-1', now)
     expect(sessions).toHaveLength(0)
 
     const sremCall = redis.calls.filter((c) => c[0] === 'srem')
     expect(sremCall.length).toBeGreaterThan(0)
+  })
+
+  it('listByUser は idle timeout 超過セッションを除外し、user_sessions セットからも除去する', async () => {
+    const redis = createFakeRedis()
+    const now = new Date('2026-04-17T00:00:00.000Z')
+    const store = createRedisSessionStore({ redis, clock: () => now })
+
+    // active + stale (idle 超過) の 2 セッションを登録
+    await store.create(makeSession(now, { id: 'sess-active', userId: 'user-1' }))
+    await store.create(
+      makeSession(now, {
+        id: 'sess-stale',
+        userId: 'user-1',
+        lastAccessAt: new Date(now.getTime() - SESSION_IDLE_TTL_MS - 1000),
+      }),
+    )
+
+    const sessions = await store.listByUser('user-1', now)
+    const ids = sessions.map((s) => s.id)
+    expect(ids).toContain('sess-active')
+    expect(ids).not.toContain('sess-stale')
+    expect(sessions).toHaveLength(1)
+
+    // user_sessions セットから sess-stale が srem されている
+    const sremCalls = redis.calls.filter((c) => c[0] === 'srem')
+    const sremStale = sremCalls.find(
+      (c) => c[1] === 'user_sessions:user-1' && c[2] === 'sess-stale',
+    )
+    expect(sremStale).toBeDefined()
+  })
+
+  it('listByUser は絶対期限切れセッションを除外する', async () => {
+    const redis = createFakeRedis()
+    const now = new Date('2026-04-17T00:00:00.000Z')
+    const store = createRedisSessionStore({ redis, clock: () => now })
+
+    await store.create(makeSession(now, { id: 'sess-active', userId: 'user-1' }))
+    await store.create(
+      makeSession(now, {
+        id: 'sess-expired',
+        userId: 'user-1',
+        expiresAt: new Date(now.getTime() - 1),
+      }),
+    )
+
+    const sessions = await store.listByUser('user-1', now)
+    const ids = sessions.map((s) => s.id)
+    expect(ids).toContain('sess-active')
+    expect(ids).not.toContain('sess-expired')
+    expect(sessions).toHaveLength(1)
+  })
+
+  it('listByUser は idle timeout と絶対期限の両方を考慮する', async () => {
+    const redis = createFakeRedis()
+    const now = new Date('2026-04-17T00:00:00.000Z')
+    const store = createRedisSessionStore({ redis, clock: () => now })
+
+    await store.create(makeSession(now, { id: 'sess-ok', userId: 'user-1' }))
+    await store.create(
+      makeSession(now, {
+        id: 'sess-expired',
+        userId: 'user-1',
+        expiresAt: new Date(now.getTime() - 1),
+      }),
+    )
+    await store.create(
+      makeSession(now, {
+        id: 'sess-idle',
+        userId: 'user-1',
+        lastAccessAt: new Date(now.getTime() - SESSION_IDLE_TTL_MS - 1000),
+      }),
+    )
+
+    const sessions = await store.listByUser('user-1', now)
+    expect(sessions).toHaveLength(1)
+    expect(sessions[0]!.id).toBe('sess-ok')
   })
 
   it('revokeByUser で所有セッションを失効できる', async () => {

--- a/src/tests/auth/session-management.test.ts
+++ b/src/tests/auth/session-management.test.ts
@@ -6,7 +6,11 @@
  */
 import { describe, it, expect } from 'vitest'
 import { SessionNotFoundError, type Session } from '@/lib/auth/auth-types'
-import { SESSION_ABSOLUTE_TTL_MS, createInMemorySessionStore } from '@/lib/auth/session-store'
+import {
+  SESSION_ABSOLUTE_TTL_MS,
+  SESSION_IDLE_TTL_MS,
+  createInMemorySessionStore,
+} from '@/lib/auth/session-store'
 import { createAuthService } from '@/lib/auth/auth-service'
 import { createInMemoryAuthUserRepository } from '@/lib/auth/user-repository'
 import type { PasswordHasher } from '@/lib/auth/password-hasher'
@@ -46,7 +50,7 @@ describe('InMemorySessionStore.listByUser', () => {
       ),
     )
 
-    const sessions = await store.listByUser('user-1')
+    const sessions = await store.listByUser('user-1', now)
     const ids = sessions.map((s) => s.id)
     expect(ids).toContain('sess-1')
     expect(ids).toContain('sess-2')
@@ -60,14 +64,14 @@ describe('InMemorySessionStore.listByUser', () => {
     await store.create(makeSession({ id: 'sess-1', userId: 'user-1' }, now))
     await store.create(makeSession({ id: 'sess-2', userId: 'user-2' }, now))
 
-    const sessions = await store.listByUser('user-1')
+    const sessions = await store.listByUser('user-1', now)
     expect(sessions.length).toBe(1)
     expect(sessions[0]!.id).toBe('sess-1')
   })
 
   it('セッションが存在しない場合は空配列を返す', async () => {
     const store = createInMemorySessionStore({ clock: () => BASE_NOW })
-    expect(await store.listByUser('user-1')).toEqual([])
+    expect(await store.listByUser('user-1', BASE_NOW)).toEqual([])
   })
 
   it('createdAt の降順でセッションを返す', async () => {
@@ -82,7 +86,7 @@ describe('InMemorySessionStore.listByUser', () => {
       ),
     )
 
-    const sessions = await store.listByUser('user-1')
+    const sessions = await store.listByUser('user-1', now)
     expect(sessions[0]!.id).toBe('sess-new')
     expect(sessions[1]!.id).toBe('sess-old')
   })
@@ -99,9 +103,84 @@ describe('InMemorySessionStore.listByUser', () => {
       ),
     )
 
-    const sessions = await store.listByUser('user-1')
+    const sessions = await store.listByUser('user-1', now)
     expect(sessions.length).toBe(1)
     expect(sessions[0]!.id).toBe('sess-active')
+  })
+
+  it('idle timeout 超過 (lastAccessAt が SESSION_IDLE_TTL_MS より古い) セッションは含まれない', async () => {
+    const now = BASE_NOW
+    const store = createInMemorySessionStore({ clock: () => now })
+
+    // lastAccessAt が now - (SESSION_IDLE_TTL_MS + 1ms) → idle 超過
+    const staleLastAccess = new Date(now.getTime() - SESSION_IDLE_TTL_MS - 1)
+    await store.create(makeSession({ id: 'sess-active', userId: 'user-1' }, now))
+    await store.create(
+      makeSession(
+        {
+          id: 'sess-idle',
+          userId: 'user-1',
+          lastAccessAt: staleLastAccess,
+        },
+        now,
+      ),
+    )
+
+    const sessions = await store.listByUser('user-1', now)
+    expect(sessions.length).toBe(1)
+    expect(sessions[0]!.id).toBe('sess-active')
+  })
+
+  it('lastAccessAt がちょうど SESSION_IDLE_TTL_MS 以内なら含まれる (境界値)', async () => {
+    const now = BASE_NOW
+    const store = createInMemorySessionStore({ clock: () => now })
+
+    // lastAccessAt が now - SESSION_IDLE_TTL_MS → ちょうど境界、含まれる
+    const edgeLastAccess = new Date(now.getTime() - SESSION_IDLE_TTL_MS)
+    await store.create(
+      makeSession(
+        {
+          id: 'sess-edge',
+          userId: 'user-1',
+          lastAccessAt: edgeLastAccess,
+        },
+        now,
+      ),
+    )
+
+    const sessions = await store.listByUser('user-1', now)
+    expect(sessions.length).toBe(1)
+    expect(sessions[0]!.id).toBe('sess-edge')
+  })
+
+  it('絶対期限/idle timeout の両方を満たすセッションのみ返す', async () => {
+    const now = BASE_NOW
+    const store = createInMemorySessionStore({ clock: () => now })
+
+    // 1. 両方OK
+    await store.create(makeSession({ id: 'sess-ok', userId: 'user-1' }, now))
+    // 2. 絶対期限切れ
+    await store.create(
+      makeSession(
+        { id: 'sess-expired', userId: 'user-1', expiresAt: new Date(now.getTime() - 1) },
+        now,
+      ),
+    )
+    // 3. idle timeout 超過
+    await store.create(
+      makeSession(
+        {
+          id: 'sess-idle',
+          userId: 'user-1',
+          lastAccessAt: new Date(now.getTime() - SESSION_IDLE_TTL_MS - 1000),
+        },
+        now,
+      ),
+    )
+
+    const sessions = await store.listByUser('user-1', now)
+    expect(sessions.length).toBe(1)
+    expect(sessions[0]!.id).toBe('sess-ok')
   })
 })
 
@@ -157,6 +236,7 @@ describe('AuthService.listSessions', () => {
       sessions,
       passwordHasher: stubHasher,
       appSecret: 'test-secret',
+      clock: () => now,
     })
     return { sessions, service }
   }
@@ -203,6 +283,7 @@ describe('AuthService.revokeSession', () => {
       sessions,
       passwordHasher: stubHasher,
       appSecret: 'test-secret',
+      clock: () => now,
     })
     return { sessions, service }
   }


### PR DESCRIPTION
Closes #108

## Summary

- `SessionStore.listByUser()` が idle timeout (30 分無操作) 済みセッションを除外するよう修正
- `SessionStore.get()` の `assertSessionLive` と同じ生存判定ロジックを適用 (絶対期限切れ or idle timeout 超過のいずれかを満たすセッションは一覧から除外)
- Redis 実装では stale セッションを `user_sessions:{userId}` セットと `session:{sessionId}` キーの両方から掃除

## Changes

- `src/lib/auth/session-store.ts`
  - `SessionStore.listByUser` に `now: Date` 引数を追加 (インターフェース変更)
  - `RedisSessionStore.listByUser` / `InMemorySessionStore.listByUser` で `isSessionLive` を用いた生存判定
  - Redis 実装は stale 検出時に `srem` + `del` で掃除
  - `InMemorySessionStoreOptions.clock` は後方互換のため受け入れを維持 (参照しない)
- `src/lib/auth/auth-service.ts`
  - `listSessions` が注入済み `clock()` を用いて `now` を生成し `listByUser` に渡す
- `src/tests/auth/session-management.test.ts`
  - 既存 `listByUser` 呼び出しに `now` を追加
  - idle timeout 超過 / 境界値 / 絶対期限+idle timeout 複合検証の 3 テストを追加
- `src/tests/auth/redis-session-store.test.ts`
  - 既存 `listByUser` 呼び出しに `now` を追加
  - idle timeout + `srem` 掃除 / 絶対期限切れ / 両方検証の 3 テストを追加

## Test plan

- [x] `pnpm test src/tests/auth/session-management.test.ts` — 16/16 passed
- [x] `pnpm test src/tests/auth/` — 150/150 passed (全 13 ファイル)
- [x] `pnpm tsc --noEmit` — 変更ファイルに新規エラーなし (pre-existing なエラーのみ: `prisma/extensions/encrypted-fields.ts`, `audit-log-emitter.ts`, `access-log-repository.ts`, next-auth 関連)

## Notes

- API ルート (`src/app/api/auth/sessions/route.ts`, `[sessionId]/route.ts`) は触っていません (AuthService が `new Date()` をカプセル化)
- Issue #107 を別エージェントが並行作業中のため、`auth-service-di.ts` / `auth-service-bootstrap.ts` / `instrumentation.ts` も触っていません