### PR TITLE
feat: [Task 6.5] ユーザー招待・パスワード設定フロー (Issue #23)

### DIFF
--- a/src/app/api/auth/invitations/[token]/route.ts
+++ b/src/app/api/auth/invitations/[token]/route.ts
@@ -1,0 +1,73 @@
+/**
+ * Task 6.5 / Req 1.10: 招待承認・初回パスワード設定 API
+ *
+ * POST /api/auth/invitations/[token]
+ * - 認証不要 (公開エンドポイント)
+ * - 招待トークンとパスワードを受け取り、アカウントを有効化する
+ */
+import { type NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+import {
+  InvitationNotFoundError,
+  InvitationExpiredError,
+  InvitationAlreadyUsedError,
+} from '@/lib/auth/invitation-types'
+import { PasswordPolicyViolationError } from '@/lib/auth/auth-types'
+import { getInvitationService } from '@/lib/auth/invitation-service-di'
+
+export {
+  setInvitationServiceForTesting,
+  clearInvitationServiceForTesting,
+} from '@/lib/auth/invitation-service-di'
+
+const acceptBodySchema = z.object({
+  password: z.string().min(1),
+})
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ token: string }> },
+): Promise<NextResponse> {
+  const { token } = await params
+
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
+  }
+
+  const parsed = acceptBodySchema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.flatten() }, { status: 422 })
+  }
+
+  let svc: ReturnType<typeof getInvitationService>
+  try {
+    svc = getInvitationService()
+  } catch {
+    return NextResponse.json({ error: 'Invitation service not initialized' }, { status: 503 })
+  }
+
+  try {
+    await svc.acceptInvitation(token, parsed.data.password)
+    return NextResponse.json({ success: true })
+  } catch (err) {
+    if (err instanceof InvitationNotFoundError) {
+      return NextResponse.json({ error: 'Invitation not found' }, { status: 404 })
+    }
+    if (err instanceof InvitationExpiredError) {
+      return NextResponse.json({ error: 'Invitation has expired' }, { status: 410 })
+    }
+    if (err instanceof InvitationAlreadyUsedError) {
+      return NextResponse.json({ error: 'Invitation already used' }, { status: 409 })
+    }
+    if (err instanceof PasswordPolicyViolationError) {
+      return NextResponse.json(
+        { error: 'Password policy violation', rule: err.rule },
+        { status: 422 },
+      )
+    }
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -1,0 +1,60 @@
+/**
+ * Task 6.5 / Req 1.10: ユーザー招待 API
+ *
+ * POST /api/users
+ * - ADMIN のみ実行可能
+ * - email / role を受け取り招待メールを送信する
+ */
+import { getServerSession } from 'next-auth'
+import { type NextRequest, NextResponse } from 'next/server'
+import { inviteUserInputSchema, EmailAlreadyExistsError } from '@/lib/auth/invitation-types'
+import { getInvitationService } from '@/lib/auth/invitation-service-di'
+
+export {
+  setInvitationServiceForTesting,
+  clearInvitationServiceForTesting,
+} from '@/lib/auth/invitation-service-di'
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const serverSession = await getServerSession()
+  if (!serverSession?.user?.email) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const sess = serverSession as Record<string, unknown>
+  const role = typeof sess.role === 'string' ? sess.role : undefined
+  const userId = typeof sess.userId === 'string' ? sess.userId : undefined
+
+  if (role !== 'ADMIN' || !userId) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
+  }
+
+  const parsed = inviteUserInputSchema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.flatten() }, { status: 422 })
+  }
+
+  let svc: ReturnType<typeof getInvitationService>
+  try {
+    svc = getInvitationService()
+  } catch {
+    return NextResponse.json({ error: 'Invitation service not initialized' }, { status: 503 })
+  }
+
+  try {
+    await svc.inviteUser(parsed.data, userId)
+    return NextResponse.json({ success: true }, { status: 201 })
+  } catch (err) {
+    if (err instanceof EmailAlreadyExistsError) {
+      return NextResponse.json({ error: 'Email already exists' }, { status: 409 })
+    }
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/lib/auth/invitation-service-di.ts
+++ b/src/lib/auth/invitation-service-di.ts
@@ -1,0 +1,28 @@
+/**
+ * Task 6.5: InvitationService のシングルトン DI モジュール。
+ * auth-service-di.ts と同パターン。
+ */
+import type { InvitationService } from './invitation-service'
+
+let _invitationService: InvitationService | null = null
+
+export function setInvitationServiceForTesting(svc: InvitationService): void {
+  _invitationService = svc
+}
+
+export function clearInvitationServiceForTesting(): void {
+  _invitationService = null
+}
+
+export function getInvitationService(): InvitationService {
+  if (_invitationService) return _invitationService
+  throw new Error(
+    'InvitationService is not initialized. ' +
+      'テストでは setInvitationServiceForTesting() を呼んでください。' +
+      'プロダクションではサーバー起動前に initInvitationService() を呼んでください。',
+  )
+}
+
+export function initInvitationService(svc: InvitationService): void {
+  _invitationService = svc
+}

--- a/src/lib/auth/invitation-service.ts
+++ b/src/lib/auth/invitation-service.ts
@@ -1,0 +1,186 @@
+/**
+ * Task 6.5 / Req 1.10: ユーザー招待サービス
+ *
+ * - inviteUser: ADMIN が新規ユーザーを招待し、招待メールを送信する
+ * - acceptInvitation: 招待トークンを使って初回パスワードを設定し、アカウントを有効化する
+ *
+ * Prisma 実装への差し替えは後続タスクで行う。
+ */
+import { randomUUID } from 'node:crypto'
+import { computeEmailHash } from '@/lib/shared/crypto'
+import { assertPasswordStrong } from './password-policy'
+import type { PasswordHasher } from './password-hasher'
+import type { InvitationTokenRepository } from './invitation-token-repository'
+import type { WritableAuthUserRepository } from './user-repository'
+import {
+  INVITATION_TTL_MS,
+  EmailAlreadyExistsError,
+  InvitationAlreadyUsedError,
+  InvitationExpiredError,
+  InvitationNotFoundError,
+  type InviteUserInput,
+} from './invitation-types'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Ports
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * 招待メール送信の narrow port。
+ * 実際のメール送信実装（Resend / SendGrid 等）は後続タスクで差し替える。
+ */
+export interface InvitationEmailSender {
+  sendInvitationEmail(params: {
+    readonly to: string
+    readonly token: string
+    readonly role: string
+  }): Promise<void>
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Service interface
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface InvitationService {
+  /**
+   * ADMIN が新規ユーザーを招待する (Req 1.10)。
+   * - PENDING_JOIN ユーザーを作成し、招待トークンを生成してメールを送信する。
+   * - 同一メールが既に存在する場合は EmailAlreadyExistsError。
+   */
+  inviteUser(input: InviteUserInput, invitedByUserId: string): Promise<void>
+
+  /**
+   * 招待トークンを使って初回パスワードを設定し、アカウントを有効化する (Req 1.10)。
+   * - トークン未存在: InvitationNotFoundError
+   * - 有効期限切れ: InvitationExpiredError
+   * - 使用済み: InvitationAlreadyUsedError
+   * - パスワードポリシー違反: PasswordPolicyViolationError
+   */
+  acceptInvitation(token: string, password: string, now?: Date): Promise<void>
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Dependencies
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface InvitationServiceDeps {
+  readonly tokens: InvitationTokenRepository
+  readonly users: WritableAuthUserRepository
+  readonly passwordHasher: PasswordHasher
+  readonly emailSender: InvitationEmailSender
+  readonly appSecret: string
+  readonly userIdFactory?: () => string
+  readonly tokenFactory?: () => string
+  readonly clock?: () => Date
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Implementation
+// ─────────────────────────────────────────────────────────────────────────────
+
+function defaultClock(): Date {
+  return new Date()
+}
+
+class InvitationServiceImpl implements InvitationService {
+  private readonly tokens: InvitationTokenRepository
+  private readonly users: WritableAuthUserRepository
+  private readonly passwordHasher: PasswordHasher
+  private readonly emailSender: InvitationEmailSender
+  private readonly appSecret: string
+  private readonly userIdFactory: () => string
+  private readonly tokenFactory: () => string
+  private readonly clock: () => Date
+
+  constructor(deps: InvitationServiceDeps) {
+    this.tokens = deps.tokens
+    this.users = deps.users
+    this.passwordHasher = deps.passwordHasher
+    this.emailSender = deps.emailSender
+    this.appSecret = deps.appSecret
+    this.userIdFactory = deps.userIdFactory ?? randomUUID
+    this.tokenFactory = deps.tokenFactory ?? randomUUID
+    this.clock = deps.clock ?? defaultClock
+  }
+
+  async inviteUser(input: InviteUserInput, invitedByUserId: string): Promise<void> {
+    const emailHash = await computeEmailHash(input.email, this.appSecret)
+
+    // 既存ユーザーとの重複チェック
+    const existing = await this.users.findByEmailHash(emailHash)
+    if (existing) {
+      throw new EmailAlreadyExistsError()
+    }
+
+    const now = this.clock()
+    const userId = this.userIdFactory()
+    const token = this.tokenFactory()
+
+    // PENDING_JOIN ステータスで仮ユーザーを作成
+    await this.users.createUser({
+      id: userId,
+      email: input.email,
+      emailHash,
+      passwordHash: '',
+      role: input.role,
+      status: 'PENDING_JOIN',
+    })
+
+    // 招待トークンを生成・保存
+    await this.tokens.create({
+      token,
+      email: input.email,
+      emailHash,
+      role: input.role,
+      invitedByUserId,
+      createdAt: now,
+      expiresAt: new Date(now.getTime() + INVITATION_TTL_MS),
+      usedAt: null,
+    })
+
+    // 招待メールを送信
+    await this.emailSender.sendInvitationEmail({
+      to: input.email,
+      token,
+      role: input.role,
+    })
+  }
+
+  async acceptInvitation(token: string, password: string, now?: Date): Promise<void> {
+    const record = await this.tokens.findByToken(token)
+    if (!record) {
+      throw new InvitationNotFoundError(token)
+    }
+
+    if (record.usedAt !== null) {
+      throw new InvitationAlreadyUsedError()
+    }
+
+    const currentTime = now ?? this.clock()
+    if (currentTime > record.expiresAt) {
+      throw new InvitationExpiredError()
+    }
+
+    // パスワードポリシー検証 (LENGTH, COMPLEXITY)
+    assertPasswordStrong(password)
+
+    // 対象ユーザーを emailHash で取得して userId を確定する
+    const user = await this.users.findByEmailHash(record.emailHash)
+    if (!user) {
+      throw new InvitationNotFoundError(token)
+    }
+
+    const newHash = await this.passwordHasher.hash(password)
+
+    // パスワードをセットしてアカウントを有効化
+    await this.users.updatePasswordHash(user.id, newHash)
+    await this.users.updateStatus(user.id, 'ACTIVE')
+
+    // トークンを使用済みにマーク
+    await this.tokens.markUsed(token, currentTime)
+  }
+}
+
+export function createInvitationService(deps: InvitationServiceDeps): InvitationService {
+  return new InvitationServiceImpl(deps)
+}

--- a/src/lib/auth/invitation-token-repository.ts
+++ b/src/lib/auth/invitation-token-repository.ts
@@ -1,0 +1,49 @@
+/**
+ * Task 6.5 / Req 1.10: 招待トークンリポジトリ
+ *
+ * - InvitationTokenRepository: create / findByToken / markUsed の narrow port
+ * - InMemoryInvitationTokenRepository: テスト / ローカル開発用の実装
+ *   Prisma 実装は後続タスクで追加する。
+ */
+import type { InvitationToken } from './invitation-types'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Port
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface InvitationTokenRepository {
+  create(record: InvitationToken): Promise<void>
+  findByToken(token: string): Promise<InvitationToken | null>
+  markUsed(token: string, usedAt: Date): Promise<void>
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// InMemory implementation
+// ─────────────────────────────────────────────────────────────────────────────
+
+function clone(record: InvitationToken): InvitationToken {
+  return { ...record }
+}
+
+class InMemoryInvitationTokenRepository implements InvitationTokenRepository {
+  private readonly store = new Map<string, InvitationToken>()
+
+  async create(record: InvitationToken): Promise<void> {
+    this.store.set(record.token, clone(record))
+  }
+
+  async findByToken(token: string): Promise<InvitationToken | null> {
+    const found = this.store.get(token)
+    return found ? clone(found) : null
+  }
+
+  async markUsed(token: string, usedAt: Date): Promise<void> {
+    const existing = this.store.get(token)
+    if (!existing) return
+    this.store.set(token, { ...existing, usedAt })
+  }
+}
+
+export function createInMemoryInvitationTokenRepository(): InvitationTokenRepository {
+  return new InMemoryInvitationTokenRepository()
+}

--- a/src/lib/auth/invitation-types.ts
+++ b/src/lib/auth/invitation-types.ts
@@ -1,0 +1,95 @@
+/**
+ * Task 6.5 / Req 1.10: ユーザー招待・パスワード設定フロー
+ *
+ * - InvitationToken: 招待トークンレコード (72 時間有効)
+ * - inviteUserInputSchema: ADMIN がユーザーを招待する入力
+ * - acceptInvitationInputSchema: 招待を承認して初回パスワードを設定する入力
+ * - ドメイン例外: InvitationNotFoundError, InvitationExpiredError, InvitationAlreadyUsedError
+ */
+import { z } from 'zod'
+import { USER_ROLES, type UserRole } from '@/lib/notification/notification-types'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Constants
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** 招待トークンの有効期限: 72 時間 */
+export const INVITATION_TTL_MS = 72 * 60 * 60 * 1000
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Domain types
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * 招待トークンレコード。
+ * ADMIN がユーザーを招待した際に生成し、ストアに保存する。
+ */
+export interface InvitationToken {
+  /** UUID (招待メール URL のパスパラメータ) */
+  readonly token: string
+  readonly email: string
+  readonly emailHash: string
+  readonly role: UserRole
+  readonly invitedByUserId: string
+  readonly createdAt: Date
+  /** createdAt + INVITATION_TTL_MS */
+  readonly expiresAt: Date
+  /** 使用済み日時 (null = 未使用) */
+  readonly usedAt: Date | null
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Schemas
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** ADMIN がユーザーを招待する入力 */
+export const inviteUserInputSchema = z.object({
+  email: z.string().email(),
+  role: z.enum(USER_ROLES),
+})
+
+export type InviteUserInput = z.infer<typeof inviteUserInputSchema>
+
+/** 招待を承認して初回パスワードを設定する入力 */
+export const acceptInvitationInputSchema = z.object({
+  token: z.string().min(1),
+  password: z.string().min(1),
+})
+
+export type AcceptInvitationInput = z.infer<typeof acceptInvitationInputSchema>
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Domain exceptions
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** 招待トークンが存在しない */
+export class InvitationNotFoundError extends Error {
+  constructor(token: string) {
+    super(`Invitation not found: ${token}`)
+    this.name = 'InvitationNotFoundError'
+  }
+}
+
+/** 招待トークンの有効期限切れ */
+export class InvitationExpiredError extends Error {
+  constructor() {
+    super('Invitation has expired')
+    this.name = 'InvitationExpiredError'
+  }
+}
+
+/** 招待トークンが既に使用済み */
+export class InvitationAlreadyUsedError extends Error {
+  constructor() {
+    super('Invitation has already been used')
+    this.name = 'InvitationAlreadyUsedError'
+  }
+}
+
+/** 招待対象のメールアドレスが既にアクティブなユーザーとして存在する */
+export class EmailAlreadyExistsError extends Error {
+  constructor() {
+    super('Email already exists')
+    this.name = 'EmailAlreadyExistsError'
+  }
+}

--- a/src/lib/auth/user-repository.ts
+++ b/src/lib/auth/user-repository.ts
@@ -1,5 +1,6 @@
 /**
  * Task 6.1: 認証ユースケースが必要とする最小限のユーザー取得ポート。
+ * Task 6.5: 招待フロー用に WritableAuthUserRepository を追加。
  *
  * Prisma 実装は Task 6.x 以降で追加する。本タスクでは InMemory 実装のみを提供し、
  * 業務ロジック層は narrow なインターフェースに依存する。
@@ -40,6 +41,16 @@ export interface AuthUserRepository {
   findById(id: string): Promise<AuthUserRecord | null>
 }
 
+/**
+ * Task 6.5: 招待フローで新規ユーザーを作成するための書き込みポート。
+ * 招待サービスのみがこのインターフェースに依存する。
+ */
+export interface WritableAuthUserRepository extends AuthUserRepository {
+  createUser(record: AuthUserRecord): Promise<void>
+  updatePasswordHash(userId: string, newHash: string): Promise<void>
+  updateStatus(userId: string, status: AuthUserStatus): Promise<void>
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // InMemory implementation (tests / local dev)
 // ─────────────────────────────────────────────────────────────────────────────
@@ -48,7 +59,7 @@ function cloneRecord(record: AuthUserRecord): AuthUserRecord {
   return { ...record }
 }
 
-class InMemoryAuthUserRepository implements AuthUserRepository {
+class InMemoryAuthUserRepository implements WritableAuthUserRepository {
   private readonly byEmailHash: Map<string, AuthUserRecord>
   private readonly byId: Map<string, AuthUserRecord>
 
@@ -73,10 +84,32 @@ class InMemoryAuthUserRepository implements AuthUserRepository {
     const found = this.byId.get(id)
     return found ? cloneRecord(found) : null
   }
+
+  async createUser(record: AuthUserRecord): Promise<void> {
+    const copy = cloneRecord(record)
+    this.byEmailHash.set(copy.emailHash, copy)
+    this.byId.set(copy.id, copy)
+  }
+
+  async updatePasswordHash(userId: string, newHash: string): Promise<void> {
+    const existing = this.byId.get(userId)
+    if (!existing) return
+    const updated: AuthUserRecord = { ...existing, passwordHash: newHash }
+    this.byEmailHash.set(updated.emailHash, updated)
+    this.byId.set(userId, updated)
+  }
+
+  async updateStatus(userId: string, status: AuthUserStatus): Promise<void> {
+    const existing = this.byId.get(userId)
+    if (!existing) return
+    const updated: AuthUserRecord = { ...existing, status }
+    this.byEmailHash.set(updated.emailHash, updated)
+    this.byId.set(userId, updated)
+  }
 }
 
 export function createInMemoryAuthUserRepository(
   seed?: readonly AuthUserRecord[],
-): AuthUserRepository {
+): WritableAuthUserRepository {
   return new InMemoryAuthUserRepository(seed)
 }

--- a/src/tests/auth/invitation-accept-route.test.ts
+++ b/src/tests/auth/invitation-accept-route.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Task 6.5 / Req 1.10: POST /api/auth/invitations/[token] ルートハンドラのテスト
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import {
+  InvitationNotFoundError,
+  InvitationExpiredError,
+  InvitationAlreadyUsedError,
+} from '@/lib/auth/invitation-types'
+import { PasswordPolicyViolationError } from '@/lib/auth/auth-types'
+import {
+  setInvitationServiceForTesting,
+  clearInvitationServiceForTesting,
+} from '@/lib/auth/invitation-service-di'
+import type { InvitationService } from '@/lib/auth/invitation-service'
+
+const { POST } = await import('@/app/api/auth/invitations/[token]/route')
+
+function makeRequest(token: string, body: unknown): NextRequest {
+  return new NextRequest(`http://localhost/api/auth/invitations/${token}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+function makeParams(token: string) {
+  return { params: Promise.resolve({ token }) }
+}
+
+function makeInvitationService(overrides?: Partial<InvitationService>): InvitationService {
+  return {
+    inviteUser: vi.fn().mockResolvedValue(undefined),
+    acceptInvitation: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  } as unknown as InvitationService
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+afterEach(() => {
+  clearInvitationServiceForTesting()
+})
+
+describe('POST /api/auth/invitations/[token]', () => {
+  it('正常承認で 200 を返す', async () => {
+    setInvitationServiceForTesting(makeInvitationService())
+    const res = await POST(
+      makeRequest('valid-token', { password: 'ValidPass1!extra' }),
+      makeParams('valid-token'),
+    )
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.success).toBe(true)
+  })
+
+  it('パスワードなしは 422', async () => {
+    setInvitationServiceForTesting(makeInvitationService())
+    const res = await POST(makeRequest('valid-token', {}), makeParams('valid-token'))
+    expect(res.status).toBe(422)
+  })
+
+  it('存在しないトークンは 404', async () => {
+    setInvitationServiceForTesting(
+      makeInvitationService({
+        acceptInvitation: vi.fn().mockRejectedValue(new InvitationNotFoundError('bad-token')),
+      }),
+    )
+    const res = await POST(
+      makeRequest('bad-token', { password: 'ValidPass1!extra' }),
+      makeParams('bad-token'),
+    )
+    expect(res.status).toBe(404)
+  })
+
+  it('期限切れトークンは 410', async () => {
+    setInvitationServiceForTesting(
+      makeInvitationService({
+        acceptInvitation: vi.fn().mockRejectedValue(new InvitationExpiredError()),
+      }),
+    )
+    const res = await POST(
+      makeRequest('expired-token', { password: 'ValidPass1!extra' }),
+      makeParams('expired-token'),
+    )
+    expect(res.status).toBe(410)
+  })
+
+  it('使用済みトークンは 409', async () => {
+    setInvitationServiceForTesting(
+      makeInvitationService({
+        acceptInvitation: vi.fn().mockRejectedValue(new InvitationAlreadyUsedError()),
+      }),
+    )
+    const res = await POST(
+      makeRequest('used-token', { password: 'ValidPass1!extra' }),
+      makeParams('used-token'),
+    )
+    expect(res.status).toBe(409)
+  })
+
+  it('パスワードポリシー違反は 422', async () => {
+    setInvitationServiceForTesting(
+      makeInvitationService({
+        acceptInvitation: vi.fn().mockRejectedValue(new PasswordPolicyViolationError('LENGTH')),
+      }),
+    )
+    const res = await POST(
+      makeRequest('valid-token', { password: 'short' }),
+      makeParams('valid-token'),
+    )
+    expect(res.status).toBe(422)
+    const body = await res.json()
+    expect(body.rule).toBe('LENGTH')
+  })
+
+  it('サービス未初期化は 503', async () => {
+    // サービス未設定のまま
+    const res = await POST(
+      makeRequest('valid-token', { password: 'ValidPass1!extra' }),
+      makeParams('valid-token'),
+    )
+    expect(res.status).toBe(503)
+  })
+})

--- a/src/tests/auth/invitation-service.test.ts
+++ b/src/tests/auth/invitation-service.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Task 6.5 / Req 1.10: InvitationService の単体テスト
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { createInvitationService } from '@/lib/auth/invitation-service'
+import { createInMemoryInvitationTokenRepository } from '@/lib/auth/invitation-token-repository'
+import { createInMemoryAuthUserRepository } from '@/lib/auth/user-repository'
+import {
+  EmailAlreadyExistsError,
+  InvitationAlreadyUsedError,
+  InvitationExpiredError,
+  InvitationNotFoundError,
+  INVITATION_TTL_MS,
+} from '@/lib/auth/invitation-types'
+import { PasswordPolicyViolationError } from '@/lib/auth/auth-types'
+import type { PasswordHasher } from '@/lib/auth/password-hasher'
+import type { InvitationEmailSender } from '@/lib/auth/invitation-service'
+
+const APP_SECRET = 'test-secret-32-chars-long-enough!!'
+
+function makeHasher(overrides?: Partial<PasswordHasher>): PasswordHasher {
+  return {
+    hash: vi.fn().mockResolvedValue('$2b$12$hashed'),
+    verify: vi.fn().mockResolvedValue(false),
+    ...overrides,
+  }
+}
+
+function makeEmailSender(): InvitationEmailSender {
+  return { sendInvitationEmail: vi.fn().mockResolvedValue(undefined) }
+}
+
+const NOW = new Date('2026-04-18T10:00:00.000Z')
+
+function makeService({
+  tokenId = 'token-uuid',
+  userId = 'user-uuid',
+  clock = () => NOW,
+  emailSender = makeEmailSender(),
+  hasher = makeHasher(),
+} = {}) {
+  const tokens = createInMemoryInvitationTokenRepository()
+  const users = createInMemoryAuthUserRepository()
+  const svc = createInvitationService({
+    tokens,
+    users,
+    passwordHasher: hasher,
+    emailSender,
+    appSecret: APP_SECRET,
+    userIdFactory: () => userId,
+    tokenFactory: () => tokenId,
+    clock,
+  })
+  return { svc, tokens, users, emailSender, hasher }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// inviteUser
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('InvitationService.inviteUser', () => {
+  it('新規ユーザーの招待が成功する', async () => {
+    const { svc, tokens, users, emailSender } = makeService()
+
+    await svc.inviteUser({ email: 'alice@example.com', role: 'EMPLOYEE' }, 'admin-1')
+
+    // PENDING_JOIN ユーザーが作成されている
+    const user = await users.findById('user-uuid')
+    expect(user?.status).toBe('PENDING_JOIN')
+    expect(user?.role).toBe('EMPLOYEE')
+
+    // トークンが作成されている
+    const token = await tokens.findByToken('token-uuid')
+    expect(token).not.toBeNull()
+    expect(token?.email).toBe('alice@example.com')
+    expect(token?.usedAt).toBeNull()
+
+    // 招待メールが送信されている
+    expect(emailSender.sendInvitationEmail).toHaveBeenCalledWith(
+      expect.objectContaining({ to: 'alice@example.com', token: 'token-uuid' }),
+    )
+  })
+
+  it('招待トークンの expiresAt は 72 時間後', async () => {
+    const { svc, tokens } = makeService()
+    await svc.inviteUser({ email: 'bob@example.com', role: 'MANAGER' }, 'admin-1')
+
+    const token = await tokens.findByToken('token-uuid')
+    expect(token?.expiresAt.getTime()).toBe(NOW.getTime() + INVITATION_TTL_MS)
+  })
+
+  it('同じメールアドレスが既存の場合は EmailAlreadyExistsError', async () => {
+    const { svc } = makeService()
+    await svc.inviteUser({ email: 'alice@example.com', role: 'EMPLOYEE' }, 'admin-1')
+
+    await expect(
+      svc.inviteUser({ email: 'alice@example.com', role: 'HR_MANAGER' }, 'admin-1'),
+    ).rejects.toBeInstanceOf(EmailAlreadyExistsError)
+  })
+
+  it('invitedByUserId がトークンに保存される', async () => {
+    const { svc, tokens } = makeService()
+    await svc.inviteUser({ email: 'carol@example.com', role: 'ADMIN' }, 'admin-99')
+
+    const token = await tokens.findByToken('token-uuid')
+    expect(token?.invitedByUserId).toBe('admin-99')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// acceptInvitation
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('InvitationService.acceptInvitation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  async function setupInvited() {
+    const ctx = makeService()
+    await ctx.svc.inviteUser({ email: 'alice@example.com', role: 'EMPLOYEE' }, 'admin-1')
+    return ctx
+  }
+
+  it('有効なトークンでパスワードを設定するとアカウントが ACTIVE になる', async () => {
+    const { svc, users } = await setupInvited()
+
+    await svc.acceptInvitation('token-uuid', 'ValidPass1!extra', NOW)
+
+    const user = await users.findById('user-uuid')
+    expect(user?.status).toBe('ACTIVE')
+    expect(user?.passwordHash).toBe('$2b$12$hashed')
+  })
+
+  it('acceptInvitation 後にトークンが使用済みになる', async () => {
+    const { svc, tokens } = await setupInvited()
+    await svc.acceptInvitation('token-uuid', 'ValidPass1!extra', NOW)
+
+    const token = await tokens.findByToken('token-uuid')
+    expect(token?.usedAt).toEqual(NOW)
+  })
+
+  it('存在しないトークンは InvitationNotFoundError', async () => {
+    const { svc } = makeService()
+    await expect(
+      svc.acceptInvitation('no-such-token', 'ValidPass1!extra', NOW),
+    ).rejects.toBeInstanceOf(InvitationNotFoundError)
+  })
+
+  it('有効期限切れのトークンは InvitationExpiredError', async () => {
+    const { svc } = await setupInvited()
+    const afterExpiry = new Date(NOW.getTime() + INVITATION_TTL_MS + 1)
+
+    await expect(
+      svc.acceptInvitation('token-uuid', 'ValidPass1!extra', afterExpiry),
+    ).rejects.toBeInstanceOf(InvitationExpiredError)
+  })
+
+  it('使用済みトークンは InvitationAlreadyUsedError', async () => {
+    const { svc } = await setupInvited()
+    await svc.acceptInvitation('token-uuid', 'ValidPass1!extra', NOW)
+
+    await expect(
+      svc.acceptInvitation('token-uuid', 'AnotherPass2!extra', NOW),
+    ).rejects.toBeInstanceOf(InvitationAlreadyUsedError)
+  })
+
+  it('パスワードが短い場合は PasswordPolicyViolationError (LENGTH)', async () => {
+    const { svc } = await setupInvited()
+    await expect(svc.acceptInvitation('token-uuid', 'Short1!', NOW)).rejects.toBeInstanceOf(
+      PasswordPolicyViolationError,
+    )
+  })
+
+  it('パスワードが複雑性要件を満たさない場合は PasswordPolicyViolationError (COMPLEXITY)', async () => {
+    const { svc } = await setupInvited()
+    await expect(
+      svc.acceptInvitation('token-uuid', 'alllowercaseonly123', NOW),
+    ).rejects.toBeInstanceOf(PasswordPolicyViolationError)
+  })
+})

--- a/src/tests/auth/users-route.test.ts
+++ b/src/tests/auth/users-route.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Task 6.5 / Req 1.10: POST /api/users ルートハンドラのテスト
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import { EmailAlreadyExistsError } from '@/lib/auth/invitation-types'
+import {
+  setInvitationServiceForTesting,
+  clearInvitationServiceForTesting,
+} from '@/lib/auth/invitation-service-di'
+import type { InvitationService } from '@/lib/auth/invitation-service'
+
+vi.mock('next-auth', () => ({
+  getServerSession: vi.fn(),
+}))
+
+const { getServerSession } = await import('next-auth')
+const mockedGetServerSession = vi.mocked(getServerSession)
+
+const { POST } = await import('@/app/api/users/route')
+
+function makeRequest(body: unknown): NextRequest {
+  return new NextRequest('http://localhost/api/users', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+function makeAdminSession(userId = 'admin-1') {
+  return { user: { email: 'admin@example.com' }, role: 'ADMIN', userId }
+}
+
+function makeInvitationService(overrides?: Partial<InvitationService>): InvitationService {
+  return {
+    inviteUser: vi.fn().mockResolvedValue(undefined),
+    acceptInvitation: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  } as unknown as InvitationService
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+afterEach(() => {
+  clearInvitationServiceForTesting()
+})
+
+describe('POST /api/users', () => {
+  it('未認証は 401', async () => {
+    mockedGetServerSession.mockResolvedValue(null)
+    const res = await POST(makeRequest({ email: 'u@example.com', role: 'EMPLOYEE' }))
+    expect(res.status).toBe(401)
+  })
+
+  it('ADMIN 以外のロールは 403', async () => {
+    mockedGetServerSession.mockResolvedValue({
+      user: { email: 'hr@example.com' },
+      role: 'HR_MANAGER',
+      userId: 'hr-1',
+    })
+    setInvitationServiceForTesting(makeInvitationService())
+    const res = await POST(makeRequest({ email: 'u@example.com', role: 'EMPLOYEE' }))
+    expect(res.status).toBe(403)
+  })
+
+  it('入力バリデーション失敗は 422', async () => {
+    mockedGetServerSession.mockResolvedValue(makeAdminSession())
+    setInvitationServiceForTesting(makeInvitationService())
+    const res = await POST(makeRequest({ email: 'not-an-email', role: 'EMPLOYEE' }))
+    expect(res.status).toBe(422)
+  })
+
+  it('正常招待で 201 を返す', async () => {
+    mockedGetServerSession.mockResolvedValue(makeAdminSession())
+    setInvitationServiceForTesting(makeInvitationService())
+    const res = await POST(makeRequest({ email: 'new@example.com', role: 'EMPLOYEE' }))
+    expect(res.status).toBe(201)
+    const body = await res.json()
+    expect(body.success).toBe(true)
+  })
+
+  it('メール重複は 409', async () => {
+    mockedGetServerSession.mockResolvedValue(makeAdminSession())
+    setInvitationServiceForTesting(
+      makeInvitationService({
+        inviteUser: vi.fn().mockRejectedValue(new EmailAlreadyExistsError()),
+      }),
+    )
+    const res = await POST(makeRequest({ email: 'exists@example.com', role: 'EMPLOYEE' }))
+    expect(res.status).toBe(409)
+  })
+
+  it('サービス未初期化は 503', async () => {
+    mockedGetServerSession.mockResolvedValue(makeAdminSession())
+    // サービス未設定のまま
+    const res = await POST(makeRequest({ email: 'new@example.com', role: 'EMPLOYEE' }))
+    expect(res.status).toBe(503)
+  })
+})


### PR DESCRIPTION
## Summary

- `invitation-types.ts`: `InvitationToken` 型・Zod スキーマ・ドメイン例外（`InvitationNotFoundError`, `InvitationExpiredError`, `InvitationAlreadyUsedError`, `EmailAlreadyExistsError`）を定義
- `invitation-token-repository.ts`: `InvitationTokenRepository` port + InMemory 実装（create / findByToken / markUsed）
- `user-repository.ts`: `WritableAuthUserRepository` を追加（`createUser` / `updatePasswordHash` / `updateStatus`）
- `invitation-service.ts`: `inviteUser`（PENDING_JOIN ユーザー作成 + トークン生成 + メール送信）/ `acceptInvitation`（パスワード設定 + ACTIVE 化）
- `invitation-service-di.ts`: `auth-service-di.ts` と同パターンのシングルトン DI モジュール
- `POST /api/users`: ADMIN のみ招待可能、メール重複時 409、バリデーション失敗時 422
- `POST /api/auth/invitations/[token]`: 認証不要の公開エンドポイント、各ドメイン例外を適切な HTTP ステータスにマッピング

## Test plan

- [x] `invitation-service.test.ts`: inviteUser (4件) / acceptInvitation (7件) = 11件
- [x] `users-route.test.ts`: 認証・認可・バリデーション・正常系・エラー = 6件
- [x] `invitation-accept-route.test.ts`: 正常系・各エラーケース = 7件
- [x] 既存テスト 155件 リグレッションなし（全179件通過）

Closes #23