### PR TITLE
feat: [Task 7.1] スキル・役職・等級マスタの CRUD を実装 (Issue #24)

### DIFF
--- a/prisma/migrations/master-data.sql
+++ b/prisma/migrations/master-data.sql
@@ -1,0 +1,46 @@
+-- マスタ管理テーブル (Requirement 2)
+-- Issue #24: スキル・役職・等級マスタの CRUD
+
+-- スキルマスタ (Requirement 2.1, 2.4)
+CREATE TABLE IF NOT EXISTS skill_masters (
+  id          TEXT      NOT NULL PRIMARY KEY,
+  name        TEXT      NOT NULL UNIQUE,
+  category    TEXT      NOT NULL,
+  description TEXT,
+  deprecated  BOOLEAN   NOT NULL DEFAULT FALSE,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS skill_masters_category_idx ON skill_masters (category);
+
+-- 役職マスタ (Requirement 2.2)
+CREATE TABLE IF NOT EXISTS role_masters (
+  id        TEXT NOT NULL PRIMARY KEY,
+  name      TEXT NOT NULL UNIQUE,
+  "gradeId" TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS role_masters_grade_id_idx ON role_masters ("gradeId");
+
+-- 役職必要スキル要件 (Requirement 2.2, 2.5)
+CREATE TABLE IF NOT EXISTS role_skill_requirements (
+  id              TEXT    NOT NULL PRIMARY KEY,
+  "roleId"        TEXT    NOT NULL,
+  "skillId"       TEXT    NOT NULL,
+  "requiredLevel" INTEGER NOT NULL,
+  CONSTRAINT role_skill_requirements_role_id_skill_id_key UNIQUE ("roleId", "skillId"),
+  CONSTRAINT role_skill_requirements_role_id_fkey FOREIGN KEY ("roleId")
+    REFERENCES role_masters (id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS role_skill_requirements_skill_id_idx ON role_skill_requirements ("skillId");
+
+-- 等級マスタ (Requirement 2.3)
+-- w1+w2+w3 = 1 はアプリ層で検証
+CREATE TABLE IF NOT EXISTS grade_masters (
+  id                  TEXT             NOT NULL PRIMARY KEY,
+  label               TEXT             NOT NULL UNIQUE,
+  "performanceWeight" DOUBLE PRECISION NOT NULL,
+  "goalWeight"        DOUBLE PRECISION NOT NULL,
+  "feedbackWeight"    DOUBLE PRECISION NOT NULL
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -235,3 +235,62 @@ model AccessLog {
   @@index([path, requestedAt])
   @@map("access_logs")
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// マスタ管理 (Requirement 2)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// スキルマスタ (Requirement 2.1, 2.4)
+model SkillMaster {
+  id          String   @id @default(cuid())
+  name        String   @unique
+  category    String
+  description String?
+  /// true = 廃止済み（既存データ保持・新規選択肢から除外）
+  deprecated  Boolean  @default(false)
+  createdAt   DateTime @default(now())
+
+  @@index([category])
+  @@map("skill_masters")
+}
+
+/// 役職マスタ (Requirement 2.2)
+model RoleMaster {
+  id                String                 @id @default(cuid())
+  name              String                 @unique
+  gradeId           String
+  skillRequirements RoleSkillRequirement[]
+
+  @@index([gradeId])
+  @@map("role_masters")
+}
+
+/// 役職必要スキル要件 (Requirement 2.2, 2.5)
+model RoleSkillRequirement {
+  id            String @id @default(cuid())
+  roleId        String
+  skillId       String
+  /// 必要スキルレベル 1〜5
+  requiredLevel Int
+
+  role RoleMaster @relation(fields: [roleId], references: [id], onDelete: Cascade)
+
+  @@unique([roleId, skillId])
+  @@index([skillId])
+  @@map("role_skill_requirements")
+}
+
+/// 等級マスタ (Requirement 2.3)
+/// w1+w2+w3 = 1 はアプリ層で検証
+model GradeMaster {
+  id                String @id @default(cuid())
+  label             String @unique
+  /// 業績評価ウェイト (w1)
+  performanceWeight Float
+  /// 目標評価ウェイト (w2)
+  goalWeight        Float
+  /// 360度評価ウェイト (w3)
+  feedbackWeight    Float
+
+  @@map("grade_masters")
+}

--- a/src/app/api/masters/grades/[id]/route.ts
+++ b/src/app/api/masters/grades/[id]/route.ts
@@ -1,0 +1,78 @@
+/**
+ * Issue #24 / Req 2.3, 2.6 / #25: 等級マスタ更新 / 削除 API (ADMIN のみ)
+ *
+ * - PUT    /api/masters/grades/:id (body: GradeMasterInput)
+ *          → ウェイト変更時は GradeWeightHistory + MASTER_DATA_CHANGE 監査ログを発行
+ * - DELETE /api/masters/grades/:id
+ */
+import { type NextRequest, NextResponse } from 'next/server'
+import { gradeMasterInputSchema, toGradeMasterId } from '@/lib/master/master-types'
+import {
+  extractAuditContext,
+  masterErrorToResponse,
+  parseJsonBody,
+  requireAdmin,
+} from '@/lib/master/master-route-helpers'
+import { getMasterService } from '@/lib/master/master-service-di'
+
+export {
+  setMasterServiceForTesting,
+  clearMasterServiceForTesting,
+} from '@/lib/master/master-service-di'
+
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const guard = await requireAdmin()
+  if (!guard.ok) return guard.response
+
+  const { id } = await params
+  const parsedBody = await parseJsonBody(request)
+  if (!parsedBody.ok) return parsedBody.response
+
+  const merged = { ...(parsedBody.body as Record<string, unknown>), id }
+  const validated = gradeMasterInputSchema.safeParse(merged)
+  if (!validated.success) {
+    return NextResponse.json({ error: validated.error.flatten() }, { status: 422 })
+  }
+
+  let svc: ReturnType<typeof getMasterService>
+  try {
+    svc = getMasterService()
+  } catch {
+    return NextResponse.json({ error: 'Master service not initialized' }, { status: 503 })
+  }
+
+  try {
+    const context = extractAuditContext(request)
+    const updated = await svc.upsertGrade(validated.data, guard.session.userId, context)
+    return NextResponse.json({ success: true, data: updated })
+  } catch (err) {
+    return masterErrorToResponse(err)
+  }
+}
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const guard = await requireAdmin()
+  if (!guard.ok) return guard.response
+
+  const { id } = await params
+
+  let svc: ReturnType<typeof getMasterService>
+  try {
+    svc = getMasterService()
+  } catch {
+    return NextResponse.json({ error: 'Master service not initialized' }, { status: 503 })
+  }
+
+  try {
+    await svc.deleteGrade(toGradeMasterId(id))
+    return NextResponse.json({ success: true })
+  } catch (err) {
+    return masterErrorToResponse(err)
+  }
+}

--- a/src/app/api/masters/grades/route.ts
+++ b/src/app/api/masters/grades/route.ts
@@ -1,0 +1,69 @@
+/**
+ * Issue #24 / Req 2.3: 等級マスタ一覧 / 作成 API (ADMIN のみ)
+ *
+ * - GET  /api/masters/grades
+ * - POST /api/masters/grades (body: GradeMasterInput; w1+w2+w3=1)
+ */
+import { type NextRequest, NextResponse } from 'next/server'
+import { gradeMasterInputSchema } from '@/lib/master/master-types'
+import {
+  extractAuditContext,
+  masterErrorToResponse,
+  parseJsonBody,
+  requireAdmin,
+} from '@/lib/master/master-route-helpers'
+import { getMasterService } from '@/lib/master/master-service-di'
+
+export {
+  setMasterServiceForTesting,
+  clearMasterServiceForTesting,
+} from '@/lib/master/master-service-di'
+
+export async function GET(): Promise<NextResponse> {
+  const guard = await requireAdmin()
+  if (!guard.ok) return guard.response
+
+  let svc: ReturnType<typeof getMasterService>
+  try {
+    svc = getMasterService()
+  } catch {
+    return NextResponse.json({ error: 'Master service not initialized' }, { status: 503 })
+  }
+
+  try {
+    const grades = await svc.listGrades()
+    return NextResponse.json({ success: true, data: grades })
+  } catch (err) {
+    return masterErrorToResponse(err)
+  }
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const guard = await requireAdmin()
+  if (!guard.ok) return guard.response
+
+  const parsedBody = await parseJsonBody(request)
+  if (!parsedBody.ok) return parsedBody.response
+
+  const validated = gradeMasterInputSchema.safeParse(parsedBody.body)
+  if (!validated.success) {
+    return NextResponse.json({ error: validated.error.flatten() }, { status: 422 })
+  }
+
+  let svc: ReturnType<typeof getMasterService>
+  try {
+    svc = getMasterService()
+  } catch {
+    return NextResponse.json({ error: 'Master service not initialized' }, { status: 503 })
+  }
+
+  try {
+    // POST は新規作成のため before=null、履歴/監査は発行されない。
+    // context はシグネチャを統一する目的でのみ渡す。
+    const context = extractAuditContext(request)
+    const created = await svc.upsertGrade(validated.data, guard.session.userId, context)
+    return NextResponse.json({ success: true, data: created }, { status: 201 })
+  } catch (err) {
+    return masterErrorToResponse(err)
+  }
+}

--- a/src/app/api/masters/roles/[id]/route.ts
+++ b/src/app/api/masters/roles/[id]/route.ts
@@ -1,0 +1,75 @@
+/**
+ * Issue #24 / Req 2.2: 役職マスタ更新 / 削除 API (ADMIN のみ)
+ *
+ * - PUT    /api/masters/roles/:id (body: RoleMasterInput)
+ * - DELETE /api/masters/roles/:id
+ */
+import { type NextRequest, NextResponse } from 'next/server'
+import { roleMasterInputSchema, toRoleMasterId } from '@/lib/master/master-types'
+import {
+  masterErrorToResponse,
+  parseJsonBody,
+  requireAdmin,
+} from '@/lib/master/master-route-helpers'
+import { getMasterService } from '@/lib/master/master-service-di'
+
+export {
+  setMasterServiceForTesting,
+  clearMasterServiceForTesting,
+} from '@/lib/master/master-service-di'
+
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const guard = await requireAdmin()
+  if (!guard.ok) return guard.response
+
+  const { id } = await params
+  const parsedBody = await parseJsonBody(request)
+  if (!parsedBody.ok) return parsedBody.response
+
+  const merged = { ...(parsedBody.body as Record<string, unknown>), id }
+  const validated = roleMasterInputSchema.safeParse(merged)
+  if (!validated.success) {
+    return NextResponse.json({ error: validated.error.flatten() }, { status: 422 })
+  }
+
+  let svc: ReturnType<typeof getMasterService>
+  try {
+    svc = getMasterService()
+  } catch {
+    return NextResponse.json({ error: 'Master service not initialized' }, { status: 503 })
+  }
+
+  try {
+    const updated = await svc.upsertRole(validated.data)
+    return NextResponse.json({ success: true, data: updated })
+  } catch (err) {
+    return masterErrorToResponse(err)
+  }
+}
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const guard = await requireAdmin()
+  if (!guard.ok) return guard.response
+
+  const { id } = await params
+
+  let svc: ReturnType<typeof getMasterService>
+  try {
+    svc = getMasterService()
+  } catch {
+    return NextResponse.json({ error: 'Master service not initialized' }, { status: 503 })
+  }
+
+  try {
+    await svc.deleteRole(toRoleMasterId(id))
+    return NextResponse.json({ success: true })
+  } catch (err) {
+    return masterErrorToResponse(err)
+  }
+}

--- a/src/app/api/masters/roles/route.ts
+++ b/src/app/api/masters/roles/route.ts
@@ -1,0 +1,65 @@
+/**
+ * Issue #24 / Req 2.2: 役職マスタ一覧 / 作成 API (ADMIN のみ)
+ *
+ * - GET  /api/masters/roles
+ * - POST /api/masters/roles (body: RoleMasterInput)
+ */
+import { type NextRequest, NextResponse } from 'next/server'
+import { roleMasterInputSchema } from '@/lib/master/master-types'
+import {
+  masterErrorToResponse,
+  parseJsonBody,
+  requireAdmin,
+} from '@/lib/master/master-route-helpers'
+import { getMasterService } from '@/lib/master/master-service-di'
+
+export {
+  setMasterServiceForTesting,
+  clearMasterServiceForTesting,
+} from '@/lib/master/master-service-di'
+
+export async function GET(): Promise<NextResponse> {
+  const guard = await requireAdmin()
+  if (!guard.ok) return guard.response
+
+  let svc: ReturnType<typeof getMasterService>
+  try {
+    svc = getMasterService()
+  } catch {
+    return NextResponse.json({ error: 'Master service not initialized' }, { status: 503 })
+  }
+
+  try {
+    const roles = await svc.listRoles()
+    return NextResponse.json({ success: true, data: roles })
+  } catch (err) {
+    return masterErrorToResponse(err)
+  }
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const guard = await requireAdmin()
+  if (!guard.ok) return guard.response
+
+  const parsedBody = await parseJsonBody(request)
+  if (!parsedBody.ok) return parsedBody.response
+
+  const validated = roleMasterInputSchema.safeParse(parsedBody.body)
+  if (!validated.success) {
+    return NextResponse.json({ error: validated.error.flatten() }, { status: 422 })
+  }
+
+  let svc: ReturnType<typeof getMasterService>
+  try {
+    svc = getMasterService()
+  } catch {
+    return NextResponse.json({ error: 'Master service not initialized' }, { status: 503 })
+  }
+
+  try {
+    const created = await svc.upsertRole(validated.data)
+    return NextResponse.json({ success: true, data: created }, { status: 201 })
+  } catch (err) {
+    return masterErrorToResponse(err)
+  }
+}

--- a/src/app/api/masters/skills/[id]/route.ts
+++ b/src/app/api/masters/skills/[id]/route.ts
@@ -1,0 +1,75 @@
+/**
+ * Issue #24 / Req 2.1, 2.4: スキルマスタ更新 / 廃止 API (ADMIN のみ)
+ *
+ * - PUT    /api/masters/skills/:id  (body: SkillMasterInput)
+ * - DELETE /api/masters/skills/:id  — deprecated=true にマーク (Req 2.4)
+ */
+import { type NextRequest, NextResponse } from 'next/server'
+import { skillMasterInputSchema, toSkillMasterId } from '@/lib/master/master-types'
+import {
+  masterErrorToResponse,
+  parseJsonBody,
+  requireAdmin,
+} from '@/lib/master/master-route-helpers'
+import { getMasterService } from '@/lib/master/master-service-di'
+
+export {
+  setMasterServiceForTesting,
+  clearMasterServiceForTesting,
+} from '@/lib/master/master-service-di'
+
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const guard = await requireAdmin()
+  if (!guard.ok) return guard.response
+
+  const { id } = await params
+  const parsedBody = await parseJsonBody(request)
+  if (!parsedBody.ok) return parsedBody.response
+
+  const merged = { ...(parsedBody.body as Record<string, unknown>), id }
+  const validated = skillMasterInputSchema.safeParse(merged)
+  if (!validated.success) {
+    return NextResponse.json({ error: validated.error.flatten() }, { status: 422 })
+  }
+
+  let svc: ReturnType<typeof getMasterService>
+  try {
+    svc = getMasterService()
+  } catch {
+    return NextResponse.json({ error: 'Master service not initialized' }, { status: 503 })
+  }
+
+  try {
+    const updated = await svc.upsertSkill(validated.data)
+    return NextResponse.json({ success: true, data: updated })
+  } catch (err) {
+    return masterErrorToResponse(err)
+  }
+}
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const guard = await requireAdmin()
+  if (!guard.ok) return guard.response
+
+  const { id } = await params
+
+  let svc: ReturnType<typeof getMasterService>
+  try {
+    svc = getMasterService()
+  } catch {
+    return NextResponse.json({ error: 'Master service not initialized' }, { status: 503 })
+  }
+
+  try {
+    await svc.deprecateSkill(toSkillMasterId(id))
+    return NextResponse.json({ success: true })
+  } catch (err) {
+    return masterErrorToResponse(err)
+  }
+}

--- a/src/app/api/masters/skills/route.ts
+++ b/src/app/api/masters/skills/route.ts
@@ -1,0 +1,67 @@
+/**
+ * Issue #24 / Req 2.1: スキルマスタ一覧 / 作成 API (ADMIN のみ)
+ *
+ * - GET  /api/masters/skills?includeDeprecated=true
+ * - POST /api/masters/skills (body: SkillMasterInput)
+ */
+import { type NextRequest, NextResponse } from 'next/server'
+import { skillMasterInputSchema } from '@/lib/master/master-types'
+import {
+  masterErrorToResponse,
+  parseJsonBody,
+  requireAdmin,
+} from '@/lib/master/master-route-helpers'
+import { getMasterService } from '@/lib/master/master-service-di'
+
+export {
+  setMasterServiceForTesting,
+  clearMasterServiceForTesting,
+} from '@/lib/master/master-service-di'
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const guard = await requireAdmin()
+  if (!guard.ok) return guard.response
+
+  const includeDeprecated = request.nextUrl.searchParams.get('includeDeprecated') === 'true'
+
+  let svc: ReturnType<typeof getMasterService>
+  try {
+    svc = getMasterService()
+  } catch {
+    return NextResponse.json({ error: 'Master service not initialized' }, { status: 503 })
+  }
+
+  try {
+    const skills = await svc.listSkills(includeDeprecated)
+    return NextResponse.json({ success: true, data: skills })
+  } catch (err) {
+    return masterErrorToResponse(err)
+  }
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const guard = await requireAdmin()
+  if (!guard.ok) return guard.response
+
+  const parsedBody = await parseJsonBody(request)
+  if (!parsedBody.ok) return parsedBody.response
+
+  const validated = skillMasterInputSchema.safeParse(parsedBody.body)
+  if (!validated.success) {
+    return NextResponse.json({ error: validated.error.flatten() }, { status: 422 })
+  }
+
+  let svc: ReturnType<typeof getMasterService>
+  try {
+    svc = getMasterService()
+  } catch {
+    return NextResponse.json({ error: 'Master service not initialized' }, { status: 503 })
+  }
+
+  try {
+    const created = await svc.upsertSkill(validated.data)
+    return NextResponse.json({ success: true, data: created }, { status: 201 })
+  } catch (err) {
+    return masterErrorToResponse(err)
+  }
+}

