### PR TITLE
fix: [Task 6.4] initAuthService bootstrap (Issue #107)

### DIFF
--- a/src/app/api/auth/sessions/[sessionId]/route.ts
+++ b/src/app/api/auth/sessions/[sessionId]/route.ts
@@ -45,8 +45,17 @@ export async function DELETE(
 
   const { sessionId } = parsed.data
 
+  // Issue #107: AuthService 未初期化は 503 Service Unavailable として扱い、
+  // instrumentation.ts の設定不備が原因であることを伝える (500 よりも安全な手掛かり)。
+  let authService: ReturnType<typeof getAuthService>
   try {
-    await getAuthService().revokeSession(userId, sessionId)
+    authService = getAuthService()
+  } catch {
+    return NextResponse.json({ error: 'Auth service not initialized' }, { status: 503 })
+  }
+
+  try {
+    await authService.revokeSession(userId, sessionId)
     return new NextResponse(null, { status: 204 })
   } catch (error: unknown) {
     if (error instanceof SessionNotFoundError) {

--- a/src/app/api/auth/sessions/route.ts
+++ b/src/app/api/auth/sessions/route.ts
@@ -35,8 +35,17 @@ export async function GET(_request: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
+  // Issue #107: AuthService 未初期化は 503 Service Unavailable として扱い、
+  // instrumentation.ts の設定不備が原因であることを伝える (500 よりも安全な手掛かり)。
+  let authService: ReturnType<typeof getAuthService>
   try {
-    const sessions = await getAuthService().listSessions(userId)
+    authService = getAuthService()
+  } catch {
+    return NextResponse.json({ error: 'Auth service not initialized' }, { status: 503 })
+  }
+
+  try {
+    const sessions = await authService.listSessions(userId)
     const response: SessionResponse[] = sessions.map((s) => ({
       ...s,
       isCurrent: s.id === currentSessionId,

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,0 +1,23 @@
+/**
+ * Issue #107 / Task 6.4: Next.js 15 instrumentation ランタイムフック
+ *
+ * Next.js 15 ではサーバー起動時に `register()` を自動実行する。
+ * ここで AuthService シングルトンを初期化しておかないと、
+ * `/api/auth/sessions` 等のルートハンドラが getAuthService() で
+ * 「AuthService is not initialized」を throw し 500 を返す (Issue #107)。
+ *
+ * - Node.js ランタイムでのみ初期化する (Edge ランタイムでは bcrypt/Redis が動かない)
+ * - 動的 import にすることで Edge ビルドに影響を出さない
+ */
+export async function register(): Promise<void> {
+  if (process.env.NEXT_RUNTIME !== 'nodejs') {
+    return
+  }
+
+  const [{ bootstrapAuthService }, { initAuthService }] = await Promise.all([
+    import('./lib/auth/auth-service-bootstrap'),
+    import('./lib/auth/auth-service-di'),
+  ])
+
+  initAuthService(bootstrapAuthService())
+}

--- a/src/lib/auth/auth-service-bootstrap.ts
+++ b/src/lib/auth/auth-service-bootstrap.ts
@@ -1,0 +1,94 @@
+/**
+ * Issue #107 / Task 6.4: AuthService ブートストラップ
+ *
+ * Next.js 15 の instrumentation.ts から呼ばれ、AuthService シングルトンを組み立てる。
+ *
+ * - REDIS_URL 設定時: Redis ベースの SessionStore
+ * - REDIS_URL 未設定時: InMemory SessionStore (開発モード / ログに警告を残す)
+ * - APP_SECRET は emailHash 算出に必須 → 未設定なら起動時に fail-fast
+ *
+ * AuthUserRepository は Prisma 版が未実装のため、暫定で InMemory 実装を返す。
+ * TODO(Prisma 移行): Task 6.x で Prisma ベースの AuthUserRepository を実装したら差し替える。
+ *
+ * 冪等性: 一度初期化したら同じインスタンスを返す。
+ * テスト用に resetAuthServiceBootstrap() を提供する。
+ */
+import { Redis } from 'ioredis'
+import { createAuthService, type AuthService } from './auth-service'
+import { createBcryptPasswordHasher } from './password-hasher'
+import {
+  createInMemorySessionStore,
+  createRedisSessionStore,
+  type SessionStore,
+} from './session-store'
+import { createInMemoryAuthUserRepository, type AuthUserRepository } from './user-repository'
+
+let _cached: AuthService | null = null
+
+/**
+ * 本番用の AuthService を組み立てる。
+ * 複数回呼ばれてもキャッシュ済みインスタンスを返す。
+ */
+export function bootstrapAuthService(): AuthService {
+  if (_cached) return _cached
+
+  const appSecret = process.env.APP_SECRET
+  if (typeof appSecret !== 'string' || appSecret.length === 0) {
+    throw new Error(
+      'APP_SECRET is not configured. Set APP_SECRET env var before starting the server.',
+    )
+  }
+
+  const sessions = buildSessionStore()
+  const users = buildUserRepository()
+  const passwordHasher = createBcryptPasswordHasher()
+
+  _cached = createAuthService({
+    users,
+    sessions,
+    passwordHasher,
+    appSecret,
+  })
+
+  return _cached
+}
+
+/**
+ * テスト用: キャッシュをクリアする。
+ * 本番コードパスから呼ぶことは想定していない。
+ */
+export function resetAuthServiceBootstrap(): void {
+  _cached = null
+}
+
+function buildSessionStore(): SessionStore {
+  const redisUrl = process.env.REDIS_URL
+  if (!redisUrl || redisUrl.trim().length === 0) {
+    // 開発 / テスト環境でのフォールバック。本番では REDIS_URL 必須とすべき。
+
+    console.warn(
+      '[auth-service-bootstrap] REDIS_URL is not configured; falling back to InMemory SessionStore. ' +
+        'This is only safe in development. Set REDIS_URL in production.',
+    )
+    return createInMemorySessionStore()
+  }
+
+  const redis = new Redis(redisUrl, {
+    // BullMQ 等と異なり、セッションストアは標準のリトライ動作で十分
+    lazyConnect: false,
+  })
+  return createRedisSessionStore({ redis })
+}
+
+function buildUserRepository(): AuthUserRepository {
+  // TODO(Prisma 移行): Task 6.x で Prisma ベースの実装に置き換える。
+  // 現状は InMemory 実装のみ。本番で API を叩くとユーザー不在で常に
+  // InvalidCredentialsError になるが、少なくとも initAuthService 未初期化による
+  // 500 エラー (Issue #107) は回避できる。
+
+  console.warn(
+    '[auth-service-bootstrap] AuthUserRepository is using InMemory fallback. ' +
+      'Replace with Prisma-backed implementation before production use.',
+  )
+  return createInMemoryAuthUserRepository()
+}

--- a/src/tests/auth/auth-service-bootstrap.test.ts
+++ b/src/tests/auth/auth-service-bootstrap.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Issue #107 / Task 6.4: AuthService ブートストラップのテスト
+ *
+ * bootstrapAuthService() は本番 (Next.js instrumentation) から呼ばれ、
+ * AuthService シングルトンを組み立てる。
+ *
+ * - REDIS_URL 未設定時は InMemory フォールバック
+ * - 複数回呼んでも冪等 (同じインスタンスを返す)
+ * - APP_SECRET が必要
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { resetAuthServiceBootstrap } from '@/lib/auth/auth-service-bootstrap'
+
+// ioredis のモック: 実 Redis に接続しないで済ませる
+vi.mock('ioredis', () => {
+  class MockRedis {
+    constructor(_url?: string, _options?: Record<string, unknown>) {}
+    // bootstrap 時点では接続しないので空でも良い
+    async quit(): Promise<'OK'> {
+      return 'OK'
+    }
+    async disconnect(): Promise<void> {
+      // noop
+    }
+  }
+  return { Redis: MockRedis, default: MockRedis }
+})
+
+const ORIGINAL_ENV = { ...process.env }
+
+describe('bootstrapAuthService', () => {
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV }
+    resetAuthServiceBootstrap()
+    // 必須の APP_SECRET は必ず設定 (crypto.ts 用)
+    process.env.APP_SECRET = 'bootstrap-test-secret-key-32chars'
+  })
+
+  afterEach(() => {
+    resetAuthServiceBootstrap()
+    process.env = { ...ORIGINAL_ENV }
+  })
+
+  it('APP_SECRET 設定済み / REDIS_URL 未設定 → AuthService を返す (InMemory フォールバック)', async () => {
+    delete process.env.REDIS_URL
+
+    const { bootstrapAuthService } = await import('@/lib/auth/auth-service-bootstrap')
+    const svc = bootstrapAuthService()
+
+    expect(svc).toBeDefined()
+    expect(typeof svc.login).toBe('function')
+    expect(typeof svc.logout).toBe('function')
+    expect(typeof svc.getSession).toBe('function')
+    expect(typeof svc.touchSession).toBe('function')
+    expect(typeof svc.listSessions).toBe('function')
+    expect(typeof svc.revokeSession).toBe('function')
+  })
+
+  it('REDIS_URL 設定済み → AuthService を返す (Redis バックエンド)', async () => {
+    process.env.REDIS_URL = 'redis://localhost:6379'
+
+    const { bootstrapAuthService } = await import('@/lib/auth/auth-service-bootstrap')
+    const svc = bootstrapAuthService()
+
+    expect(svc).toBeDefined()
+    expect(typeof svc.login).toBe('function')
+  })
+
+  it('複数回呼んでも同じインスタンスを返す (冪等)', async () => {
+    delete process.env.REDIS_URL
+
+    const { bootstrapAuthService } = await import('@/lib/auth/auth-service-bootstrap')
+    const first = bootstrapAuthService()
+    const second = bootstrapAuthService()
+
+    expect(first).toBe(second)
+  })
+
+  it('APP_SECRET 未設定なら throw する', async () => {
+    delete process.env.APP_SECRET
+
+    const { bootstrapAuthService } = await import('@/lib/auth/auth-service-bootstrap')
+
+    expect(() => bootstrapAuthService()).toThrow(/APP_SECRET/)
+  })
+
+  it('resetAuthServiceBootstrap() 後は新しいインスタンスを返す', async () => {
+    delete process.env.REDIS_URL
+
+    const { bootstrapAuthService } = await import('@/lib/auth/auth-service-bootstrap')
+    const first = bootstrapAuthService()
+    resetAuthServiceBootstrap()
+    const second = bootstrapAuthService()
+
+    expect(first).not.toBe(second)
+  })
+})


### PR DESCRIPTION
Closes #107

## Summary

Next.js 15 の `instrumentation.ts` ランタイムフックで `AuthService` を
起動時に初期化し、セッション一覧 / 失効 API が本番環境で 500 を返す問題
(Issue #107) を解消する。

## 変更点

- **`src/instrumentation.ts`** (新規): `register()` で
  `bootstrapAuthService()` → `initAuthService()` を呼ぶ。
  `NEXT_RUNTIME === 'nodejs'` のみで実行し、Edge ランタイムには干渉しない。
- **`src/lib/auth/auth-service-bootstrap.ts`** (新規): 環境変数から本番
  DI を組み立てるファクトリ。
  - `APP_SECRET` 必須 (未設定なら fail-fast)
  - `REDIS_URL` 設定時は Redis セッションストア、未設定時は InMemory に
    フォールバックして警告ログ
  - `AuthUserRepository` は Prisma 版が未実装のため暫定 InMemory (TODO コメント付き)
  - 冪等性: キャッシュ済みインスタンスを返却。テスト用に
    `resetAuthServiceBootstrap()` を export
- **`src/app/api/auth/sessions/route.ts` / `[sessionId]/route.ts`**:
  `getAuthService()` が throw した場合は 500 ではなく 503 Service Unavailable
  を返す安全網を追加 (安全側にフォールバック)
- **`src/tests/auth/auth-service-bootstrap.test.ts`** (新規): 5 件
  - InMemory / Redis 両パスで AuthService を返すこと
  - 冪等性
  - `APP_SECRET` 未設定で throw
  - `resetAuthServiceBootstrap()` 後は新しいインスタンス

## Test Plan

- [x] `pnpm test src/tests/auth/` — 14 files / 149 tests 全てパス
- [x] `pnpm test` — 71 files / 799 tests 全てパス (既存のテストにリグレッションなし)
- [x] `pnpm tsc --noEmit` — 本 PR で新規のエラーは追加されない
  (既存の `audit-log-emitter.ts` / `next-auth` 関連エラーは Issue #107 の
  対象外)
- [ ] 手動: 本番環境 (または本番相当 env) で `/api/auth/sessions` を叩き、
  200 / 401 が返ることを確認
- [ ] Prisma 版 `AuthUserRepository` 実装後に TODO を解消 (別タスク)

## Notes

- `pnpm build` は本リポジトリの main ブランチ時点で既に失敗していた
  (`getServerSession` が `next-auth` v5 beta から export されていない問題)。
  本 PR ではビルド経路そのものには触れていない。
- `next.config.ts` には触れていない。Next.js 15 では instrumentation hook が
  デフォルトで有効なため追加設定は不要。