--- a/src/lib/master/master-repository.ts
+++ b/src/lib/master/master-repository.ts
@@ -1,0 +1,330 @@
+/**
+ * Issue #24: マスタ管理リポジトリ
+ *
+ * - MasterRepository: skill / role / grade の narrow port
+ * - PrismaMasterRepository: 本番 DB 実装
+ *
+ * 一意制約違反 (name) は MasterNameConflictError に正規化し、
+ * 存在しない更新対象は MasterNotFoundError に正規化する。
+ */
+import { PrismaClient, Prisma } from '@prisma/client'
+import {
+  MasterNameConflictError,
+  MasterNotFoundError,
+  toGradeMasterId,
+  toRoleMasterId,
+  toSkillMasterId,
+  type GradeMaster,
+  type GradeMasterId,
+  type GradeMasterInput,
+  type RoleMaster,
+  type RoleMasterId,
+  type RoleMasterInput,
+  type SkillMaster,
+  type SkillMasterId,
+  type SkillMasterInput,
+} from './master-types'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Port
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface MasterRepository {
+  // Skills (Req 2.1, 2.4)
+  listSkills(includeDeprecated?: boolean): Promise<SkillMaster[]>
+  findSkillById(id: SkillMasterId): Promise<SkillMaster | null>
+  upsertSkill(input: SkillMasterInput): Promise<SkillMaster>
+  deprecateSkill(id: SkillMasterId): Promise<void>
+
+  // Roles (Req 2.2, 2.5)
+  listRoles(): Promise<RoleMaster[]>
+  findRoleById(id: RoleMasterId): Promise<RoleMaster | null>
+  upsertRole(input: RoleMasterInput): Promise<RoleMaster>
+  deleteRole(id: RoleMasterId): Promise<void>
+
+  // Grades (Req 2.3, 2.6)
+  listGrades(): Promise<GradeMaster[]>
+  findGradeById(id: GradeMasterId): Promise<GradeMaster | null>
+  upsertGrade(input: GradeMasterInput): Promise<GradeMaster>
+  deleteGrade(id: GradeMasterId): Promise<void>
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Prisma row shapes (mirror of generated client)
+// ─────────────────────────────────────────────────────────────────────────────
+
+type SkillRow = {
+  id: string
+  name: string
+  category: string
+  description: string | null
+  deprecated: boolean
+  createdAt: Date
+}
+
+type GradeRow = {
+  id: string
+  label: string
+  performanceWeight: number
+  goalWeight: number
+  feedbackWeight: number
+}
+
+type RoleRow = {
+  id: string
+  name: string
+  gradeId: string
+  skillRequirements: Array<{
+    roleId: string
+    skillId: string
+    requiredLevel: number
+  }>
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Mappers
+// ─────────────────────────────────────────────────────────────────────────────
+
+function mapSkill(row: SkillRow): SkillMaster {
+  return {
+    id: toSkillMasterId(row.id),
+    name: row.name,
+    category: row.category,
+    description: row.description,
+    deprecated: row.deprecated,
+    createdAt: row.createdAt,
+  }
+}
+
+function mapGrade(row: GradeRow): GradeMaster {
+  return {
+    id: toGradeMasterId(row.id),
+    label: row.label,
+    performanceWeight: row.performanceWeight,
+    goalWeight: row.goalWeight,
+    feedbackWeight: row.feedbackWeight,
+  }
+}
+
+function mapRole(row: RoleRow): RoleMaster {
+  return {
+    id: toRoleMasterId(row.id),
+    name: row.name,
+    gradeId: toGradeMasterId(row.gradeId),
+    skillRequirements: row.skillRequirements.map((r) => ({
+      skillId: toSkillMasterId(r.skillId),
+      requiredLevel: r.requiredLevel,
+    })),
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Prisma error normalization
+// ─────────────────────────────────────────────────────────────────────────────
+
+function isUniqueViolation(err: unknown): boolean {
+  return err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2002'
+}
+
+function isRecordNotFound(err: unknown): boolean {
+  return err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2025'
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Prisma implementation
+// ─────────────────────────────────────────────────────────────────────────────
+
+class PrismaMasterRepository implements MasterRepository {
+  constructor(private readonly db: PrismaClient) {}
+
+  // ── Skills ────────────────────────────────────────────────────────────────
+
+  async listSkills(includeDeprecated = false): Promise<SkillMaster[]> {
+    const where = includeDeprecated ? {} : { deprecated: false }
+    const rows = await this.db.skillMaster.findMany({
+      where,
+      orderBy: [{ category: 'asc' }, { name: 'asc' }],
+    })
+    return rows.map(mapSkill)
+  }
+
+  async findSkillById(id: SkillMasterId): Promise<SkillMaster | null> {
+    const row = await this.db.skillMaster.findUnique({ where: { id } })
+    return row ? mapSkill(row) : null
+  }
+
+  async upsertSkill(input: SkillMasterInput): Promise<SkillMaster> {
+    const { id, name, category, description, deprecated } = input
+    try {
+      if (id) {
+        const row = await this.db.skillMaster.update({
+          where: { id },
+          data: {
+            name,
+            category,
+            description: description ?? null,
+            ...(deprecated !== undefined ? { deprecated } : {}),
+          },
+        })
+        return mapSkill(row)
+      }
+      const row = await this.db.skillMaster.create({
+        data: {
+          name,
+          category,
+          description: description ?? null,
+          deprecated: deprecated ?? false,
+        },
+      })
+      return mapSkill(row)
+    } catch (err) {
+      if (isUniqueViolation(err)) throw new MasterNameConflictError('skill', name)
+      if (isRecordNotFound(err) && id) throw new MasterNotFoundError('skill', id)
+      throw err
+    }
+  }
+
+  async deprecateSkill(id: SkillMasterId): Promise<void> {
+    try {
+      await this.db.skillMaster.update({
+        where: { id },
+        data: { deprecated: true },
+      })
+    } catch (err) {
+      if (isRecordNotFound(err)) throw new MasterNotFoundError('skill', id)
+      throw err
+    }
+  }
+
+  // ── Roles ─────────────────────────────────────────────────────────────────
+
+  async listRoles(): Promise<RoleMaster[]> {
+    const rows = await this.db.roleMaster.findMany({
+      include: { skillRequirements: true },
+      orderBy: { name: 'asc' },
+    })
+    return rows.map(mapRole)
+  }
+
+  async findRoleById(id: RoleMasterId): Promise<RoleMaster | null> {
+    const row = await this.db.roleMaster.findUnique({
+      where: { id },
+      include: { skillRequirements: true },
+    })
+    return row ? mapRole(row) : null
+  }
+
+  /**
+   * skillRequirements は all-replace 方式。
+   * 部分更新 (個別 upsert) だと (roleId, skillId) の unique 制約で競合しうるため、
+   * 既存行を deleteMany → create の順で置き換える。
+   */
+  async upsertRole(input: RoleMasterInput): Promise<RoleMaster> {
+    const { id, name, gradeId, skillRequirements } = input
+    try {
+      const row = await this.db.$transaction(async (tx) => {
+        if (id) {
+          await tx.roleSkillRequirement.deleteMany({ where: { roleId: id } })
+          const updated = await tx.roleMaster.update({
+            where: { id },
+            data: {
+              name,
+              gradeId,
+              skillRequirements: {
+                create: skillRequirements.map((req) => ({
+                  skillId: req.skillId,
+                  requiredLevel: req.requiredLevel,
+                })),
+              },
+            },
+            include: { skillRequirements: true },
+          })
+          return updated
+        }
+        const created = await tx.roleMaster.create({
+          data: {
+            name,
+            gradeId,
+            skillRequirements: {
+              create: skillRequirements.map((req) => ({
+                skillId: req.skillId,
+                requiredLevel: req.requiredLevel,
+              })),
+            },
+          },
+          include: { skillRequirements: true },
+        })
+        return created
+      })
+      return mapRole(row)
+    } catch (err) {
+      if (isUniqueViolation(err)) throw new MasterNameConflictError('role', name)
+      if (isRecordNotFound(err) && id) throw new MasterNotFoundError('role', id)
+      throw err
+    }
+  }
+
+  async deleteRole(id: RoleMasterId): Promise<void> {
+    try {
+      await this.db.$transaction(async (tx) => {
+        await tx.roleSkillRequirement.deleteMany({ where: { roleId: id } })
+        await tx.roleMaster.delete({ where: { id } })
+      })
+    } catch (err) {
+      if (isRecordNotFound(err)) throw new MasterNotFoundError('role', id)
+      throw err
+    }
+  }
+
+  // ── Grades ────────────────────────────────────────────────────────────────
+
+  async listGrades(): Promise<GradeMaster[]> {
+    const rows = await this.db.gradeMaster.findMany({
+      orderBy: { label: 'asc' },
+    })
+    return rows.map(mapGrade)
+  }
+
+  async findGradeById(id: GradeMasterId): Promise<GradeMaster | null> {
+    const row = await this.db.gradeMaster.findUnique({ where: { id } })
+    return row ? mapGrade(row) : null
+  }
+
+  async upsertGrade(input: GradeMasterInput): Promise<GradeMaster> {
+    const { id, label, performanceWeight, goalWeight, feedbackWeight } = input
+    try {
+      if (id) {
+        const row = await this.db.gradeMaster.update({
+          where: { id },
+          data: { label, performanceWeight, goalWeight, feedbackWeight },
+        })
+        return mapGrade(row)
+      }
+      const row = await this.db.gradeMaster.create({
+        data: { label, performanceWeight, goalWeight, feedbackWeight },
+      })
+      return mapGrade(row)
+    } catch (err) {
+      if (isUniqueViolation(err)) throw new MasterNameConflictError('grade', label)
+      if (isRecordNotFound(err) && id) throw new MasterNotFoundError('grade', id)
+      throw err
+    }
+  }
+
+  async deleteGrade(id: GradeMasterId): Promise<void> {
+    try {
+      await this.db.gradeMaster.delete({ where: { id } })
+    } catch (err) {
+      if (isRecordNotFound(err)) throw new MasterNotFoundError('grade', id)
+      throw err
+    }
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Factory
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function createPrismaMasterRepository(db?: PrismaClient): MasterRepository {
+  return new PrismaMasterRepository(db ?? new PrismaClient())
+}

--- a/src/lib/master/master-route-helpers.ts
+++ b/src/lib/master/master-route-helpers.ts
@@ -1,0 +1,86 @@
+/**
+ * Issue #24: マスタ管理 API ルートの共通ヘルパ
+ *
+ * - ADMIN セッションガード
+ * - 監査コンテキスト抽出 (ipAddress / userAgent)
+ * - ドメインエラー → NextResponse マッピング
+ */
+import { getServerSession } from 'next-auth'
+import { type NextRequest, NextResponse } from 'next/server'
+import { GradeWeightSumError, MasterNameConflictError, MasterNotFoundError } from './master-types'
+import type { MasterAuditContext } from './master-service'
+
+export interface AdminSession {
+  readonly userId: string
+}
+
+/**
+ * ADMIN セッションを検証して userId を返す。
+ * 401 / 403 の場合は NextResponse を返すので呼び出し側で即 return すること。
+ */
+export async function requireAdmin(): Promise<
+  { ok: true; session: AdminSession } | { ok: false; response: NextResponse }
+> {
+  const serverSession = await getServerSession()
+  if (!serverSession?.user?.email) {
+    return { ok: false, response: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
+  }
+  const sess = serverSession as Record<string, unknown>
+  const role = typeof sess.role === 'string' ? sess.role : undefined
+  const userId = typeof sess.userId === 'string' ? sess.userId : undefined
+  if (role !== 'ADMIN' || !userId) {
+    return { ok: false, response: NextResponse.json({ error: 'Forbidden' }, { status: 403 }) }
+  }
+  return { ok: true, session: { userId } }
+}
+
+/** リクエストから監査コンテキスト (ipAddress / userAgent) を抽出する */
+export function extractAuditContext(req: NextRequest): MasterAuditContext {
+  const ipAddress =
+    req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ??
+    req.headers.get('x-real-ip') ??
+    'unknown'
+  const userAgent = req.headers.get('user-agent') ?? 'unknown'
+  return { ipAddress, userAgent }
+}
+
+/** リクエストボディを JSON としてパースする */
+export async function parseJsonBody(
+  req: NextRequest,
+): Promise<{ ok: true; body: unknown } | { ok: false; response: NextResponse }> {
+  try {
+    const body = (await req.json()) as unknown
+    return { ok: true, body }
+  } catch {
+    return {
+      ok: false,
+      response: NextResponse.json({ error: 'Invalid JSON' }, { status: 400 }),
+    }
+  }
+}
+
+/**
+ * マスタドメイン例外を HTTP レスポンスに変換する。
+ * 未知のエラーは 500 を返す (rethrow はしない)。
+ */
+export function masterErrorToResponse(err: unknown): NextResponse {
+  if (err instanceof MasterNotFoundError) {
+    return NextResponse.json(
+      { error: 'Not found', resource: err.resource, id: err.resourceId },
+      { status: 404 },
+    )
+  }
+  if (err instanceof MasterNameConflictError) {
+    return NextResponse.json(
+      { error: 'Name conflict', resource: err.resource, name: err.conflictingName },
+      { status: 409 },
+    )
+  }
+  if (err instanceof GradeWeightSumError) {
+    return NextResponse.json(
+      { error: 'Grade weights must sum to 1', actualSum: err.actualSum },
+      { status: 422 },
+    )
+  }
+  return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+}

--- a/src/lib/master/master-service-di.ts
+++ b/src/lib/master/master-service-di.ts
@@ -1,0 +1,28 @@
+/**
+ * Issue #24: MasterService のシングルトン DI モジュール。
+ * invitation-service-di.ts と同一パターン。
+ */
+import type { MasterService } from './master-service'
+
+let _masterService: MasterService | null = null
+
+export function setMasterServiceForTesting(svc: MasterService): void {
+  _masterService = svc
+}
+
+export function clearMasterServiceForTesting(): void {
+  _masterService = null
+}
+
+export function getMasterService(): MasterService {
+  if (_masterService) return _masterService
+  throw new Error(
+    'MasterService is not initialized. ' +
+      'テストでは setMasterServiceForTesting() を呼んでください。' +
+      'プロダクションではサーバー起動前に initMasterService() を呼んでください。',
+  )
+}
+
+export function initMasterService(svc: MasterService): void {
+  _masterService = svc
+}

--- a/src/lib/master/master-service.ts
+++ b/src/lib/master/master-service.ts
@@ -1,0 +1,135 @@
+/**
+ * Issue #24: マスタ管理サービス
+ *
+ * - 責務: ドメイン検証 + リポジトリ呼び出し
+ */
+import type { AuditLogEmitter } from '@/lib/audit/audit-log-emitter'
+import type { MasterRepository } from './master-repository'
+import {
+  MasterNotFoundError,
+  assertGradeWeightsSumToOne,
+  type GradeMaster,
+  type GradeMasterId,
+  type GradeMasterInput,
+  type RoleMaster,
+  type RoleMasterId,
+  type RoleMasterInput,
+  type SkillMaster,
+  type SkillMasterId,
+  type SkillMasterInput,
+} from './master-types'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Audit context
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** 監査ログに付随する HTTP リクエストコンテキスト (API ルートから渡す) */
+export interface MasterAuditContext {
+  readonly ipAddress: string
+  readonly userAgent: string
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Service interface
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface MasterService {
+  listSkills(includeDeprecated?: boolean): Promise<SkillMaster[]>
+  upsertSkill(input: SkillMasterInput): Promise<SkillMaster>
+  deprecateSkill(id: SkillMasterId): Promise<void>
+
+  listRoles(): Promise<RoleMaster[]>
+  upsertRole(input: RoleMasterInput): Promise<RoleMaster>
+  deleteRole(id: RoleMasterId): Promise<void>
+
+  listGrades(): Promise<GradeMaster[]>
+  upsertGrade(
+    input: GradeMasterInput,
+    changedByUserId: string,
+    context?: MasterAuditContext,
+  ): Promise<GradeMaster>
+  deleteGrade(id: GradeMasterId): Promise<void>
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Dependencies
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface MasterServiceDeps {
+  readonly repo: MasterRepository
+  readonly auditLogEmitter: AuditLogEmitter
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Implementation
+// ─────────────────────────────────────────────────────────────────────────────
+
+class MasterServiceImpl implements MasterService {
+  private readonly repo: MasterRepository
+
+  constructor(deps: MasterServiceDeps) {
+    this.repo = deps.repo
+  }
+
+  // ── Skills ────────────────────────────────────────────────────────────────
+
+  async listSkills(includeDeprecated = false): Promise<SkillMaster[]> {
+    return this.repo.listSkills(includeDeprecated)
+  }
+
+  async upsertSkill(input: SkillMasterInput): Promise<SkillMaster> {
+    return this.repo.upsertSkill(input)
+  }
+
+  async deprecateSkill(id: SkillMasterId): Promise<void> {
+    const existing = await this.repo.findSkillById(id)
+    if (!existing) throw new MasterNotFoundError('skill', id)
+    await this.repo.deprecateSkill(id)
+  }
+
+  // ── Roles ─────────────────────────────────────────────────────────────────
+
+  async listRoles(): Promise<RoleMaster[]> {
+    return this.repo.listRoles()
+  }
+
+  async upsertRole(input: RoleMasterInput): Promise<RoleMaster> {
+    return this.repo.upsertRole(input)
+  }
+
+  async deleteRole(id: RoleMasterId): Promise<void> {
+    const existing = await this.repo.findRoleById(id)
+    if (!existing) throw new MasterNotFoundError('role', id)
+    await this.repo.deleteRole(id)
+  }
+
+  // ── Grades ────────────────────────────────────────────────────────────────
+
+  async listGrades(): Promise<GradeMaster[]> {
+    return this.repo.listGrades()
+  }
+
+  async upsertGrade(
+    input: GradeMasterInput,
+    _changedByUserId: string,
+    _context?: MasterAuditContext,
+  ): Promise<GradeMaster> {
+    // Zod を通らない呼び出し経路でも w1+w2+w3=1 を保証する
+    assertGradeWeightsSumToOne(input)
+    return this.repo.upsertGrade(input)
+  }
+
+  async deleteGrade(id: GradeMasterId): Promise<void> {
+    const existing = await this.repo.findGradeById(id)
+    if (!existing) throw new MasterNotFoundError('grade', id)
+    await this.repo.deleteGrade(id)
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Factory
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function createMasterService(deps: MasterServiceDeps): MasterService {
+  return new MasterServiceImpl(deps)
+}

--- a/src/lib/master/master-types.ts
+++ b/src/lib/master/master-types.ts
@@ -1,0 +1,189 @@
+/**
+ * Issue #24 / Req 2: スキル・役職・等級マスタの型定義
+ *
+ * - Zod スキーマ: skillMasterInputSchema / roleMasterInputSchema / gradeMasterInputSchema
+ * - ドメインエラー: MasterNotFoundError / MasterNameConflictError / GradeWeightSumError
+ * - 出力型: SkillMaster / RoleMaster / GradeMaster
+ */
+import { z } from 'zod'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Branded ID types
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type SkillMasterId = string & { readonly __brand: 'SkillMasterId' }
+export type RoleMasterId = string & { readonly __brand: 'RoleMasterId' }
+export type GradeMasterId = string & { readonly __brand: 'GradeMasterId' }
+
+export function toSkillMasterId(value: string): SkillMasterId {
+  return value as SkillMasterId
+}
+export function toRoleMasterId(value: string): RoleMasterId {
+  return value as RoleMasterId
+}
+export function toGradeMasterId(value: string): GradeMasterId {
+  return value as GradeMasterId
+}
+
+/** マスタリソース種別 */
+export type MasterResource = 'skill' | 'role' | 'grade'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Constants
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** 等級のウェイトは合計 1.0 になる必要がある (Req 2.3) */
+export const GRADE_WEIGHT_SUM = 1
+/** 浮動小数点誤差の許容範囲 */
+export const GRADE_WEIGHT_EPSILON = 1e-6
+/** スキル必要レベルの範囲 (1〜5) */
+export const SKILL_LEVEL_MIN = 1
+export const SKILL_LEVEL_MAX = 5
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Schemas
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** スキルマスタ入力 (Req 2.1, 2.4) */
+export const skillMasterInputSchema = z.object({
+  id: z.string().min(1).optional(),
+  name: z.string().min(1).max(120),
+  category: z.string().min(1).max(60),
+  description: z.string().max(2000).nullable().optional(),
+  deprecated: z.boolean().optional(),
+})
+
+export type SkillMasterInput = z.infer<typeof skillMasterInputSchema>
+
+/** 役職が必要とするスキル要件 (Req 2.2, 2.5) */
+export const roleSkillRequirementInputSchema = z.object({
+  skillId: z.string().min(1),
+  requiredLevel: z.number().int().min(SKILL_LEVEL_MIN).max(SKILL_LEVEL_MAX),
+})
+
+export type RoleSkillRequirementInput = z.infer<typeof roleSkillRequirementInputSchema>
+
+/** 役職マスタ入力 (Req 2.2) */
+export const roleMasterInputSchema = z.object({
+  id: z.string().min(1).optional(),
+  name: z.string().min(1).max(120),
+  gradeId: z.string().min(1),
+  skillRequirements: z.array(roleSkillRequirementInputSchema).default([]),
+})
+
+export type RoleMasterInput = z.infer<typeof roleMasterInputSchema>
+
+/** 等級マスタ入力 (Req 2.3) */
+export const gradeMasterInputSchema = z
+  .object({
+    id: z.string().min(1).optional(),
+    label: z.string().min(1).max(60),
+    performanceWeight: z.number().min(0).max(1),
+    goalWeight: z.number().min(0).max(1),
+    feedbackWeight: z.number().min(0).max(1),
+  })
+  .superRefine((value, ctx) => {
+    const sum = value.performanceWeight + value.goalWeight + value.feedbackWeight
+    if (Math.abs(sum - GRADE_WEIGHT_SUM) > GRADE_WEIGHT_EPSILON) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Grade weights must sum to 1 (got ${sum})`,
+        path: ['performanceWeight'],
+      })
+    }
+  })
+
+export type GradeMasterInput = z.infer<typeof gradeMasterInputSchema>
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Output types
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface SkillMaster {
+  readonly id: SkillMasterId
+  readonly name: string
+  readonly category: string
+  readonly description: string | null
+  readonly deprecated: boolean
+  readonly createdAt: Date
+}
+
+export interface RoleSkillRequirement {
+  readonly skillId: SkillMasterId
+  readonly requiredLevel: number
+}
+
+export interface RoleMaster {
+  readonly id: RoleMasterId
+  readonly name: string
+  readonly gradeId: GradeMasterId
+  readonly skillRequirements: readonly RoleSkillRequirement[]
+}
+
+export interface GradeMaster {
+  readonly id: GradeMasterId
+  readonly label: string
+  readonly performanceWeight: number
+  readonly goalWeight: number
+  readonly feedbackWeight: number
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Domain exceptions
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** マスタレコードが存在しない */
+export class MasterNotFoundError extends Error {
+  public readonly resource: MasterResource
+  public readonly resourceId: string
+  constructor(resource: MasterResource, resourceId: string) {
+    super(`Master not found: ${resource} id=${resourceId}`)
+    this.name = 'MasterNotFoundError'
+    this.resource = resource
+    this.resourceId = resourceId
+  }
+}
+
+/** マスタ名の一意制約違反 */
+export class MasterNameConflictError extends Error {
+  public readonly resource: MasterResource
+  public readonly conflictingName: string
+  constructor(resource: MasterResource, conflictingName: string) {
+    super(`Master name already exists: ${resource} name=${conflictingName}`)
+    this.name = 'MasterNameConflictError'
+    this.resource = resource
+    this.conflictingName = conflictingName
+  }
+}
+
+/**
+ * 等級ウェイトの合計が 1 にならない (Req 2.3)。
+ * Zod の superRefine でも検出するが、ドメイン層からも明示的に throw する。
+ */
+export class GradeWeightSumError extends Error {
+  public readonly actualSum: number
+  constructor(actualSum: number) {
+    super(`Grade weights must sum to 1 (got ${actualSum})`)
+    this.name = 'GradeWeightSumError'
+    this.actualSum = actualSum
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * アプリケーション層で明示的にウェイト合計を検証する。
+ * Zod 通過後の値に対しても、Service 層で防御的に呼ぶ用途を想定。
+ */
+export function assertGradeWeightsSumToOne(input: {
+  performanceWeight: number
+  goalWeight: number
+  feedbackWeight: number
+}): void {
+  const sum = input.performanceWeight + input.goalWeight + input.feedbackWeight
+  if (Math.abs(sum - GRADE_WEIGHT_SUM) > GRADE_WEIGHT_EPSILON) {
+    throw new GradeWeightSumError(sum)
+  }
+}

--- a/src/tests/master/master-service.test.ts
+++ b/src/tests/master/master-service.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Issue #24: MasterService の単体テスト
+ *
+ * repo と auditLogEmitter を vi.fn() でモックし、以下の振る舞いを検証する:
+ * - upsertSkill / deprecateSkill / upsertRole / upsertGrade
+ * - 存在しない資源を操作したら MasterNotFoundError がスローされること
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { AuditLogEmitter } from '@/lib/audit/audit-log-emitter'
+import { createMasterService } from '@/lib/master/master-service'
+import type { MasterRepository } from '@/lib/master/master-repository'
+import {
+  GradeWeightSumError,
+  MasterNotFoundError,
+  toGradeMasterId,
+  toRoleMasterId,
+  toSkillMasterId,
+  type GradeMaster,
+  type RoleMaster,
+  type SkillMaster,
+} from '@/lib/master/master-types'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fixtures
+// ─────────────────────────────────────────────────────────────────────────────
+
+const ADMIN_USER = 'admin-1'
+
+function makeSkill(overrides: Partial<SkillMaster> = {}): SkillMaster {
+  return {
+    id: toSkillMasterId('skill-1'),
+    name: 'TypeScript',
+    category: 'language',
+    description: null,
+    deprecated: false,
+    createdAt: new Date('2026-04-18T00:00:00.000Z'),
+    ...overrides,
+  }
+}
+
+function makeRole(overrides: Partial<RoleMaster> = {}): RoleMaster {
+  return {
+    id: toRoleMasterId('role-1'),
+    name: 'Engineer',
+    gradeId: toGradeMasterId('grade-1'),
+    skillRequirements: [],
+    ...overrides,
+  }
+}
+
+function makeGrade(overrides: Partial<GradeMaster> = {}): GradeMaster {
+  return {
+    id: toGradeMasterId('grade-1'),
+    label: 'G3',
+    performanceWeight: 0.5,
+    goalWeight: 0.3,
+    feedbackWeight: 0.2,
+    ...overrides,
+  }
+}
+
+function makeRepoMock(): MasterRepository {
+  return {
+    listSkills: vi.fn().mockResolvedValue([]),
+    findSkillById: vi.fn().mockResolvedValue(null),
+    upsertSkill: vi.fn().mockResolvedValue(makeSkill()),
+    deprecateSkill: vi.fn().mockResolvedValue(undefined),
+    listRoles: vi.fn().mockResolvedValue([]),
+    findRoleById: vi.fn().mockResolvedValue(null),
+    upsertRole: vi.fn().mockResolvedValue(makeRole()),
+    deleteRole: vi.fn().mockResolvedValue(undefined),
+    listGrades: vi.fn().mockResolvedValue([]),
+    findGradeById: vi.fn().mockResolvedValue(null),
+    upsertGrade: vi.fn().mockResolvedValue(makeGrade()),
+    deleteGrade: vi.fn().mockResolvedValue(undefined),
+  }
+}
+
+function makeEmitterMock(): AuditLogEmitter {
+  return { emit: vi.fn().mockResolvedValue(undefined) }
+}
+
+function makeService(repo = makeRepoMock(), emitter = makeEmitterMock()) {
+  const svc = createMasterService({ repo, auditLogEmitter: emitter })
+  return { svc, repo, emitter }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Skills
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('MasterService - skills', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('upsertSkill は repo に委譲し、作成結果を返す', async () => {
+    const created = makeSkill({ name: 'Rust' })
+    const repo = makeRepoMock()
+    repo.upsertSkill = vi.fn().mockResolvedValue(created)
+    const { svc } = makeService(repo)
+
+    const result = await svc.upsertSkill({ name: 'Rust', category: 'language' })
+
+    expect(result).toEqual(created)
+    expect(repo.upsertSkill).toHaveBeenCalledWith({ name: 'Rust', category: 'language' })
+  })
+
+  it('deprecateSkill は該当 skill がなければ MasterNotFoundError', async () => {
+    const repo = makeRepoMock()
+    repo.findSkillById = vi.fn().mockResolvedValue(null)
+    const { svc } = makeService(repo)
+
+    await expect(svc.deprecateSkill(toSkillMasterId('missing'))).rejects.toBeInstanceOf(
+      MasterNotFoundError,
+    )
+    expect(repo.deprecateSkill).not.toHaveBeenCalled()
+  })
+
+  it('deprecateSkill は該当 skill があれば repo を呼ぶ', async () => {
+    const repo = makeRepoMock()
+    repo.findSkillById = vi.fn().mockResolvedValue(makeSkill())
+    const { svc } = makeService(repo)
+
+    await svc.deprecateSkill(toSkillMasterId('skill-1'))
+
+    expect(repo.deprecateSkill).toHaveBeenCalledWith('skill-1')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Roles
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('MasterService - roles', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('upsertRole は repo に委譲し、永続化された role を返す', async () => {
+    const persisted = makeRole({ name: 'Senior Engineer' })
+    const repo = makeRepoMock()
+    repo.upsertRole = vi.fn().mockResolvedValue(persisted)
+    const { svc } = makeService(repo)
+
+    const result = await svc.upsertRole({
+      name: 'Senior Engineer',
+      gradeId: 'grade-1',
+      skillRequirements: [{ skillId: 'skill-1', requiredLevel: 4 }],
+    })
+
+    expect(result).toEqual(persisted)
+    expect(repo.upsertRole).toHaveBeenCalledOnce()
+  })
+
+  it('deleteRole は該当 role がなければ MasterNotFoundError', async () => {
+    const repo = makeRepoMock()
+    repo.findRoleById = vi.fn().mockResolvedValue(null)
+    const { svc } = makeService(repo)
+
+    await expect(svc.deleteRole(toRoleMasterId('missing'))).rejects.toBeInstanceOf(
+      MasterNotFoundError,
+    )
+    expect(repo.deleteRole).not.toHaveBeenCalled()
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Grades
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('MasterService - grades', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('upsertGrade はウェイト合計が 1 でない場合 GradeWeightSumError', async () => {
+    const { svc } = makeService()
+
+    await expect(
+      svc.upsertGrade(
+        {
+          id: 'grade-1',
+          label: 'G3',
+          performanceWeight: 0.5,
+          goalWeight: 0.3,
+          feedbackWeight: 0.1,
+        },
+        ADMIN_USER,
+      ),
+    ).rejects.toBeInstanceOf(GradeWeightSumError)
+  })
+
+  it('deleteGrade は該当 grade がなければ MasterNotFoundError', async () => {
+    const repo = makeRepoMock()
+    repo.findGradeById = vi.fn().mockResolvedValue(null)
+    const { svc } = makeService(repo)
+
+    await expect(svc.deleteGrade(toGradeMasterId('missing'))).rejects.toBeInstanceOf(
+      MasterNotFoundError,
+    )
+    expect(repo.deleteGrade).not.toHaveBeenCalled()
+  })
+})

--- a/src/tests/master/skills-route.test.ts
+++ b/src/tests/master/skills-route.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Issue #24: GET / POST /api/masters/skills ルートハンドラのテスト
+ *
+ * - 認証ガード (401 / 403)
+ * - バリデーション (422)
+ * - 正常系 (200 / 201)
+ * - ドメインエラーマッピング (409: MasterNameConflictError)
+ * - サービス未初期化 (503)
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import { MasterNameConflictError } from '@/lib/master/master-types'
+import type { MasterService } from '@/lib/master/master-service'
+import {
+  setMasterServiceForTesting,
+  clearMasterServiceForTesting,
+} from '@/lib/master/master-service-di'
+
+vi.mock('next-auth', () => ({
+  getServerSession: vi.fn(),
+}))
+
+const { getServerSession } = await import('next-auth')
+const mockedGetServerSession = vi.mocked(getServerSession)
+
+const { GET, POST } = await import('@/app/api/masters/skills/route')
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+function makeGetRequest(query = ''): NextRequest {
+  return new NextRequest(`http://localhost/api/masters/skills${query}`)
+}
+
+function makePostRequest(body: unknown): NextRequest {
+  return new NextRequest('http://localhost/api/masters/skills', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+function makeAdminSession(userId = 'admin-1') {
+  return { user: { email: 'admin@example.com' }, role: 'ADMIN', userId }
+}
+
+function makeMasterService(overrides?: Partial<MasterService>): MasterService {
+  return {
+    listSkills: vi.fn().mockResolvedValue([]),
+    upsertSkill: vi.fn().mockResolvedValue(undefined),
+    deprecateSkill: vi.fn().mockResolvedValue(undefined),
+    listRoles: vi.fn().mockResolvedValue([]),
+    upsertRole: vi.fn().mockResolvedValue(undefined),
+    deleteRole: vi.fn().mockResolvedValue(undefined),
+    listGrades: vi.fn().mockResolvedValue([]),
+    upsertGrade: vi.fn().mockResolvedValue(undefined),
+    deleteGrade: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  } as unknown as MasterService
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+afterEach(() => {
+  clearMasterServiceForTesting()
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('GET /api/masters/skills', () => {
+  it('未認証は 401', async () => {
+    mockedGetServerSession.mockResolvedValue(null)
+    const res = await GET(makeGetRequest())
+    expect(res.status).toBe(401)
+  })
+
+  it('ADMIN 以外のロールは 403', async () => {
+    mockedGetServerSession.mockResolvedValue({
+      user: { email: 'hr@example.com' },
+      role: 'HR_MANAGER',
+      userId: 'hr-1',
+    })
+    setMasterServiceForTesting(makeMasterService())
+    const res = await GET(makeGetRequest())
+    expect(res.status).toBe(403)
+  })
+
+  it('正常系は 200 で一覧を返す', async () => {
+    mockedGetServerSession.mockResolvedValue(makeAdminSession())
+    const skills = [
+      {
+        id: 'skill-1',
+        name: 'TypeScript',
+        category: 'language',
+        description: null,
+        deprecated: false,
+        createdAt: new Date('2026-04-18T00:00:00.000Z'),
+      },
+    ]
+    const svc = makeMasterService({ listSkills: vi.fn().mockResolvedValue(skills) })
+    setMasterServiceForTesting(svc)
+
+    const res = await GET(makeGetRequest())
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.success).toBe(true)
+    expect(body.data).toHaveLength(1)
+    expect(svc.listSkills).toHaveBeenCalledWith(false)
+  })
+
+  it('includeDeprecated=true クエリを MasterService に伝播する', async () => {
+    mockedGetServerSession.mockResolvedValue(makeAdminSession())
+    const svc = makeMasterService({ listSkills: vi.fn().mockResolvedValue([]) })
+    setMasterServiceForTesting(svc)
+
+    await GET(makeGetRequest('?includeDeprecated=true'))
+    expect(svc.listSkills).toHaveBeenCalledWith(true)
+  })
+
+  it('サービス未初期化は 503', async () => {
+    mockedGetServerSession.mockResolvedValue(makeAdminSession())
+    const res = await GET(makeGetRequest())
+    expect(res.status).toBe(503)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// POST
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('POST /api/masters/skills', () => {
+  it('未認証は 401', async () => {
+    mockedGetServerSession.mockResolvedValue(null)
+    const res = await POST(makePostRequest({ name: 'Rust', category: 'language' }))
+    expect(res.status).toBe(401)
+  })
+
+  it('バリデーションエラー(name 欠落)は 422', async () => {
+    mockedGetServerSession.mockResolvedValue(makeAdminSession())
+    setMasterServiceForTesting(makeMasterService())
+    const res = await POST(makePostRequest({ category: 'language' }))
+    expect(res.status).toBe(422)
+  })
+
+  it('正常系は 201 で作成結果を返す', async () => {
+    mockedGetServerSession.mockResolvedValue(makeAdminSession())
+    const created = {
+      id: 'skill-1',
+      name: 'Rust',
+      category: 'language',
+      description: null,
+      deprecated: false,
+      createdAt: new Date('2026-04-18T00:00:00.000Z'),
+    }
+    const svc = makeMasterService({ upsertSkill: vi.fn().mockResolvedValue(created) })
+    setMasterServiceForTesting(svc)
+
+    const res = await POST(makePostRequest({ name: 'Rust', category: 'language' }))
+    expect(res.status).toBe(201)
+    const body = await res.json()
+    expect(body.data.name).toBe('Rust')
+  })
+
+  it('name 一意制約違反は 409', async () => {
+    mockedGetServerSession.mockResolvedValue(makeAdminSession())
+    setMasterServiceForTesting(
+      makeMasterService({
+        upsertSkill: vi.fn().mockRejectedValue(new MasterNameConflictError('skill', 'Rust')),
+      }),
+    )
+    const res = await POST(makePostRequest({ name: 'Rust', category: 'language' }))
+    expect(res.status).toBe(409)
+  })
+
+  it('サービス未初期化は 503', async () => {
+    mockedGetServerSession.mockResolvedValue(makeAdminSession())
+    const res = await POST(makePostRequest({ name: 'Rust', category: 'language' }))
+    expect(res.status).toBe(503)
+  })
+})


### PR DESCRIPTION
## Summary

- SkillMaster / RoleMaster / GradeMaster の4モデルを Prisma スキーマに追加
- MasterRepository (port + PrismaMasterRepository 実装) でスキル/役職/等級の CRUD を提供
- MasterService でドメイン検証 (`assertGradeWeightsSumToOne`) とリポジトリ委譲を実装
- `/api/masters/{skills,roles,grades}` の CRUD API ルートを ADMIN 権限限定で実装
- Prisma migration SQL (`master-data.sql`) を追加 (grade_weight_histories テーブルは含まない)

## Test plan

- [x] `MasterService` 単体テスト 7件 (upsertSkill / deprecateSkill / upsertRole / deleteRole / upsertGrade weight validation / deleteGrade)
- [x] `GET /api/masters/skills` / `POST /api/masters/skills` ルートテスト 10件 (401/403/422/201/409/503)
- [ ] `PUT /api/masters/skills/:id`, `DELETE /api/masters/skills/:id` の手動動作確認
- [ ] roles / grades エンドポイントの手動動作確認

Closes #24