### PR TITLE
Feat/task 6 5 user invitation

### DIFF
--- a/prisma/migrations/master-data.sql
+++ b/prisma/migrations/master-data.sql
@@ -1,9 +1,6 @@
 -- マスタ管理テーブル (Requirement 2)
 -- Issue #24: スキル・役職・等級マスタの CRUD
-<<<<<<< HEAD
 -- Issue #25: マスタ変更の監査ログ連携
-=======
->>>>>>> d0a9ccabe5005090ea6ee73e6e016f1360c76691
 
 -- スキルマスタ (Requirement 2.1, 2.4)
 CREATE TABLE IF NOT EXISTS skill_masters (
@@ -48,7 +45,6 @@ CREATE TABLE IF NOT EXISTS grade_masters (
   "goalWeight"        DOUBLE PRECISION NOT NULL,
   "feedbackWeight"    DOUBLE PRECISION NOT NULL
 );
-<<<<<<< HEAD
 
 -- 等級ウェイト変更履歴 (Requirement 2.6)
 CREATE TABLE IF NOT EXISTS grade_weight_histories (
@@ -63,5 +59,3 @@ CREATE TABLE IF NOT EXISTS grade_weight_histories (
 );
 
 CREATE INDEX IF NOT EXISTS grade_weight_histories_grade_id_idx ON grade_weight_histories ("gradeId");
-=======
->>>>>>> d0a9ccabe5005090ea6ee73e6e016f1360c76691

--- a/prisma/migrations/organization.sql
+++ b/prisma/migrations/organization.sql
@@ -1,0 +1,40 @@
+-- 組織管理テーブル (Requirement 3)
+-- Issue #27: Department / Position / TransferRecord の DDL
+-- Department の parent / Position の supervisor は自己参照。論理削除は deletedAt で表現。
+
+-- 部署 (Requirement 3.6)
+CREATE TABLE IF NOT EXISTS departments (
+  id          TEXT         NOT NULL PRIMARY KEY,
+  name        TEXT         NOT NULL,
+  "parentId"  TEXT,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "deletedAt" TIMESTAMP(3)
+);
+
+CREATE INDEX IF NOT EXISTS departments_parent_id_idx ON departments ("parentId");
+
+-- ポジション (Requirement 3.6, 3.7)
+CREATE TABLE IF NOT EXISTS positions (
+  id                     TEXT NOT NULL PRIMARY KEY,
+  "departmentId"         TEXT NOT NULL,
+  "roleId"               TEXT NOT NULL,
+  "holderUserId"         TEXT,
+  "supervisorPositionId" TEXT
+);
+
+CREATE INDEX IF NOT EXISTS positions_department_id_idx ON positions ("departmentId");
+CREATE INDEX IF NOT EXISTS positions_supervisor_position_id_idx ON positions ("supervisorPositionId");
+
+-- 異動履歴 (Requirement 3.7)
+CREATE TABLE IF NOT EXISTS transfer_records (
+  id               TEXT         NOT NULL PRIMARY KEY,
+  "userId"         TEXT         NOT NULL,
+  "fromPositionId" TEXT,
+  "toPositionId"   TEXT,
+  "effectiveDate"  TIMESTAMP(3) NOT NULL,
+  "changedBy"      TEXT         NOT NULL,
+  "createdAt"      TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS transfer_records_user_id_effective_date_idx
+  ON transfer_records ("userId", "effectiveDate");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -283,20 +283,14 @@ model RoleSkillRequirement {
 /// 等級マスタ (Requirement 2.3)
 /// w1+w2+w3 = 1 はアプリ層で検証
 model GradeMaster {
-<<<<<<< HEAD
   id                String               @id @default(cuid())
   label             String               @unique
-=======
-  id                String @id @default(cuid())
-  label             String @unique
->>>>>>> d0a9ccabe5005090ea6ee73e6e016f1360c76691
   /// 業績評価ウェイト (w1)
   performanceWeight Float
   /// 目標評価ウェイト (w2)
   goalWeight        Float
   /// 360度評価ウェイト (w3)
   feedbackWeight    Float
-<<<<<<< HEAD
   weightHistory     GradeWeightHistory[]
 
   @@map("grade_masters")
@@ -316,8 +310,49 @@ model GradeWeightHistory {
   @@index([gradeId])
   @@map("grade_weight_histories")
 }
-=======
 
-  @@map("grade_masters")
+// ─────────────────────────────────────────────────────────────────────────────
+// 組織管理 (Requirement 3)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// 部署 (Requirement 3.6)
+/// 階層構造は parentId による自己参照で表現し、deletedAt による論理削除をサポート。
+model Department {
+  id        String    @id @default(cuid())
+  name      String
+  parentId  String?
+  createdAt DateTime  @default(now())
+  deletedAt DateTime?
+
+  @@index([parentId])
+  @@map("departments")
 }
->>>>>>> d0a9ccabe5005090ea6ee73e6e016f1360c76691
+
+/// ポジション (Requirement 3.6, 3.7)
+/// supervisorPositionId による上下関係、holderUserId による担当者割当を表現する。
+model Position {
+  id                   String  @id @default(cuid())
+  departmentId         String
+  roleId               String
+  holderUserId         String?
+  supervisorPositionId String?
+
+  @@index([departmentId])
+  @@index([supervisorPositionId])
+  @@map("positions")
+}
+
+/// 異動履歴 (Requirement 3.7)
+/// ポジション変更時に追記される append-only なイベントレコード。
+model TransferRecord {
+  id             String   @id @default(cuid())
+  userId         String
+  fromPositionId String?
+  toPositionId   String?
+  effectiveDate  DateTime
+  changedBy      String
+  createdAt      DateTime @default(now())
+
+  @@index([userId, effectiveDate])
+  @@map("transfer_records")
+}

--- a/src/app/api/lifecycle/employees/import/route.ts
+++ b/src/app/api/lifecycle/employees/import/route.ts
@@ -1,0 +1,112 @@
+/**
+ * Issue #29 / Req 14.9: 社員 CSV 一括インポート API
+ *
+ * POST /api/lifecycle/employees/import
+ * - ADMIN または HR_MANAGER のみ実行可能
+ * - multipart/form-data で `file` フィールド（CSV）を受け取る
+ * - BulkImportResult を返却
+ *   - 全件成功: 201
+ *   - 部分失敗: 207 Multi-Status
+ * - 422 / 413 / 401 / 403 / 503 は共通
+ */
+import { getServerSession } from 'next-auth'
+import { type NextRequest, NextResponse } from 'next/server'
+import { getLifecycleService } from '@/lib/lifecycle/lifecycle-service-di'
+
+export {
+  setLifecycleServiceForTesting,
+  clearLifecycleServiceForTesting,
+} from '@/lib/lifecycle/lifecycle-service-di'
+
+const MAX_CSV_BYTES = 5 * 1024 * 1024 // 5MB
+const ALLOWED_ROLES = new Set<string>(['ADMIN', 'HR_MANAGER'])
+const STATUS_MULTI_STATUS = 207
+const STATUS_CREATED = 201
+
+interface AuthorizedSession {
+  readonly userId: string
+}
+
+function authorize(
+  serverSession: Awaited<ReturnType<typeof getServerSession>>,
+): { ok: true; session: AuthorizedSession } | { ok: false; response: NextResponse } {
+  if (!serverSession?.user?.email) {
+    return { ok: false, response: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
+  }
+  const sess = serverSession as Record<string, unknown>
+  const role = typeof sess.role === 'string' ? sess.role : undefined
+  const userId = typeof sess.userId === 'string' ? sess.userId : undefined
+  if (!role || !ALLOWED_ROLES.has(role) || !userId) {
+    return { ok: false, response: NextResponse.json({ error: 'Forbidden' }, { status: 403 }) }
+  }
+  return { ok: true, session: { userId } }
+}
+
+async function extractCsvFile(
+  request: NextRequest,
+): Promise<{ ok: true; buffer: Buffer } | { ok: false; response: NextResponse }> {
+  let form: FormData
+  try {
+    form = await request.formData()
+  } catch {
+    return {
+      ok: false,
+      response: NextResponse.json({ error: 'Invalid multipart/form-data body' }, { status: 400 }),
+    }
+  }
+
+  const file = form.get('file')
+  if (!(file instanceof File)) {
+    return {
+      ok: false,
+      response: NextResponse.json({ error: 'file field is required' }, { status: 422 }),
+    }
+  }
+  if (file.size === 0) {
+    return { ok: false, response: NextResponse.json({ error: 'file is empty' }, { status: 422 }) }
+  }
+  if (file.size > MAX_CSV_BYTES) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: `file exceeds ${MAX_CSV_BYTES} bytes` },
+        { status: 413 },
+      ),
+    }
+  }
+
+  const arrayBuf = await file.arrayBuffer()
+  return { ok: true, buffer: Buffer.from(arrayBuf) }
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const auth = authorize(await getServerSession())
+  if (!auth.ok) return auth.response
+
+  const fileResult = await extractCsvFile(request)
+  if (!fileResult.ok) return fileResult.response
+
+  let svc: ReturnType<typeof getLifecycleService>
+  try {
+    svc = getLifecycleService()
+  } catch {
+    return NextResponse.json({ error: 'Lifecycle service not initialized' }, { status: 503 })
+  }
+
+  try {
+    const result = await svc.bulkImportUsers(fileResult.buffer, auth.session.userId)
+    const status = result.failureCount === 0 ? STATUS_CREATED : STATUS_MULTI_STATUS
+    return NextResponse.json(
+      {
+        totalRows: result.totalRows,
+        successCount: result.successCount,
+        failureCount: result.failureCount,
+        errors: result.errors,
+        jobId: result.jobId,
+      },
+      { status },
+    )
+  } catch {
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/api/lifecycle/employees/route.ts
+++ b/src/app/api/lifecycle/employees/route.ts
@@ -1,0 +1,93 @@
+/**
+ * Issue #29 / Req 14.1: 社員作成 API
+ *
+ * POST /api/lifecycle/employees
+ * - ADMIN または HR_MANAGER のみ実行可能
+ * - body: CreateEmployeeInput (hireDate は YYYY-MM-DD)
+ * - 201: 作成された社員の基本情報
+ * - 422: バリデーションエラー
+ * - 401 / 403: 認証/認可エラー
+ * - 409: email 重複
+ * - 503: サービス未初期化
+ */
+import { getServerSession } from 'next-auth'
+import { type NextRequest, NextResponse } from 'next/server'
+import { getLifecycleService } from '@/lib/lifecycle/lifecycle-service-di'
+import {
+  createEmployeeInputSchema,
+  EmployeeAlreadyExistsError,
+  type Employee,
+} from '@/lib/lifecycle/lifecycle-types'
+
+export {
+  setLifecycleServiceForTesting,
+  clearLifecycleServiceForTesting,
+} from '@/lib/lifecycle/lifecycle-service-di'
+
+const ALLOWED_ROLES = new Set<string>(['ADMIN', 'HR_MANAGER'])
+
+interface AuthorizedSession {
+  readonly userId: string
+}
+
+function authorize(
+  serverSession: Awaited<ReturnType<typeof getServerSession>>,
+): { ok: true; session: AuthorizedSession } | { ok: false; response: NextResponse } {
+  if (!serverSession?.user?.email) {
+    return { ok: false, response: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
+  }
+  const sess = serverSession as Record<string, unknown>
+  const role = typeof sess.role === 'string' ? sess.role : undefined
+  const userId = typeof sess.userId === 'string' ? sess.userId : undefined
+  if (!role || !ALLOWED_ROLES.has(role) || !userId) {
+    return { ok: false, response: NextResponse.json({ error: 'Forbidden' }, { status: 403 }) }
+  }
+  return { ok: true, session: { userId } }
+}
+
+function toResponsePayload(employee: Employee): Record<string, unknown> {
+  return {
+    id: employee.id,
+    email: employee.email,
+    firstName: employee.firstName,
+    lastName: employee.lastName,
+    role: employee.role,
+    hireDate: employee.hireDate.toISOString().slice(0, 10),
+    departmentId: employee.departmentId,
+    positionId: employee.positionId,
+  }
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const auth = authorize(await getServerSession())
+  if (!auth.ok) return auth.response
+
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
+  }
+
+  const parsed = createEmployeeInputSchema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.flatten() }, { status: 422 })
+  }
+
+  let svc: ReturnType<typeof getLifecycleService>
+  try {
+    svc = getLifecycleService()
+  } catch {
+    return NextResponse.json({ error: 'Lifecycle service not initialized' }, { status: 503 })
+  }
+
+  try {
+    const employee = await svc.createEmployee(parsed.data, auth.session.userId)
+    return NextResponse.json(toResponsePayload(employee), { status: 201 })
+  } catch (err) {
+    if (err instanceof EmployeeAlreadyExistsError) {
+      return NextResponse.json({ error: 'Email already exists', email: err.email }, { status: 409 })
+    }
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/api/organization/commit/route.ts
+++ b/src/app/api/organization/commit/route.ts
@@ -1,0 +1,62 @@
+/**
+ * Issue #27 / Req 3.3, 3.4: 組織変更確定 API (HR_MANAGER / ADMIN)
+ *
+ * - POST /api/organization/commit  body: { changes: OrgChange[] }
+ *   循環参照があれば 422 を返し、DB 保存は行わない。
+ *   成功時は ORGANIZATION_CHANGE の監査ログを発行する (service 内で実施)。
+ */
+import { type NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+import {
+  extractOrganizationAuditContext,
+  organizationErrorToResponse,
+  parseJsonBody,
+  requireHrManager,
+} from '@/lib/organization/organization-route-helpers'
+import { getOrganizationService } from '@/lib/organization/organization-service-di'
+import { orgChangeSchema } from '@/lib/organization/organization-types'
+
+export {
+  setOrganizationServiceForTesting,
+  clearOrganizationServiceForTesting,
+} from '@/lib/organization/organization-service-di'
+
+const bodySchema = z.object({ changes: z.array(orgChangeSchema) })
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const guard = await requireHrManager()
+  if (!guard.ok) return guard.response
+
+  const parsedBody = await parseJsonBody(request)
+  if (!parsedBody.ok) return parsedBody.response
+
+  const validated = bodySchema.safeParse(parsedBody.body)
+  if (!validated.success) {
+    return NextResponse.json({ error: validated.error.flatten() }, { status: 422 })
+  }
+
+  let svc: ReturnType<typeof getOrganizationService>
+  try {
+    svc = getOrganizationService()
+  } catch {
+    return NextResponse.json({ error: 'Organization service not initialized' }, { status: 503 })
+  }
+
+  try {
+    const context = extractOrganizationAuditContext(request, guard.session.userId)
+    const result = await svc.commitHierarchyChange(validated.data.changes, context)
+    if (!result.ok) {
+      return NextResponse.json(
+        {
+          error: 'Cyclic reference',
+          kind: result.error.kind,
+          path: result.error.path,
+        },
+        { status: 422 },
+      )
+    }
+    return NextResponse.json({ success: true }, { status: 200 })
+  } catch (err) {
+    return organizationErrorToResponse(err)
+  }
+}

--- a/src/app/api/organization/export/route.ts
+++ b/src/app/api/organization/export/route.ts
@@ -1,0 +1,39 @@
+/**
+ * Issue #27 / Req 3.8: 組織データ CSV エクスポート投入 API (HR_MANAGER / ADMIN)
+ *
+ * - POST /api/organization/export
+ *   ExportJob に OrganizationCsv ジョブを投入し、jobId を返す。
+ *   実際の CSV 生成は export-worker 側で行う。
+ */
+import { type NextRequest, NextResponse } from 'next/server'
+import {
+  extractOrganizationAuditContext,
+  organizationErrorToResponse,
+  requireHrManager,
+} from '@/lib/organization/organization-route-helpers'
+import { getOrganizationService } from '@/lib/organization/organization-service-di'
+
+export {
+  setOrganizationServiceForTesting,
+  clearOrganizationServiceForTesting,
+} from '@/lib/organization/organization-service-di'
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const guard = await requireHrManager()
+  if (!guard.ok) return guard.response
+
+  let svc: ReturnType<typeof getOrganizationService>
+  try {
+    svc = getOrganizationService()
+  } catch {
+    return NextResponse.json({ error: 'Organization service not initialized' }, { status: 503 })
+  }
+
+  try {
+    const context = extractOrganizationAuditContext(request, guard.session.userId)
+    const result = await svc.exportCsv(context)
+    return NextResponse.json({ success: true, data: result }, { status: 202 })
+  } catch (err) {
+    return organizationErrorToResponse(err)
+  }
+}

--- a/src/app/api/organization/positions/[id]/holder/route.ts
+++ b/src/app/api/organization/positions/[id]/holder/route.ts
@@ -1,0 +1,79 @@
+/**
+ * Issue #27 / Req 3.7: ポジション保持者変更 API (HR_MANAGER / ADMIN)
+ *
+ * - POST /api/organization/positions/[id]/holder
+ *   body: { userId: string, newPositionId?: string | null }
+ *   ポジションに保持者を割り当て、TransferRecord を記録する。
+ *   newPositionId を null 指定で「割当解除」も可能。
+ *
+ * URL の [id] は「新しく就く先のポジション ID」として扱う。
+ */
+import { type NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+import {
+  extractOrganizationAuditContext,
+  organizationErrorToResponse,
+  parseJsonBody,
+  requireHrManager,
+} from '@/lib/organization/organization-route-helpers'
+import { getOrganizationService } from '@/lib/organization/organization-service-di'
+import { toPositionId, toUserId } from '@/lib/organization/organization-types'
+
+export {
+  setOrganizationServiceForTesting,
+  clearOrganizationServiceForTesting,
+} from '@/lib/organization/organization-service-di'
+
+const bodySchema = z.object({
+  userId: z.string().min(1),
+  /** null 指定で「離任のみ」扱い。省略時は URL の positionId を新ポジションとする */
+  newPositionId: z.string().min(1).nullable().optional(),
+})
+
+interface RouteContext {
+  readonly params: Promise<{ id: string }> | { id: string }
+}
+
+async function resolveParams(ctx: RouteContext): Promise<{ id: string }> {
+  return 'then' in ctx.params ? await ctx.params : ctx.params
+}
+
+export async function POST(request: NextRequest, ctx: RouteContext): Promise<NextResponse> {
+  const guard = await requireHrManager()
+  if (!guard.ok) return guard.response
+
+  const { id } = await resolveParams(ctx)
+  if (!id) {
+    return NextResponse.json({ error: 'Missing position id' }, { status: 400 })
+  }
+
+  const parsedBody = await parseJsonBody(request)
+  if (!parsedBody.ok) return parsedBody.response
+
+  const validated = bodySchema.safeParse(parsedBody.body)
+  if (!validated.success) {
+    return NextResponse.json({ error: validated.error.flatten() }, { status: 422 })
+  }
+
+  let svc: ReturnType<typeof getOrganizationService>
+  try {
+    svc = getOrganizationService()
+  } catch {
+    return NextResponse.json({ error: 'Organization service not initialized' }, { status: 503 })
+  }
+
+  try {
+    const context = extractOrganizationAuditContext(request, guard.session.userId)
+    const newPositionIdRaw =
+      validated.data.newPositionId !== undefined ? validated.data.newPositionId : id
+    const newPositionId = newPositionIdRaw ? toPositionId(newPositionIdRaw) : null
+    const transfer = await svc.changePosition(
+      toUserId(validated.data.userId),
+      newPositionId,
+      context,
+    )
+    return NextResponse.json({ success: true, data: transfer }, { status: 201 })
+  } catch (err) {
+    return organizationErrorToResponse(err)
+  }
+}

--- a/src/app/api/organization/preview/route.ts
+++ b/src/app/api/organization/preview/route.ts
@@ -1,0 +1,50 @@
+/**
+ * Issue #27 / Req 3.3, 3.4: 組織変更プレビュー API (HR_MANAGER / ADMIN)
+ *
+ * - POST /api/organization/preview  body: { changes: OrgChange[] }
+ *   循環参照が発生する場合も、警告を summary に含めて 200 で返す。
+ *   コミット時点での循環参照は 422 になる (commit ルート参照)。
+ */
+import { type NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+import {
+  organizationErrorToResponse,
+  parseJsonBody,
+  requireHrManager,
+} from '@/lib/organization/organization-route-helpers'
+import { getOrganizationService } from '@/lib/organization/organization-service-di'
+import { orgChangeSchema } from '@/lib/organization/organization-types'
+
+export {
+  setOrganizationServiceForTesting,
+  clearOrganizationServiceForTesting,
+} from '@/lib/organization/organization-service-di'
+
+const bodySchema = z.object({ changes: z.array(orgChangeSchema) })
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const guard = await requireHrManager()
+  if (!guard.ok) return guard.response
+
+  const parsedBody = await parseJsonBody(request)
+  if (!parsedBody.ok) return parsedBody.response
+
+  const validated = bodySchema.safeParse(parsedBody.body)
+  if (!validated.success) {
+    return NextResponse.json({ error: validated.error.flatten() }, { status: 422 })
+  }
+
+  let svc: ReturnType<typeof getOrganizationService>
+  try {
+    svc = getOrganizationService()
+  } catch {
+    return NextResponse.json({ error: 'Organization service not initialized' }, { status: 503 })
+  }
+
+  try {
+    const preview = await svc.previewHierarchyChange(validated.data.changes)
+    return NextResponse.json({ success: true, data: preview })
+  } catch (err) {
+    return organizationErrorToResponse(err)
+  }
+}

--- a/src/app/api/organization/tree/route.ts
+++ b/src/app/api/organization/tree/route.ts
@@ -1,0 +1,35 @@
+/**
+ * Issue #27 / Req 3.6: 組織ツリー取得 API (HR_MANAGER / ADMIN)
+ *
+ * - GET /api/organization/tree
+ */
+import { NextResponse } from 'next/server'
+import {
+  organizationErrorToResponse,
+  requireHrManager,
+} from '@/lib/organization/organization-route-helpers'
+import { getOrganizationService } from '@/lib/organization/organization-service-di'
+
+export {
+  setOrganizationServiceForTesting,
+  clearOrganizationServiceForTesting,
+} from '@/lib/organization/organization-service-di'
+
+export async function GET(): Promise<NextResponse> {
+  const guard = await requireHrManager()
+  if (!guard.ok) return guard.response
+
+  let svc: ReturnType<typeof getOrganizationService>
+  try {
+    svc = getOrganizationService()
+  } catch {
+    return NextResponse.json({ error: 'Organization service not initialized' }, { status: 503 })
+  }
+
+  try {
+    const tree = await svc.getCurrentTree()
+    return NextResponse.json({ success: true, data: tree })
+  } catch (err) {
+    return organizationErrorToResponse(err)
+  }
+}

--- a/src/app/organization/my-team/page.tsx
+++ b/src/app/organization/my-team/page.tsx
@@ -1,0 +1,124 @@
+/**
+ * Issue #28 / Req 3.5: MANAGER 向け直属メンバー一覧画面
+ *
+ * - マウント時に GET /api/organization/my-team を取得
+ * - 自分の部署情報と直属メンバーをカード + MemberList で表示
+ * - ローディング / エラー / 空状態を適切にハンドリング
+ *
+ * MANAGER 以外のアクセスはサーバ側で 403 とする想定。
+ */
+'use client'
+
+import { useEffect, useState, type ReactElement } from 'react'
+import type { MyTeamResponse } from '@/lib/organization/organization-types'
+import { MemberList } from '@/components/organization/MemberList'
+
+type LoadState =
+  | { readonly kind: 'loading' }
+  | { readonly kind: 'error'; readonly message: string }
+  | { readonly kind: 'ready'; readonly data: MyTeamResponse }
+
+const MY_TEAM_URL = '/api/organization/my-team'
+
+export default function MyTeamPage(): ReactElement {
+  const [state, setState] = useState<LoadState>({ kind: 'loading' })
+
+  useEffect(() => {
+    let cancelled = false
+    void (async () => {
+      try {
+        const res = await fetch(MY_TEAM_URL, { cache: 'no-store' })
+        if (!res.ok) {
+          throw new Error(`Failed to load my-team: ${res.status}`)
+        }
+        const data = (await res.json()) as MyTeamResponse
+        if (cancelled) return
+        setState({ kind: 'ready', data })
+      } catch (err) {
+        if (cancelled) return
+        setState({ kind: 'error', message: readError(err) })
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  return (
+    <main className="mx-auto max-w-4xl px-6 py-10">
+      <header className="mb-8">
+        <p className="text-xs font-semibold tracking-widest text-emerald-600 uppercase">My Team</p>
+        <h1 className="mt-1 text-3xl font-bold text-slate-900">直属メンバー</h1>
+        <p className="mt-2 text-sm text-slate-600">
+          あなたが上長として登録されているメンバーを確認できます。
+        </p>
+      </header>
+      <Body state={state} />
+    </main>
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// サブコンポーネント
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface BodyProps {
+  readonly state: LoadState
+}
+
+function Body(props: BodyProps): ReactElement {
+  const { state } = props
+  if (state.kind === 'loading') {
+    return (
+      <div className="flex items-center justify-center rounded-xl border border-slate-200 bg-white py-16 text-sm text-slate-500">
+        <span className="animate-pulse">チーム情報を読み込み中…</span>
+      </div>
+    )
+  }
+  if (state.kind === 'error') {
+    return (
+      <div className="rounded-xl border border-rose-300 bg-rose-50 p-6 text-sm text-rose-800">
+        <p className="font-semibold">情報の取得に失敗しました</p>
+        <p className="mt-1 text-xs">{state.message}</p>
+      </div>
+    )
+  }
+  return (
+    <div className="space-y-6">
+      <ManagerSummary
+        managerName={state.data.managerName}
+        departmentName={state.data.departmentName}
+      />
+      <section>
+        <h2 className="mb-3 text-sm font-semibold text-slate-700">
+          メンバー ({state.data.directReports.length} 名)
+        </h2>
+        <MemberList members={state.data.directReports} />
+      </section>
+    </div>
+  )
+}
+
+interface ManagerSummaryProps {
+  readonly managerName: string
+  readonly departmentName: string
+}
+
+function ManagerSummary(props: ManagerSummaryProps): ReactElement {
+  return (
+    <section className="flex flex-col gap-1 rounded-xl border border-slate-200 bg-gradient-to-br from-white to-slate-50 p-6 shadow-sm">
+      <p className="text-xs tracking-wider text-slate-500 uppercase">Manager</p>
+      <p className="text-xl font-semibold text-slate-900">{props.managerName}</p>
+      <p className="text-sm text-slate-600">{props.departmentName}</p>
+    </section>
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ユーティリティ
+// ─────────────────────────────────────────────────────────────────────────────
+
+function readError(err: unknown): string {
+  if (err instanceof Error) return err.message
+  return '予期せぬエラーが発生しました'
+}

--- a/src/app/organization/page.tsx
+++ b/src/app/organization/page.tsx
@@ -1,0 +1,321 @@
+/**
+ * Issue #28 / Req 3.1, 3.2: 組織管理画面 (HR_MANAGER 向け)
+ *
+ * - マウント時に GET /api/organization/tree を取得
+ * - OrganizationChart でインタラクティブにドラッグ&ドロップ
+ * - 変更差分があるときだけ「変更をプレビュー」「確定」ボタンを活性化
+ * - 確定時は POST /api/organization/commit で operations を送信
+ *
+ * HR_MANAGER 以外のアクセスはサーバ側で弾かれる想定。UI 側は role を
+ * クライアント状態として受け取り、編集可否 (editable) を切り替える。
+ */
+'use client'
+
+import { useCallback, useEffect, useState, type ReactElement } from 'react'
+import type {
+  OrgTree,
+  OrgMoveOperation,
+  OrgCommitResponse,
+} from '@/lib/organization/organization-types'
+import { OrgChangeError } from '@/lib/organization/organization-types'
+import { hasStructuralDiff, flattenNodes } from '@/lib/organization/org-tree-ops'
+import { OrganizationChart } from '@/components/organization/OrganizationChart'
+
+type LoadState =
+  | { readonly kind: 'loading' }
+  | { readonly kind: 'error'; readonly message: string }
+  | { readonly kind: 'ready'; readonly original: OrgTree; readonly current: OrgTree }
+
+type CommitState =
+  | { readonly kind: 'idle' }
+  | { readonly kind: 'saving' }
+  | { readonly kind: 'success'; readonly applied: number }
+  | { readonly kind: 'error'; readonly message: string }
+
+const ORG_TREE_URL = '/api/organization/tree'
+const ORG_COMMIT_URL = '/api/organization/commit'
+
+export default function OrganizationPage(): ReactElement {
+  const [loadState, setLoadState] = useState<LoadState>({ kind: 'loading' })
+  const [commitState, setCommitState] = useState<CommitState>({ kind: 'idle' })
+  const [dragError, setDragError] = useState<string | null>(null)
+  // HR_MANAGER role を仮定 (実際のユーザロール判定は認証層が行う想定)
+  const editable = true
+
+  useEffect(() => {
+    let cancelled = false
+    void (async () => {
+      try {
+        const res = await fetch(ORG_TREE_URL, { cache: 'no-store' })
+        if (!res.ok) {
+          throw new Error(`Failed to load org tree: ${res.status}`)
+        }
+        const tree = (await res.json()) as OrgTree
+        if (cancelled) return
+        setLoadState({ kind: 'ready', original: tree, current: tree })
+      } catch (err) {
+        if (cancelled) return
+        setLoadState({ kind: 'error', message: readError(err) })
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const handleTreeChange = useCallback((next: OrgTree) => {
+    setLoadState((prev) => (prev.kind === 'ready' ? { ...prev, current: next } : prev))
+    setCommitState({ kind: 'idle' })
+    setDragError(null)
+  }, [])
+
+  const handleDragError = useCallback((err: OrgChangeError) => {
+    setDragError(translateOrgChangeError(err))
+  }, [])
+
+  const handleReset = useCallback(() => {
+    setLoadState((prev) => (prev.kind === 'ready' ? { ...prev, current: prev.original } : prev))
+    setCommitState({ kind: 'idle' })
+    setDragError(null)
+  }, [])
+
+  const handleCommit = useCallback(async () => {
+    if (loadState.kind !== 'ready') return
+    const operations = diffOperations(loadState.original, loadState.current)
+    if (operations.length === 0) return
+    setCommitState({ kind: 'saving' })
+    try {
+      const body = JSON.stringify({ operations })
+      const res = await fetch(ORG_COMMIT_URL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body,
+      })
+      if (!res.ok) {
+        const msg = await readServerError(res)
+        throw new Error(msg)
+      }
+      const payload = (await res.json()) as OrgCommitResponse
+      setCommitState({ kind: 'success', applied: payload.appliedOperations })
+      setLoadState((prev) => (prev.kind === 'ready' ? { ...prev, original: prev.current } : prev))
+    } catch (err) {
+      setCommitState({ kind: 'error', message: readError(err) })
+    }
+  }, [loadState])
+
+  return (
+    <main className="mx-auto max-w-6xl px-6 py-10">
+      <Header />
+      <PageBody
+        loadState={loadState}
+        commitState={commitState}
+        dragError={dragError}
+        editable={editable}
+        onTreeChange={handleTreeChange}
+        onDragError={handleDragError}
+        onReset={handleReset}
+        onCommit={handleCommit}
+      />
+    </main>
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// サブコンポーネント
+// ─────────────────────────────────────────────────────────────────────────────
+
+function Header(): ReactElement {
+  return (
+    <header className="mb-8">
+      <p className="text-xs font-semibold tracking-widest text-indigo-600 uppercase">
+        Organization
+      </p>
+      <h1 className="mt-1 text-3xl font-bold text-slate-900">組織管理</h1>
+      <p className="mt-2 text-sm text-slate-600">
+        ノードをドラッグ&ドロップして組織構造を編集できます。変更は確定するまで保存されません。
+      </p>
+    </header>
+  )
+}
+
+interface PageBodyProps {
+  readonly loadState: LoadState
+  readonly commitState: CommitState
+  readonly dragError: string | null
+  readonly editable: boolean
+  readonly onTreeChange: (t: OrgTree) => void
+  readonly onDragError: (err: OrgChangeError) => void
+  readonly onReset: () => void
+  readonly onCommit: () => void
+}
+
+function PageBody(props: PageBodyProps): ReactElement {
+  const { loadState } = props
+  if (loadState.kind === 'loading') return <LoadingCard />
+  if (loadState.kind === 'error') return <ErrorCard message={loadState.message} />
+
+  const changed = hasStructuralDiff(loadState.original, loadState.current)
+  const pendingOps = diffOperations(loadState.original, loadState.current)
+
+  return (
+    <section className="space-y-6">
+      <Toolbar
+        changed={changed}
+        commitState={props.commitState}
+        pendingCount={pendingOps.length}
+        onReset={props.onReset}
+        onCommit={props.onCommit}
+      />
+      {props.dragError && <InlineBanner tone="error" message={props.dragError} />}
+      {changed && (
+        <InlineBanner
+          tone="info"
+          message={`未確定の変更が ${pendingOps.length} 件あります。内容を確認して確定してください。`}
+        />
+      )}
+      <OrganizationChart
+        tree={loadState.current}
+        editable={props.editable}
+        onTreeChange={props.onTreeChange}
+        onError={props.onDragError}
+      />
+    </section>
+  )
+}
+
+function LoadingCard(): ReactElement {
+  return (
+    <div className="flex items-center justify-center rounded-xl border border-slate-200 bg-white py-16 text-sm text-slate-500">
+      <span className="animate-pulse">組織データを読み込み中…</span>
+    </div>
+  )
+}
+
+interface ErrorCardProps {
+  readonly message: string
+}
+
+function ErrorCard(props: ErrorCardProps): ReactElement {
+  return (
+    <div className="rounded-xl border border-rose-300 bg-rose-50 p-6 text-sm text-rose-800">
+      <p className="font-semibold">組織データの取得に失敗しました</p>
+      <p className="mt-1 text-xs">{props.message}</p>
+    </div>
+  )
+}
+
+interface ToolbarProps {
+  readonly changed: boolean
+  readonly commitState: CommitState
+  readonly pendingCount: number
+  readonly onReset: () => void
+  readonly onCommit: () => void
+}
+
+function Toolbar(props: ToolbarProps): ReactElement {
+  const saving = props.commitState.kind === 'saving'
+  const disabledCommit = !props.changed || saving
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-slate-200 bg-white px-4 py-3 shadow-sm">
+      <div className="text-xs text-slate-600">
+        {props.changed ? `変更あり (${props.pendingCount} 件)` : '変更はありません'}
+        {props.commitState.kind === 'success' && (
+          <span className="ml-2 font-semibold text-emerald-600">
+            ✓ {props.commitState.applied} 件の変更を保存しました
+          </span>
+        )}
+        {props.commitState.kind === 'error' && (
+          <span className="ml-2 font-semibold text-rose-600">
+            保存失敗: {props.commitState.message}
+          </span>
+        )}
+      </div>
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={props.onReset}
+          disabled={!props.changed || saving}
+          className="rounded-md border border-slate-300 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 transition-colors hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          変更を破棄
+        </button>
+        <button
+          type="button"
+          onClick={props.onCommit}
+          disabled={disabledCommit}
+          className="rounded-md bg-indigo-600 px-4 py-1.5 text-xs font-semibold text-white transition-colors hover:bg-indigo-700 disabled:cursor-not-allowed disabled:bg-slate-300"
+        >
+          {saving ? '保存中…' : '変更を確定'}
+        </button>
+      </div>
+    </div>
+  )
+}
+
+interface BannerProps {
+  readonly tone: 'info' | 'error'
+  readonly message: string
+}
+
+function InlineBanner(props: BannerProps): ReactElement {
+  const cls =
+    props.tone === 'error'
+      ? 'border-rose-300 bg-rose-50 text-rose-800'
+      : 'border-indigo-200 bg-indigo-50 text-indigo-800'
+  return (
+    <div className={`rounded-lg border ${cls} px-4 py-3 text-xs font-medium`}>{props.message}</div>
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 差分 → 操作列
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** original → current の差分から OrgMoveOperation の配列を生成 */
+function diffOperations(original: OrgTree, current: OrgTree): ReadonlyArray<OrgMoveOperation> {
+  const origParents = new Map<string, string | null>()
+  for (const n of flattenNodes(original)) origParents.set(n.id, n.parentId)
+  const ops: OrgMoveOperation[] = []
+  for (const n of flattenNodes(current)) {
+    const before = origParents.get(n.id)
+    if (before === undefined) continue
+    if (before !== n.parentId) {
+      ops.push({ nodeId: n.id, newParentId: n.parentId })
+    }
+  }
+  return ops
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// エラー整形
+// ─────────────────────────────────────────────────────────────────────────────
+
+function readError(err: unknown): string {
+  if (err instanceof Error) return err.message
+  return '予期せぬエラーが発生しました'
+}
+
+async function readServerError(res: Response): Promise<string> {
+  try {
+    const body = (await res.json()) as { readonly error?: string }
+    if (typeof body.error === 'string') return body.error
+  } catch {
+    // noop
+  }
+  return `HTTP ${res.status}`
+}
+
+function translateOrgChangeError(err: OrgChangeError): string {
+  switch (err.code) {
+    case 'CYCLE_DETECTED':
+      return '循環参照が発生するため、この移動はできません。'
+    case 'NODE_NOT_FOUND':
+      return '対象のノードが見つかりません。'
+    case 'SAME_PARENT':
+      return '既にその上長の配下にあります。'
+    case 'INVALID_OPERATION':
+      return '不正な操作です。'
+    default:
+      return err.message
+  }
+}

--- a/src/components/organization/MemberList.tsx
+++ b/src/components/organization/MemberList.tsx
@@ -1,0 +1,49 @@
+/**
+ * Issue #28 / Req 3.5: 直属メンバー一覧コンポーネント
+ *
+ * MANAGER の my-team ページで使用。
+ * - 名前 / メールアドレス / 役職 / 部署 を一覧表示
+ * - 空リスト時は「直属メンバーがいません」を表示
+ */
+'use client'
+
+import type { ReactElement } from 'react'
+import type { DirectReport } from '@/lib/organization/organization-types'
+
+interface MemberListProps {
+  readonly members: ReadonlyArray<DirectReport>
+}
+
+export function MemberList(props: MemberListProps): ReactElement {
+  const { members } = props
+
+  if (members.length === 0) {
+    return (
+      <div className="rounded-lg border border-dashed border-slate-300 bg-slate-50 px-6 py-10 text-center text-sm text-slate-500">
+        直属メンバーはまだ登録されていません。
+      </div>
+    )
+  }
+
+  return (
+    <ul className="divide-y divide-slate-200 overflow-hidden rounded-lg border border-slate-200 bg-white">
+      {members.map((m) => (
+        <li
+          key={m.userId}
+          className="flex flex-col gap-1 px-5 py-4 transition-colors hover:bg-slate-50 sm:flex-row sm:items-center sm:justify-between"
+        >
+          <div className="flex-1">
+            <p className="text-sm font-semibold text-slate-900">{m.name}</p>
+            <p className="text-xs text-slate-500">{m.email}</p>
+          </div>
+          <div className="flex items-center gap-3 text-xs">
+            <span className="rounded-full bg-indigo-50 px-3 py-1 font-medium text-indigo-700">
+              {m.roleName}
+            </span>
+            <span className="text-slate-500">{m.departmentName}</span>
+          </div>
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/src/components/organization/OrgNode.tsx
+++ b/src/components/organization/OrgNode.tsx
@@ -1,0 +1,213 @@
+/**
+ * Issue #28 / Req 3.1: 組織ノードコンポーネント
+ *
+ * 単一ノードの描画を担当。
+ * - 部署名 / メンバー数 / ポジション一覧を表示
+ * - クリックで展開 / 折りたたみ
+ * - editable=true (HR_MANAGER) のときだけドラッグハンドルを描画
+ * - ドロップ対象として children を受け付け、isDropTarget で視覚フィードバック
+ */
+'use client'
+
+import { useState, type DragEvent, type KeyboardEvent, type ReactElement } from 'react'
+import type { OrgNode as OrgNodeType } from '@/lib/organization/organization-types'
+import { countMembers } from '@/lib/organization/org-tree-ops'
+
+interface OrgNodeCardProps {
+  readonly node: OrgNodeType
+  readonly editable: boolean
+  readonly draggingNodeId: string | null
+  readonly onDragStart: (nodeId: string) => void
+  readonly onDragEnd: () => void
+  readonly onDropOn: (targetId: string) => void
+  readonly defaultExpanded?: boolean
+}
+
+/**
+ * 再帰的に子ノードを描画する組織図カード。
+ * 自ノードの表示と、ドロップエリア / 子リストを一緒に管理する。
+ */
+export function OrgNodeCard(props: OrgNodeCardProps): ReactElement {
+  const { node, editable, draggingNodeId, onDragStart, onDragEnd, onDropOn, defaultExpanded } =
+    props
+  const [expanded, setExpanded] = useState<boolean>(defaultExpanded ?? true)
+  const [isHovered, setIsHovered] = useState<boolean>(false)
+  const hasChildren = node.children.length > 0
+  const totalMembers = countMembers(node)
+  const beingDragged = draggingNodeId === node.id
+  const isValidTarget = editable && draggingNodeId !== null && draggingNodeId !== node.id
+
+  function toggle(): void {
+    setExpanded((v) => !v)
+  }
+
+  function onKeyDown(event: KeyboardEvent<HTMLButtonElement>): void {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault()
+      toggle()
+    }
+  }
+
+  function handleDragStart(event: DragEvent<HTMLDivElement>): void {
+    if (!editable) return
+    event.dataTransfer.effectAllowed = 'move'
+    event.dataTransfer.setData('text/org-node-id', node.id)
+    onDragStart(node.id)
+  }
+
+  function handleDragOver(event: DragEvent<HTMLDivElement>): void {
+    if (!isValidTarget) return
+    event.preventDefault()
+    event.dataTransfer.dropEffect = 'move'
+    setIsHovered(true)
+  }
+
+  function handleDragLeave(): void {
+    setIsHovered(false)
+  }
+
+  function handleDrop(event: DragEvent<HTMLDivElement>): void {
+    event.preventDefault()
+    setIsHovered(false)
+    if (!isValidTarget) return
+    onDropOn(node.id)
+  }
+
+  return (
+    <li className="relative">
+      <div
+        draggable={editable}
+        onDragStart={handleDragStart}
+        onDragEnd={onDragEnd}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onDrop={handleDrop}
+        data-testid={`org-node-${node.id}`}
+        className={buildCardClass({ beingDragged, isHovered, isValidTarget })}
+      >
+        <NodeHeader
+          node={node}
+          editable={editable}
+          expanded={expanded}
+          hasChildren={hasChildren}
+          totalMembers={totalMembers}
+          onToggle={toggle}
+          onHeaderKey={onKeyDown}
+        />
+        {node.positions.length > 0 && <PositionList positions={node.positions} />}
+      </div>
+
+      {hasChildren && expanded && (
+        <ul className="mt-3 ml-6 space-y-3 border-l border-dashed border-slate-300 pl-6">
+          {node.children.map((child) => (
+            <OrgNodeCard
+              key={child.id}
+              node={child}
+              editable={editable}
+              draggingNodeId={draggingNodeId}
+              onDragStart={onDragStart}
+              onDragEnd={onDragEnd}
+              onDropOn={onDropOn}
+              defaultExpanded={defaultExpanded}
+            />
+          ))}
+        </ul>
+      )}
+    </li>
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 内部: カードのクラス組み立て
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface BuildCardClassOptions {
+  readonly beingDragged: boolean
+  readonly isHovered: boolean
+  readonly isValidTarget: boolean
+}
+
+function buildCardClass(opts: BuildCardClassOptions): string {
+  const base =
+    'group w-72 rounded-lg border bg-white px-4 py-3 shadow-sm transition-all duration-150'
+  if (opts.beingDragged) {
+    return `${base} border-amber-400 opacity-40 ring-2 ring-amber-200`
+  }
+  if (opts.isHovered && opts.isValidTarget) {
+    return `${base} border-dashed border-2 border-emerald-500 bg-emerald-50 shadow-md`
+  }
+  return `${base} border-slate-200 hover:border-slate-400 hover:shadow-md`
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 内部: ヘッダ
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface NodeHeaderProps {
+  readonly node: OrgNodeType
+  readonly editable: boolean
+  readonly expanded: boolean
+  readonly hasChildren: boolean
+  readonly totalMembers: number
+  readonly onToggle: () => void
+  readonly onHeaderKey: (event: KeyboardEvent<HTMLButtonElement>) => void
+}
+
+function NodeHeader(props: NodeHeaderProps): ReactElement {
+  const { node, editable, expanded, hasChildren, totalMembers, onToggle, onHeaderKey } = props
+  return (
+    <div className="flex items-start gap-2">
+      {editable && (
+        <span
+          aria-hidden="true"
+          className="mt-1 shrink-0 cursor-grab text-slate-400 select-none group-active:cursor-grabbing"
+          title="ドラッグして上長を変更"
+        >
+          ⋮⋮
+        </span>
+      )}
+      <button
+        type="button"
+        onClick={onToggle}
+        onKeyDown={onHeaderKey}
+        aria-expanded={expanded}
+        className="flex-1 text-left"
+      >
+        <div className="flex items-center justify-between gap-2">
+          <span className="font-semibold text-slate-900">{node.name}</span>
+          {hasChildren && (
+            <span className="text-xs text-slate-500" aria-hidden="true">
+              {expanded ? '▼' : '▶'}
+            </span>
+          )}
+        </div>
+        <div className="mt-0.5 text-xs text-slate-500">
+          メンバー {totalMembers} 名 / ポジション {node.positions.length} 件
+        </div>
+      </button>
+    </div>
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 内部: ポジション一覧
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface PositionListProps {
+  readonly positions: OrgNodeType['positions']
+}
+
+function PositionList(props: PositionListProps): ReactElement {
+  return (
+    <ul className="mt-3 space-y-1 border-t border-slate-100 pt-3">
+      {props.positions.map((p) => (
+        <li key={p.id} className="flex items-center justify-between text-xs">
+          <span className="font-medium text-slate-600">{p.roleId}</span>
+          <span className={p.holderName ? 'text-slate-800' : 'text-slate-400 italic'}>
+            {p.holderName ?? '未配属'}
+          </span>
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/src/components/organization/OrganizationChart.tsx
+++ b/src/components/organization/OrganizationChart.tsx
@@ -1,0 +1,156 @@
+/**
+ * Issue #28 / Req 3.1, 3.2: 組織図 (インタラクティブ DnD) コンポーネント
+ *
+ * - HTML5 DnD API を使用 (外部依存なし)
+ * - 編集可能 (editable=HR_MANAGER) のときだけドラッグを許可
+ * - ドラッグ&ドロップ発生時、moveNode / wouldCreateCycle で循環判定を行い
+ *   新しいツリーを親に通知 (onTreeChange)
+ * - ツリー空エリアへのドロップは "ルートへの移動" として扱う
+ */
+'use client'
+
+import { useState, useCallback, type DragEvent, type ReactElement } from 'react'
+import type { OrgTree } from '@/lib/organization/organization-types'
+import { OrgChangeError } from '@/lib/organization/organization-types'
+import { moveNode } from '@/lib/organization/org-tree-ops'
+import { OrgNodeCard } from './OrgNode'
+
+interface OrganizationChartProps {
+  readonly tree: OrgTree
+  readonly editable: boolean
+  readonly onTreeChange: (nextTree: OrgTree) => void
+  readonly onError?: (error: OrgChangeError) => void
+}
+
+/**
+ * 組織図ルートコンポーネント。ルートノード群を横に並べる。
+ * ツリー操作のオーケストレーションを担当する。
+ */
+export function OrganizationChart(props: OrganizationChartProps): ReactElement {
+  const { tree, editable, onTreeChange, onError } = props
+  const [draggingNodeId, setDraggingNodeId] = useState<string | null>(null)
+  const [rootHover, setRootHover] = useState<boolean>(false)
+
+  const handleDragStart = useCallback((nodeId: string) => {
+    setDraggingNodeId(nodeId)
+  }, [])
+
+  const handleDragEnd = useCallback(() => {
+    setDraggingNodeId(null)
+    setRootHover(false)
+  }, [])
+
+  const applyMove = useCallback(
+    (nodeId: string, newParentId: string | null) => {
+      try {
+        const nextTree = moveNode(tree, nodeId, newParentId)
+        onTreeChange(nextTree)
+      } catch (err) {
+        if (err instanceof OrgChangeError) {
+          onError?.(err)
+        } else {
+          throw err
+        }
+      } finally {
+        setDraggingNodeId(null)
+        setRootHover(false)
+      }
+    },
+    [tree, onTreeChange, onError],
+  )
+
+  const handleDropOnNode = useCallback(
+    (targetId: string) => {
+      if (!draggingNodeId) return
+      applyMove(draggingNodeId, targetId)
+    },
+    [draggingNodeId, applyMove],
+  )
+
+  function handleRootDragOver(event: DragEvent<HTMLDivElement>): void {
+    if (!editable || !draggingNodeId) return
+    event.preventDefault()
+    event.dataTransfer.dropEffect = 'move'
+    setRootHover(true)
+  }
+
+  function handleRootDragLeave(event: DragEvent<HTMLDivElement>): void {
+    if (event.currentTarget.contains(event.relatedTarget as Node | null)) return
+    setRootHover(false)
+  }
+
+  function handleRootDrop(event: DragEvent<HTMLDivElement>): void {
+    event.preventDefault()
+    setRootHover(false)
+    if (!draggingNodeId) return
+    if (event.target !== event.currentTarget) return
+    applyMove(draggingNodeId, null)
+  }
+
+  const rootClass = buildRootClass({
+    editable,
+    dragging: draggingNodeId !== null,
+    rootHover,
+  })
+
+  return (
+    <div
+      data-testid="organization-chart"
+      className={rootClass}
+      onDragOver={handleRootDragOver}
+      onDragLeave={handleRootDragLeave}
+      onDrop={handleRootDrop}
+    >
+      {tree.roots.length === 0 ? (
+        <EmptyState />
+      ) : (
+        <ul className="flex flex-wrap gap-6">
+          {tree.roots.map((root) => (
+            <OrgNodeCard
+              key={root.id}
+              node={root}
+              editable={editable}
+              draggingNodeId={draggingNodeId}
+              onDragStart={handleDragStart}
+              onDragEnd={handleDragEnd}
+              onDropOn={handleDropOnNode}
+            />
+          ))}
+        </ul>
+      )}
+      {editable && draggingNodeId && (
+        <p className="mt-4 text-xs text-slate-500">
+          カードをドロップして親部署を変更。空白エリアに落とすとルートへ移動します。
+        </p>
+      )}
+    </div>
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ヘルパ
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface RootClassOptions {
+  readonly editable: boolean
+  readonly dragging: boolean
+  readonly rootHover: boolean
+}
+
+function buildRootClass(opts: RootClassOptions): string {
+  const base = 'w-full rounded-xl bg-slate-50 p-6 transition-colors duration-150'
+  if (opts.editable && opts.dragging) {
+    return `${base} border-2 border-dashed ${
+      opts.rootHover ? 'border-emerald-500 bg-emerald-50' : 'border-slate-300'
+    }`
+  }
+  return `${base} border border-slate-200`
+}
+
+function EmptyState(): ReactElement {
+  return (
+    <div className="flex flex-col items-center justify-center py-16 text-slate-400">
+      <p className="text-sm">組織データがまだ登録されていません。</p>
+    </div>
+  )
+}

--- a/src/lib/audit/audit-log-emitter.ts
+++ b/src/lib/audit/audit-log-emitter.ts
@@ -1,4 +1,3 @@
-import { PrismaClient, Prisma } from '@prisma/client'
 import { Prisma, PrismaClient } from '@prisma/client'
 import type { AuditLogEntry } from './audit-log-types'
 

--- a/src/lib/import/import-worker.ts
+++ b/src/lib/import/import-worker.ts
@@ -9,6 +9,7 @@ import {
   parseSkillCsv,
   type MasterResource,
 } from '@/lib/master/master-csv'
+import { parseEmployeeCsv } from '@/lib/lifecycle/employee-csv'
 
 // ─────────────────────────────────────────────────────────────────────────────
 // ジョブプロセッサ（テスト可能な純粋関数として分離）
@@ -32,7 +33,7 @@ export async function processImportJob(job: Job): Promise<ImportResult> {
   if (payload.type === 'MasterCsv') {
     return processMasterCsv(payload.resource, csvContent)
   }
-  return processEmployeeCsv()
+  return processEmployeeCsv(csvContent)
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -83,9 +84,24 @@ function buildResourceError(resource: string): ImportResult {
   return { totalRows: 1, successCount: 0, failureCount: 1, errors: [err] }
 }
 
-function processEmployeeCsv(): ImportResult {
-  // 後続タスクで実装予定
-  return { totalRows: 0, successCount: 0, failureCount: 0, errors: [] }
+/**
+ * Issue #29: EmployeeCsv バリアントの実処理。
+ * CSV をパースして ImportRowError[] に集約する。
+ * 実際の DB 書き込みは LifecycleService (API 層) が担う。
+ */
+function processEmployeeCsv(csvContent: string): ImportResult {
+  if (csvContent.length === 0) {
+    return { totalRows: 0, successCount: 0, failureCount: 0, errors: [] }
+  }
+  const { rows, errors } = parseEmployeeCsv(csvContent)
+  const successCount = rows.length
+  const failureCount = errors.length
+  return {
+    totalRows: successCount + failureCount,
+    successCount,
+    failureCount,
+    errors,
+  }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/lib/lifecycle/employee-csv.ts
+++ b/src/lib/lifecycle/employee-csv.ts
@@ -1,0 +1,295 @@
+/**
+ * Issue #29 / Req 14.9: 社員 CSV パーサ
+ *
+ * CSV パースとバリデーションの純粋関数群。DB 依存を持たず、
+ * ImportRowError[] として行単位エラーを集約する（master-csv.ts と同形）。
+ *
+ * CSV ヘッダー: email,firstName,lastName,role,hireDate,departmentId,positionId
+ */
+import type { ImportRowError } from '@/lib/import/import-types'
+import { USER_ROLES, type UserRole } from '@/lib/notification/notification-types'
+import { parseIsoDate, type EmployeeCsvRow } from './lifecycle-types'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ヘッダ定義
+// ─────────────────────────────────────────────────────────────────────────────
+
+const EMPLOYEE_HEADER = [
+  'email',
+  'firstName',
+  'lastName',
+  'role',
+  'hireDate',
+  'departmentId',
+  'positionId',
+] as const
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CSV テキストパーサ（master-csv.ts と同一ロジック）
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * 極小 CSV パーサ。クォート付き値とエスケープ（""）に対応。
+ * master-csv.ts と意図的に同一ロジックを用いる（後続で共通モジュール化してもよい）。
+ */
+function parseCsvText(csv: string): string[][] {
+  const rows: string[][] = []
+  let cur: string[] = []
+  let field = ''
+  let inQuotes = false
+  let i = 0
+
+  while (i < csv.length) {
+    const ch = csv[i]
+
+    if (inQuotes) {
+      if (ch === '"') {
+        if (csv[i + 1] === '"') {
+          field += '"'
+          i += 2
+          continue
+        }
+        inQuotes = false
+        i += 1
+        continue
+      }
+      field += ch
+      i += 1
+      continue
+    }
+
+    if (ch === '"') {
+      inQuotes = true
+      i += 1
+      continue
+    }
+    if (ch === ',') {
+      cur.push(field)
+      field = ''
+      i += 1
+      continue
+    }
+    if (ch === '\r') {
+      i += 1
+      continue
+    }
+    if (ch === '\n') {
+      cur.push(field)
+      rows.push(cur)
+      cur = []
+      field = ''
+      i += 1
+      continue
+    }
+    field += ch
+    i += 1
+  }
+
+  if (field.length > 0 || cur.length > 0) {
+    cur.push(field)
+    rows.push(cur)
+  }
+
+  return rows
+}
+
+function isBlankRow(cells: readonly string[]): boolean {
+  return cells.every((c) => c.trim().length === 0)
+}
+
+function validateHeader(
+  actual: readonly string[],
+  expected: readonly string[],
+): ImportRowError | null {
+  const trimmed = actual.map((c) => c.trim())
+  for (let i = 0; i < expected.length; i += 1) {
+    if (trimmed[i] !== expected[i]) {
+      return {
+        rowNumber: 1,
+        field: expected[i] ?? 'header',
+        message: `ヘッダーが不正です。期待: ${expected.join(',')}`,
+      }
+    }
+  }
+  return null
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Row 検証
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface RawRow {
+  readonly rowNumber: number
+  readonly email: string
+  readonly firstName: string
+  readonly lastName: string
+  readonly role: string
+  readonly hireDate: string
+  readonly departmentId: string
+  readonly positionId: string
+}
+
+function extractRawRow(rowNumber: number, cells: readonly string[]): RawRow {
+  return {
+    rowNumber,
+    email: (cells[0] ?? '').trim(),
+    firstName: (cells[1] ?? '').trim(),
+    lastName: (cells[2] ?? '').trim(),
+    role: (cells[3] ?? '').trim(),
+    hireDate: (cells[4] ?? '').trim(),
+    departmentId: (cells[5] ?? '').trim(),
+    positionId: (cells[6] ?? '').trim(),
+  }
+}
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+function isUserRole(value: string): value is UserRole {
+  return (USER_ROLES as readonly string[]).includes(value)
+}
+
+/** 必須文字列フィールドの欠如チェック */
+function pushIfEmpty(
+  errors: ImportRowError[],
+  rowNumber: number,
+  field: string,
+  value: string,
+): boolean {
+  if (value.length === 0) {
+    errors.push({ rowNumber, field, message: `${field} は必須です` })
+    return true
+  }
+  return false
+}
+
+/** email フィールドの形式チェック */
+function validateEmail(errors: ImportRowError[], rowNumber: number, email: string): void {
+  if (pushIfEmpty(errors, rowNumber, 'email', email)) return
+  if (!EMAIL_REGEX.test(email)) {
+    errors.push({
+      rowNumber,
+      field: 'email',
+      message: `email の形式が不正です（値: "${email}"）`,
+    })
+  }
+}
+
+/** role フィールドの enum チェック */
+function validateRole(errors: ImportRowError[], rowNumber: number, role: string): void {
+  if (pushIfEmpty(errors, rowNumber, 'role', role)) return
+  if (!isUserRole(role)) {
+    errors.push({
+      rowNumber,
+      field: 'role',
+      message: `role は ${USER_ROLES.join(' | ')} のいずれかである必要があります（値: "${role}"）`,
+    })
+  }
+}
+
+/** hireDate フィールドの ISO 日付チェック */
+function validateHireDate(
+  errors: ImportRowError[],
+  rowNumber: number,
+  hireDate: string,
+): Date | null {
+  if (pushIfEmpty(errors, rowNumber, 'hireDate', hireDate)) return null
+  const d = parseIsoDate(hireDate)
+  if (d === null) {
+    errors.push({
+      rowNumber,
+      field: 'hireDate',
+      message: `hireDate は YYYY-MM-DD 形式である必要があります（値: "${hireDate}"）`,
+    })
+    return null
+  }
+  return d
+}
+
+/** 1 行を検証して Row か null を返す */
+function validateRow(raw: RawRow, errors: ImportRowError[]): EmployeeCsvRow | null {
+  const before = errors.length
+
+  validateEmail(errors, raw.rowNumber, raw.email)
+  pushIfEmpty(errors, raw.rowNumber, 'firstName', raw.firstName)
+  pushIfEmpty(errors, raw.rowNumber, 'lastName', raw.lastName)
+  validateRole(errors, raw.rowNumber, raw.role)
+  const hireDate = validateHireDate(errors, raw.rowNumber, raw.hireDate)
+  pushIfEmpty(errors, raw.rowNumber, 'departmentId', raw.departmentId)
+  pushIfEmpty(errors, raw.rowNumber, 'positionId', raw.positionId)
+
+  if (errors.length !== before) return null
+  if (hireDate === null) return null
+  if (!isUserRole(raw.role)) return null
+
+  return {
+    rowNumber: raw.rowNumber,
+    email: raw.email,
+    firstName: raw.firstName,
+    lastName: raw.lastName,
+    role: raw.role,
+    hireDate,
+    departmentId: raw.departmentId,
+    positionId: raw.positionId,
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Public API
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * 社員 CSV をパースして検証結果を返す。
+ * - ヘッダーが不正な場合は rows=[] でエラー 1 件返す
+ * - 各行のエラーは ImportRowError として集約する
+ * - 同一 CSV 内で重複 email があれば 2 件目以降を重複エラーとして弾く
+ */
+export function parseEmployeeCsv(csv: string): {
+  rows: EmployeeCsvRow[]
+  errors: ImportRowError[]
+} {
+  const parsed = parseCsvText(csv)
+  const errors: ImportRowError[] = []
+  const rows: EmployeeCsvRow[] = []
+
+  if (parsed.length === 0) {
+    errors.push({ rowNumber: 1, field: 'header', message: 'CSV が空です' })
+    return { rows, errors }
+  }
+
+  const headerError = validateHeader(parsed[0] ?? [], EMPLOYEE_HEADER)
+  if (headerError) {
+    errors.push(headerError)
+    return { rows, errors }
+  }
+
+  const seenEmails = new Map<string, number>() // email(lowercase) -> rowNumber of first occurrence
+
+  for (let r = 1; r < parsed.length; r += 1) {
+    const cells = parsed[r] ?? []
+    if (isBlankRow(cells)) continue
+
+    const rowNumber = r + 1
+    const raw = extractRawRow(rowNumber, cells)
+    const row = validateRow(raw, errors)
+    if (row === null) continue
+
+    const emailKey = row.email.toLowerCase()
+    const prev = seenEmails.get(emailKey)
+    if (prev !== undefined) {
+      errors.push({
+        rowNumber,
+        field: 'email',
+        message: `email が CSV 内で重複しています（最初の出現: 行 ${prev}）`,
+      })
+      continue
+    }
+
+    seenEmails.set(emailKey, rowNumber)
+    rows.push(row)
+  }
+
+  return { rows, errors }
+}
+
+/** テスト/他モジュールで参照する CSV ヘッダー（readonly 配列） */
+export const EMPLOYEE_CSV_HEADER: readonly string[] = EMPLOYEE_HEADER

--- a/src/lib/lifecycle/lifecycle-service-di.ts
+++ b/src/lib/lifecycle/lifecycle-service-di.ts
@@ -1,0 +1,28 @@
+/**
+ * Issue #29: LifecycleService のシングルトン DI モジュール。
+ * master-service-di.ts / invitation-service-di.ts と同一パターン。
+ */
+import type { LifecycleService } from './lifecycle-service'
+
+let _lifecycleService: LifecycleService | null = null
+
+export function setLifecycleServiceForTesting(svc: LifecycleService): void {
+  _lifecycleService = svc
+}
+
+export function clearLifecycleServiceForTesting(): void {
+  _lifecycleService = null
+}
+
+export function getLifecycleService(): LifecycleService {
+  if (_lifecycleService) return _lifecycleService
+  throw new Error(
+    'LifecycleService is not initialized. ' +
+      'テストでは setLifecycleServiceForTesting() を呼んでください。' +
+      'プロダクションではサーバー起動前に initLifecycleService() を呼んでください。',
+  )
+}
+
+export function initLifecycleService(svc: LifecycleService): void {
+  _lifecycleService = svc
+}

--- a/src/lib/lifecycle/lifecycle-service.ts
+++ b/src/lib/lifecycle/lifecycle-service.ts
@@ -1,0 +1,199 @@
+/**
+ * Issue #29 / Req 14.1, 14.9: 社員ライフサイクルサービス
+ *
+ * - createEmployee: 招待フローを呼び出して PENDING_JOIN ユーザーを作成し、
+ *   プロフィール情報（入社日・配属・役職）を EmployeeProfileRepository に保存する
+ * - bulkImportUsers: CSV をパースして有効行を createEmployee に流し、失敗行を集約する
+ *
+ * 既存の InvitationService / WritableAuthUserRepository を再利用し、
+ * ユーザー作成の責務はサービス層で重複させない。
+ */
+import { randomUUID } from 'node:crypto'
+import { computeEmailHash } from '@/lib/shared/crypto'
+import type { InvitationService } from '@/lib/auth/invitation-service'
+import { EmailAlreadyExistsError } from '@/lib/auth/invitation-types'
+import type { WritableAuthUserRepository } from '@/lib/auth/user-repository'
+import type { ImportRowError } from '@/lib/import/import-types'
+import { parseEmployeeCsv } from './employee-csv'
+import {
+  EmployeeAlreadyExistsError,
+  type BulkImportResult,
+  type CreateEmployeeInput,
+  type Employee,
+  type EmployeeCsvRow,
+} from './lifecycle-types'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Ports
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** 社員プロフィール（入社日 / 配属 / 役職）を保存する narrow port */
+export interface EmployeeProfileRepository {
+  saveProfile(profile: {
+    readonly userId: string
+    readonly firstName: string
+    readonly lastName: string
+    readonly hireDate: Date
+    readonly departmentId: string
+    readonly positionId: string
+  }): Promise<void>
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Service interface
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface LifecycleService {
+  /**
+   * 社員を 1 件作成する。
+   * - 招待フローを経由して PENDING_JOIN ユーザーを作成
+   * - プロフィール（firstName / lastName / hireDate / departmentId / positionId）を保存
+   * - 既存メール重複は EmployeeAlreadyExistsError として再スロー
+   */
+  createEmployee(input: CreateEmployeeInput, invitedByUserId: string): Promise<Employee>
+
+  /**
+   * 社員 CSV を一括インポートする。
+   * - パースエラーは errors に集約
+   * - 有効行は createEmployee で 1 件ずつ作成（失敗行もエラー集約）
+   * - 常に totalRows = successCount + failureCount を満たす
+   */
+  bulkImportUsers(file: Buffer, invitedByUserId: string): Promise<BulkImportResult>
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Dependencies
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface LifecycleServiceDeps {
+  readonly invitations: InvitationService
+  readonly users: WritableAuthUserRepository
+  readonly profiles: EmployeeProfileRepository
+  readonly appSecret: string
+  readonly jobIdFactory?: () => string
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Implementation
+// ─────────────────────────────────────────────────────────────────────────────
+
+class LifecycleServiceImpl implements LifecycleService {
+  private readonly invitations: InvitationService
+  private readonly users: WritableAuthUserRepository
+  private readonly profiles: EmployeeProfileRepository
+  private readonly appSecret: string
+  private readonly jobIdFactory: () => string
+
+  constructor(deps: LifecycleServiceDeps) {
+    this.invitations = deps.invitations
+    this.users = deps.users
+    this.profiles = deps.profiles
+    this.appSecret = deps.appSecret
+    this.jobIdFactory = deps.jobIdFactory ?? randomUUID
+  }
+
+  async createEmployee(input: CreateEmployeeInput, invitedByUserId: string): Promise<Employee> {
+    try {
+      await this.invitations.inviteUser({ email: input.email, role: input.role }, invitedByUserId)
+    } catch (err) {
+      if (err instanceof EmailAlreadyExistsError) {
+        throw new EmployeeAlreadyExistsError(input.email)
+      }
+      throw err
+    }
+
+    const emailHash = await computeEmailHash(input.email, this.appSecret)
+    const created = await this.users.findByEmailHash(emailHash)
+    if (!created) {
+      // InvitationService が inviteUser 成功時に PENDING_JOIN を作成する契約が崩れた場合
+      throw new Error('Invited user not found after inviteUser succeeded')
+    }
+
+    await this.profiles.saveProfile({
+      userId: created.id,
+      firstName: input.firstName,
+      lastName: input.lastName,
+      hireDate: input.hireDate,
+      departmentId: input.departmentId,
+      positionId: input.positionId,
+    })
+
+    return {
+      id: created.id,
+      email: input.email,
+      firstName: input.firstName,
+      lastName: input.lastName,
+      role: input.role,
+      hireDate: input.hireDate,
+      departmentId: input.departmentId,
+      positionId: input.positionId,
+    }
+  }
+
+  async bulkImportUsers(file: Buffer, invitedByUserId: string): Promise<BulkImportResult> {
+    const csv = file.toString('utf-8')
+    const { rows, errors: parseErrors } = parseEmployeeCsv(csv)
+
+    const errors: ImportRowError[] = [...parseErrors]
+    let successCount = 0
+
+    for (const row of rows) {
+      const rowErrors = await this.createFromRow(row, invitedByUserId)
+      if (rowErrors.length === 0) {
+        successCount += 1
+        continue
+      }
+      errors.push(...rowErrors)
+    }
+
+    const failureCount = errors.length
+    const totalRows = successCount + failureCount
+
+    return {
+      totalRows,
+      successCount,
+      failureCount,
+      errors,
+      jobId: this.jobIdFactory(),
+    }
+  }
+
+  private async createFromRow(
+    row: EmployeeCsvRow,
+    invitedByUserId: string,
+  ): Promise<ImportRowError[]> {
+    try {
+      await this.createEmployee(
+        {
+          email: row.email,
+          firstName: row.firstName,
+          lastName: row.lastName,
+          role: row.role,
+          hireDate: row.hireDate,
+          departmentId: row.departmentId,
+          positionId: row.positionId,
+        },
+        invitedByUserId,
+      )
+      return []
+    } catch (err) {
+      return [toRowError(row.rowNumber, err)]
+    }
+  }
+}
+
+function toRowError(rowNumber: number, err: unknown): ImportRowError {
+  if (err instanceof EmployeeAlreadyExistsError) {
+    return {
+      rowNumber,
+      field: 'email',
+      message: `既に登録済みのメールアドレスです: ${err.email}`,
+    }
+  }
+  const message = err instanceof Error ? err.message : 'Unknown error'
+  return { rowNumber, field: 'row', message }
+}
+
+export function createLifecycleService(deps: LifecycleServiceDeps): LifecycleService {
+  return new LifecycleServiceImpl(deps)
+}

--- a/src/lib/lifecycle/lifecycle-types.ts
+++ b/src/lib/lifecycle/lifecycle-types.ts
@@ -1,0 +1,116 @@
+/**
+ * Issue #29 / Req 14.1, 14.9: 社員ライフサイクル型定義
+ *
+ * - CreateEmployeeInput: 社員作成入力 (ADMIN / HR_MANAGER)
+ * - EmployeeCsvRow: CSV 1 行を表す Row 型（バリデーション済み）
+ * - BulkImportResult: CSV 一括インポートの結果
+ * - Employee: 作成した社員の基本投影
+ * - ドメイン例外: EmployeeAlreadyExistsError
+ */
+import { z } from 'zod'
+import { USER_ROLES, type UserRole } from '@/lib/notification/notification-types'
+import type { ImportRowError } from '@/lib/import/import-types'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CreateEmployeeInput
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** ISO 日付 YYYY-MM-DD の厳密な正規表現（0000-9999） */
+export const ISO_DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/
+
+/**
+ * YYYY-MM-DD 文字列を Date に変換する。
+ * 不正な日付（例: 2026-02-30）は Invalid Date として弾く。
+ */
+export function parseIsoDate(input: string): Date | null {
+  if (!ISO_DATE_REGEX.test(input)) return null
+  const d = new Date(`${input}T00:00:00.000Z`)
+  if (Number.isNaN(d.getTime())) return null
+  // 月末補正などで入力と UTC 表現がズレる場合を検出
+  const iso = d.toISOString().slice(0, 10)
+  return iso === input ? d : null
+}
+
+/**
+ * 社員作成入力のスキーマ。
+ * - API 層 (JSON) では hireDate は ISO 日付文字列 (YYYY-MM-DD) で受け取り、Date に変換する
+ * - CSV 層でも同様の文字列 → Date 変換を行う
+ */
+export const createEmployeeInputSchema = z.object({
+  email: z.string().email(),
+  firstName: z.string().min(1),
+  lastName: z.string().min(1),
+  role: z.enum(USER_ROLES),
+  hireDate: z
+    .union([
+      z.string().refine((s) => parseIsoDate(s) !== null, {
+        message: 'hireDate must be ISO date (YYYY-MM-DD)',
+      }),
+      z.date(),
+    ])
+    .transform((v) => (v instanceof Date ? v : (parseIsoDate(v) as Date))),
+  departmentId: z.string().min(1),
+  positionId: z.string().min(1),
+})
+
+/** 社員作成入力（業務層が扱う Date 化済みの形） */
+export type CreateEmployeeInput = z.infer<typeof createEmployeeInputSchema>
+
+// ─────────────────────────────────────────────────────────────────────────────
+// EmployeeCsvRow
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** CSV 由来の社員 1 行。文字列→Date 変換済みで業務層に渡す。 */
+export interface EmployeeCsvRow {
+  readonly rowNumber: number
+  readonly email: string
+  readonly firstName: string
+  readonly lastName: string
+  readonly role: UserRole
+  readonly hireDate: Date
+  readonly departmentId: string
+  readonly positionId: string
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Employee / BulkImportResult
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * 作成された社員の基本投影。
+ * API レスポンスでは hireDate を ISO 文字列化して返す。
+ */
+export interface Employee {
+  readonly id: string
+  readonly email: string
+  readonly firstName: string
+  readonly lastName: string
+  readonly role: UserRole
+  readonly hireDate: Date
+  readonly departmentId: string
+  readonly positionId: string
+}
+
+/** CSV 一括インポート結果 */
+export interface BulkImportResult {
+  readonly totalRows: number
+  readonly successCount: number
+  readonly failureCount: number
+  readonly errors: readonly ImportRowError[]
+  readonly jobId: string
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Domain exceptions
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** 指定メールアドレスのユーザーが既に存在する（createEmployee 用） */
+export class EmployeeAlreadyExistsError extends Error {
+  public readonly email: string
+
+  constructor(email: string) {
+    super(`Employee already exists: ${email}`)
+    this.name = 'EmployeeAlreadyExistsError'
+    this.email = email
+  }
+}

--- a/src/lib/organization/cycle-detection.ts
+++ b/src/lib/organization/cycle-detection.ts
@@ -1,0 +1,78 @@
+/**
+ * Issue #27 / Req 3.4: 組織階層の循環参照検出 (純粋関数)
+ *
+ * DFS で parent / supervisor を辿り、自己参照が発生したら循環パスを返す。
+ * - 入力は Map<nodeId, parentId | null> として受け取り、DB 依存を持たない
+ * - サービス層からは「適用後の状態」を作ってから呼ぶ (プレビュー / コミット共通)
+ */
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** 親ポインタマップ: nodeId -> parentId (null はルート) */
+export type ParentMap = ReadonlyMap<string, string | null>
+
+/** 循環検出結果 */
+export type CycleCheckResult =
+  | { readonly ok: true }
+  | { readonly ok: false; readonly path: readonly string[] }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// DFS 実装
+// ─────────────────────────────────────────────────────────────────────────────
+
+const MAX_DEPTH = 10_000
+
+/**
+ * 1 ノードから親方向に辿り、循環が無いかを検査する。
+ * - 既に検査済 (visited) のノードに到達したら打ち切り
+ * - 経路 (path) に同一 ID が再登場したら循環
+ */
+function walkFromNode(
+  start: string,
+  parentMap: ParentMap,
+  globallyVisited: Set<string>,
+): CycleCheckResult {
+  const path: string[] = []
+  const inPath = new Set<string>()
+  let current: string | null | undefined = start
+  let depth = 0
+
+  while (current !== null && current !== undefined) {
+    if (depth++ > MAX_DEPTH) {
+      return { ok: false, path: [...path, current, '...truncated'] }
+    }
+    if (inPath.has(current)) {
+      const cycleStart = path.indexOf(current)
+      const cyclePath = path.slice(cycleStart).concat(current)
+      return { ok: false, path: cyclePath }
+    }
+    if (globallyVisited.has(current)) {
+      break
+    }
+    path.push(current)
+    inPath.add(current)
+    current = parentMap.get(current) ?? null
+  }
+
+  for (const id of path) {
+    globallyVisited.add(id)
+  }
+  return { ok: true }
+}
+
+/**
+ * parentMap 全体に循環が無いか検査する純粋関数。
+ *
+ * @returns サイクルがあれば ok=false & 循環パス、なければ ok=true
+ */
+export function detectCycle(parentMap: ParentMap): CycleCheckResult {
+  const globallyVisited = new Set<string>()
+  for (const nodeId of parentMap.keys()) {
+    if (globallyVisited.has(nodeId)) continue
+    const result = walkFromNode(nodeId, parentMap, globallyVisited)
+    if (!result.ok) return result
+  }
+  return { ok: true }
+}

--- a/src/lib/organization/org-tree-ops.ts
+++ b/src/lib/organization/org-tree-ops.ts
@@ -1,0 +1,212 @@
+/**
+ * Issue #28 / Req 3.2, 3.4: 組織ツリー (OrgTree) に対する純粋な操作関数
+ *
+ * - findNode: ツリーから id でノードを探索
+ * - flattenNodes: ツリー全体を平坦化 (id / parentId のマップ構築用)
+ * - moveNode: ノードを別の親の下に移動し、新しいツリーを返す (immutable)
+ * - wouldCreateCycle: 移動操作が循環参照になるかを事前判定
+ * - collectDescendantIds: 子孫 id 集合を返す
+ * - countMembers: ノード配下の総ホルダー数 (holderUserId != null) をカウント
+ *
+ * 全関数は入力を一切変更せず、必要な場合は新オブジェクトを返す。
+ */
+import type { OrgNode, OrgTree, OrgMoveOperation } from './organization-types'
+import { OrgChangeError } from './organization-types'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 探索
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** ツリーから id でノードを探索 (見つからなければ null) */
+export function findNode(tree: OrgTree, nodeId: string): OrgNode | null {
+  for (const root of tree.roots) {
+    const found = findNodeRecursive(root, nodeId)
+    if (found) return found
+  }
+  return null
+}
+
+function findNodeRecursive(node: OrgNode, nodeId: string): OrgNode | null {
+  if (node.id === nodeId) return node
+  for (const child of node.children) {
+    const found = findNodeRecursive(child, nodeId)
+    if (found) return found
+  }
+  return null
+}
+
+/** ツリーを平坦化した配列を返す */
+export function flattenNodes(tree: OrgTree): ReadonlyArray<OrgNode> {
+  const acc: OrgNode[] = []
+  for (const root of tree.roots) {
+    flattenRecursive(root, acc)
+  }
+  return acc
+}
+
+function flattenRecursive(node: OrgNode, acc: OrgNode[]): void {
+  acc.push(node)
+  for (const child of node.children) {
+    flattenRecursive(child, acc)
+  }
+}
+
+/** 指定ノード以下の子孫 id 集合を返す (自身は含めない) */
+export function collectDescendantIds(node: OrgNode): ReadonlySet<string> {
+  const ids = new Set<string>()
+  for (const child of node.children) {
+    collectDescendantRecursive(child, ids)
+  }
+  return ids
+}
+
+function collectDescendantRecursive(node: OrgNode, ids: Set<string>): void {
+  ids.add(node.id)
+  for (const child of node.children) {
+    collectDescendantRecursive(child, ids)
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 循環参照検出
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * 「nodeId を newParentId の下に移動する」操作が循環参照を生むかを判定。
+ * - newParentId が null (ルート) は循環しない
+ * - newParentId が nodeId 自身は循環
+ * - newParentId が nodeId の子孫 (collectDescendantIds の要素) は循環
+ */
+export function wouldCreateCycle(
+  tree: OrgTree,
+  nodeId: string,
+  newParentId: string | null,
+): boolean {
+  if (newParentId === null) return false
+  if (newParentId === nodeId) return true
+
+  const node = findNode(tree, nodeId)
+  if (!node) return false
+
+  const descendants = collectDescendantIds(node)
+  return descendants.has(newParentId)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// メンバー数カウント
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** ノード自身のポジションのうちホルダーが埋まっている件数 */
+export function countDirectMembers(node: OrgNode): number {
+  return node.positions.reduce((sum, p) => (p.holderUserId ? sum + 1 : sum), 0)
+}
+
+/** ノード以下すべての holderUserId 埋まり数 */
+export function countMembers(node: OrgNode): number {
+  let total = countDirectMembers(node)
+  for (const child of node.children) {
+    total += countMembers(child)
+  }
+  return total
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 移動操作 (immutable)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * nodeId を切り出し、newParentId の children に追加した新しいツリーを返す。
+ * - newParentId が null のときはルートへ移動
+ * - 循環参照が発生する場合は OrgChangeError を throw
+ * - 既に newParentId の直下であれば OrgChangeError('SAME_PARENT') を throw
+ */
+export function moveNode(tree: OrgTree, nodeId: string, newParentId: string | null): OrgTree {
+  const target = findNode(tree, nodeId)
+  if (!target) {
+    throw new OrgChangeError('NODE_NOT_FOUND', `Node not found: ${nodeId}`)
+  }
+  if (target.parentId === newParentId) {
+    throw new OrgChangeError('SAME_PARENT', 'Node is already under the requested parent')
+  }
+  if (wouldCreateCycle(tree, nodeId, newParentId)) {
+    throw new OrgChangeError('CYCLE_DETECTED', 'Move would create a cycle in the organization')
+  }
+
+  const detached = detachNode(tree, nodeId)
+  const movedNode: OrgNode = { ...target, parentId: newParentId, children: target.children }
+
+  if (newParentId === null) {
+    return { roots: [...detached.roots, movedNode] }
+  }
+  const newRoots = detached.roots.map((r) => attachUnder(r, newParentId, movedNode))
+  return { roots: newRoots }
+}
+
+/** nodeId をツリーから切り離した新しいツリーを返す */
+function detachNode(tree: OrgTree, nodeId: string): OrgTree {
+  const filteredRoots: OrgNode[] = []
+  for (const root of tree.roots) {
+    if (root.id === nodeId) continue
+    filteredRoots.push(detachRecursive(root, nodeId))
+  }
+  return { roots: filteredRoots }
+}
+
+function detachRecursive(node: OrgNode, nodeId: string): OrgNode {
+  const nextChildren: OrgNode[] = []
+  for (const child of node.children) {
+    if (child.id === nodeId) continue
+    nextChildren.push(detachRecursive(child, nodeId))
+  }
+  return { ...node, children: nextChildren }
+}
+
+/** parentId の直下に newNode を追加した新しいノードを返す */
+function attachUnder(node: OrgNode, parentId: string, newNode: OrgNode): OrgNode {
+  if (node.id === parentId) {
+    return { ...node, children: [...node.children, newNode] }
+  }
+  const nextChildren = node.children.map((c) => attachUnder(c, parentId, newNode))
+  return { ...node, children: nextChildren }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 操作列の適用
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * 操作列を順番に適用した新しいツリーを返す。
+ * 途中でエラーが出たらその場で throw。
+ */
+export function applyOperations(
+  tree: OrgTree,
+  operations: ReadonlyArray<OrgMoveOperation>,
+): OrgTree {
+  let current = tree
+  for (const op of operations) {
+    current = moveNode(current, op.nodeId, op.newParentId)
+  }
+  return current
+}
+
+/**
+ * 2 つのツリーの親子関係に差分があるかを判定 (プレビューで「変更あり」表示に使う)。
+ * positions / name の変更は検知対象外。
+ */
+export function hasStructuralDiff(a: OrgTree, b: OrgTree): boolean {
+  const mapA = buildParentMap(a)
+  const mapB = buildParentMap(b)
+  if (mapA.size !== mapB.size) return true
+  for (const [id, parent] of mapA) {
+    if (mapB.get(id) !== parent) return true
+  }
+  return false
+}
+
+function buildParentMap(tree: OrgTree): Map<string, string | null> {
+  const map = new Map<string, string | null>()
+  for (const node of flattenNodes(tree)) {
+    map.set(node.id, node.parentId)
+  }
+  return map
+}

--- a/src/lib/organization/organization-repository.ts
+++ b/src/lib/organization/organization-repository.ts
@@ -1,0 +1,290 @@
+/**
+ * Issue #27: 組織管理リポジトリ
+ *
+ * - OrgRepository: Department / Position / TransferRecord の narrow port
+ * - PrismaOrgRepository: 本番 DB 実装
+ *
+ * Prisma 固有のエラーは DepartmentNotFoundError / PositionNotFoundError に正規化する。
+ */
+import { Prisma, PrismaClient } from '@prisma/client'
+import {
+  DepartmentNotFoundError,
+  PositionNotFoundError,
+  toDepartmentId,
+  toPositionId,
+  toTransferRecordId,
+  type Department,
+  type DepartmentId,
+  type Position,
+  type PositionId,
+  type TransferRecord,
+} from './organization-types'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Row shapes (mirror of generated client)
+// ─────────────────────────────────────────────────────────────────────────────
+
+type DepartmentRow = {
+  id: string
+  name: string
+  parentId: string | null
+  createdAt: Date
+  deletedAt: Date | null
+}
+
+type PositionRow = {
+  id: string
+  departmentId: string
+  roleId: string
+  holderUserId: string | null
+  supervisorPositionId: string | null
+}
+
+type TransferRecordRow = {
+  id: string
+  userId: string
+  fromPositionId: string | null
+  toPositionId: string | null
+  effectiveDate: Date
+  changedBy: string
+  createdAt: Date
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Mappers
+// ─────────────────────────────────────────────────────────────────────────────
+
+function mapDepartment(row: DepartmentRow): Department {
+  return {
+    id: toDepartmentId(row.id),
+    name: row.name,
+    parentId: row.parentId ? toDepartmentId(row.parentId) : null,
+    createdAt: row.createdAt,
+    deletedAt: row.deletedAt,
+  }
+}
+
+function mapPosition(row: PositionRow): Position {
+  return {
+    id: toPositionId(row.id),
+    departmentId: toDepartmentId(row.departmentId),
+    roleId: row.roleId,
+    holderUserId: row.holderUserId,
+    supervisorPositionId: row.supervisorPositionId ? toPositionId(row.supervisorPositionId) : null,
+  }
+}
+
+function mapTransferRecord(row: TransferRecordRow): TransferRecord {
+  return {
+    id: toTransferRecordId(row.id),
+    userId: row.userId,
+    fromPositionId: row.fromPositionId ? toPositionId(row.fromPositionId) : null,
+    toPositionId: row.toPositionId ? toPositionId(row.toPositionId) : null,
+    effectiveDate: row.effectiveDate,
+    changedBy: row.changedBy,
+    createdAt: row.createdAt,
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Input shapes
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface CreateDepartmentInput {
+  readonly name: string
+  readonly parentId: DepartmentId | null
+}
+
+export interface UpdateDepartmentInput {
+  readonly name?: string
+  readonly parentId?: DepartmentId | null
+}
+
+export interface CreateTransferRecordInput {
+  readonly userId: string
+  readonly fromPositionId: PositionId | null
+  readonly toPositionId: PositionId | null
+  readonly effectiveDate: Date
+  readonly changedBy: string
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Port
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface OrgRepository {
+  // Departments
+  getDepartments(): Promise<Department[]>
+  findDepartmentById(id: DepartmentId): Promise<Department | null>
+  createDepartment(input: CreateDepartmentInput): Promise<Department>
+  updateDepartment(id: DepartmentId, input: UpdateDepartmentInput): Promise<Department>
+  softDeleteDepartment(id: DepartmentId, when: Date): Promise<void>
+
+  // Positions
+  getPositions(): Promise<Position[]>
+  findPositionById(id: PositionId): Promise<Position | null>
+  updatePositionHolder(id: PositionId, newHolderUserId: string | null): Promise<Position>
+  updateSupervisor(id: PositionId, newSupervisorPositionId: PositionId | null): Promise<Position>
+
+  // TransferRecord
+  createTransferRecord(input: CreateTransferRecordInput): Promise<TransferRecord>
+  findPositionOfUser(userId: string): Promise<Position | null>
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Prisma error normalization
+// ─────────────────────────────────────────────────────────────────────────────
+
+function isRecordNotFound(err: unknown): boolean {
+  return err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2025'
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Prisma delegate shim (models depend on schema generation timing)
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface OrgDelegates {
+  department: {
+    findMany(args: unknown): Promise<DepartmentRow[]>
+    findUnique(args: unknown): Promise<DepartmentRow | null>
+    create(args: unknown): Promise<DepartmentRow>
+    update(args: unknown): Promise<DepartmentRow>
+  }
+  position: {
+    findMany(args: unknown): Promise<PositionRow[]>
+    findUnique(args: unknown): Promise<PositionRow | null>
+    findFirst(args: unknown): Promise<PositionRow | null>
+    update(args: unknown): Promise<PositionRow>
+  }
+  transferRecord: {
+    create(args: unknown): Promise<TransferRecordRow>
+  }
+}
+
+function asOrgDelegates(db: PrismaClient): OrgDelegates {
+  return db as unknown as OrgDelegates
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Prisma implementation
+// ─────────────────────────────────────────────────────────────────────────────
+
+class PrismaOrgRepository implements OrgRepository {
+  private readonly delegates: OrgDelegates
+
+  constructor(db: PrismaClient) {
+    this.delegates = asOrgDelegates(db)
+  }
+
+  async getDepartments(): Promise<Department[]> {
+    const rows = await this.delegates.department.findMany({
+      where: { deletedAt: null },
+      orderBy: [{ name: 'asc' }],
+    })
+    return rows.map(mapDepartment)
+  }
+
+  async findDepartmentById(id: DepartmentId): Promise<Department | null> {
+    const row = await this.delegates.department.findUnique({ where: { id } })
+    return row ? mapDepartment(row) : null
+  }
+
+  async createDepartment(input: CreateDepartmentInput): Promise<Department> {
+    const row = await this.delegates.department.create({
+      data: { name: input.name, parentId: input.parentId },
+    })
+    return mapDepartment(row)
+  }
+
+  async updateDepartment(id: DepartmentId, input: UpdateDepartmentInput): Promise<Department> {
+    try {
+      const data: { name?: string; parentId?: string | null } = {}
+      if (input.name !== undefined) data.name = input.name
+      if (input.parentId !== undefined) data.parentId = input.parentId
+      const row = await this.delegates.department.update({ where: { id }, data })
+      return mapDepartment(row)
+    } catch (err) {
+      if (isRecordNotFound(err)) throw new DepartmentNotFoundError(id)
+      throw err
+    }
+  }
+
+  async softDeleteDepartment(id: DepartmentId, when: Date): Promise<void> {
+    try {
+      await this.delegates.department.update({
+        where: { id },
+        data: { deletedAt: when },
+      })
+    } catch (err) {
+      if (isRecordNotFound(err)) throw new DepartmentNotFoundError(id)
+      throw err
+    }
+  }
+
+  async getPositions(): Promise<Position[]> {
+    const rows = await this.delegates.position.findMany({ orderBy: [{ id: 'asc' }] })
+    return rows.map(mapPosition)
+  }
+
+  async findPositionById(id: PositionId): Promise<Position | null> {
+    const row = await this.delegates.position.findUnique({ where: { id } })
+    return row ? mapPosition(row) : null
+  }
+
+  async updatePositionHolder(id: PositionId, newHolderUserId: string | null): Promise<Position> {
+    try {
+      const row = await this.delegates.position.update({
+        where: { id },
+        data: { holderUserId: newHolderUserId },
+      })
+      return mapPosition(row)
+    } catch (err) {
+      if (isRecordNotFound(err)) throw new PositionNotFoundError(id)
+      throw err
+    }
+  }
+
+  async updateSupervisor(
+    id: PositionId,
+    newSupervisorPositionId: PositionId | null,
+  ): Promise<Position> {
+    try {
+      const row = await this.delegates.position.update({
+        where: { id },
+        data: { supervisorPositionId: newSupervisorPositionId },
+      })
+      return mapPosition(row)
+    } catch (err) {
+      if (isRecordNotFound(err)) throw new PositionNotFoundError(id)
+      throw err
+    }
+  }
+
+  async findPositionOfUser(userId: string): Promise<Position | null> {
+    const row = await this.delegates.position.findFirst({
+      where: { holderUserId: userId },
+    })
+    return row ? mapPosition(row) : null
+  }
+
+  async createTransferRecord(input: CreateTransferRecordInput): Promise<TransferRecord> {
+    const row = await this.delegates.transferRecord.create({
+      data: {
+        userId: input.userId,
+        fromPositionId: input.fromPositionId,
+        toPositionId: input.toPositionId,
+        effectiveDate: input.effectiveDate,
+        changedBy: input.changedBy,
+      },
+    })
+    return mapTransferRecord(row)
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Factory
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function createPrismaOrgRepository(db?: PrismaClient): OrgRepository {
+  return new PrismaOrgRepository(db ?? new PrismaClient())
+}

--- a/src/lib/organization/organization-route-helpers.ts
+++ b/src/lib/organization/organization-route-helpers.ts
@@ -1,0 +1,94 @@
+/**
+ * Issue #27: 組織管理 API ルートの共通ヘルパ
+ *
+ * - HR_MANAGER セッションガード (Requirement 3.3)
+ * - 監査コンテキスト抽出 (ipAddress / userAgent)
+ * - ドメインエラー → NextResponse マッピング
+ */
+import { getServerSession } from 'next-auth'
+import { type NextRequest, NextResponse } from 'next/server'
+import {
+  CyclicReferenceError,
+  DepartmentNotFoundError,
+  PositionNotFoundError,
+} from './organization-types'
+import type { OrganizationAuditContext } from './organization-service'
+
+export interface HrManagerSession {
+  readonly userId: string
+  readonly role: 'HR_MANAGER' | 'ADMIN'
+}
+
+/**
+ * HR_MANAGER / ADMIN セッションを検証して userId を返す。
+ * 401 / 403 の場合は NextResponse を返す。
+ */
+export async function requireHrManager(): Promise<
+  { ok: true; session: HrManagerSession } | { ok: false; response: NextResponse }
+> {
+  const serverSession = await getServerSession()
+  if (!serverSession?.user?.email) {
+    return {
+      ok: false,
+      response: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }),
+    }
+  }
+  const sess = serverSession as Record<string, unknown>
+  const role = typeof sess.role === 'string' ? sess.role : undefined
+  const userId = typeof sess.userId === 'string' ? sess.userId : undefined
+  if (!userId || (role !== 'HR_MANAGER' && role !== 'ADMIN')) {
+    return {
+      ok: false,
+      response: NextResponse.json({ error: 'Forbidden' }, { status: 403 }),
+    }
+  }
+  return { ok: true, session: { userId, role: role as HrManagerSession['role'] } }
+}
+
+/** リクエストから監査コンテキストを抽出する */
+export function extractOrganizationAuditContext(
+  req: NextRequest,
+  userId: string,
+): OrganizationAuditContext {
+  const ipAddress =
+    req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ??
+    req.headers.get('x-real-ip') ??
+    'unknown'
+  const userAgent = req.headers.get('user-agent') ?? 'unknown'
+  return { userId, ipAddress, userAgent }
+}
+
+/** リクエストボディを JSON としてパースする */
+export async function parseJsonBody(
+  req: NextRequest,
+): Promise<{ ok: true; body: unknown } | { ok: false; response: NextResponse }> {
+  try {
+    const body = (await req.json()) as unknown
+    return { ok: true, body }
+  } catch {
+    return {
+      ok: false,
+      response: NextResponse.json({ error: 'Invalid JSON' }, { status: 400 }),
+    }
+  }
+}
+
+/** 組織ドメイン例外を HTTP レスポンスに変換する。 */
+export function organizationErrorToResponse(err: unknown): NextResponse {
+  if (err instanceof CyclicReferenceError) {
+    return NextResponse.json(
+      { error: 'Cyclic reference', kind: err.kind, path: err.path },
+      { status: 422 },
+    )
+  }
+  if (err instanceof DepartmentNotFoundError) {
+    return NextResponse.json(
+      { error: 'Department not found', id: err.departmentId },
+      { status: 404 },
+    )
+  }
+  if (err instanceof PositionNotFoundError) {
+    return NextResponse.json({ error: 'Position not found', id: err.positionId }, { status: 404 })
+  }
+  return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+}

--- a/src/lib/organization/organization-service-di.ts
+++ b/src/lib/organization/organization-service-di.ts
@@ -1,0 +1,28 @@
+/**
+ * Issue #27: OrganizationService のシングルトン DI モジュール。
+ * master-service-di.ts と同一パターン。
+ */
+import type { OrganizationService } from './organization-service'
+
+let _organizationService: OrganizationService | null = null
+
+export function setOrganizationServiceForTesting(svc: OrganizationService): void {
+  _organizationService = svc
+}
+
+export function clearOrganizationServiceForTesting(): void {
+  _organizationService = null
+}
+
+export function getOrganizationService(): OrganizationService {
+  if (_organizationService) return _organizationService
+  throw new Error(
+    'OrganizationService is not initialized. ' +
+      'テストでは setOrganizationServiceForTesting() を呼んでください。' +
+      'プロダクションではサーバー起動前に initOrganizationService() を呼んでください。',
+  )
+}
+
+export function initOrganizationService(svc: OrganizationService): void {
+  _organizationService = svc
+}

--- a/src/lib/organization/organization-service.ts
+++ b/src/lib/organization/organization-service.ts
@@ -1,0 +1,422 @@
+/**
+ * Issue #27 / Req 3.3, 3.4, 3.6, 3.7, 3.8: 組織管理サービス
+ *
+ * - getCurrentTree: Department を階層ツリーとして取得 (Req 3.6)
+ * - previewHierarchyChange / commitHierarchyChange:
+ *   変更プレビューと確定。循環参照検出 (Req 3.4) とコミット時の監査ログ記録 (Req 3.3)
+ * - changePosition: ポジション変更時に TransferRecord を記録 (Req 3.7)
+ * - exportCsv: ExportJob に OrganizationCsv ジョブを投入 (Req 3.8)
+ */
+import type { AuditLogEmitter } from '@/lib/audit/audit-log-emitter'
+import type { AuditLogEntry } from '@/lib/audit/audit-log-types'
+import type { ExportJob } from '@/lib/export/export-job'
+import type { ExportJobId } from '@/lib/export/export-types'
+import { detectCycle, type ParentMap } from './cycle-detection'
+import type { OrgRepository } from './organization-repository'
+import {
+  CyclicReferenceError,
+  DepartmentNotFoundError,
+  PositionNotFoundError,
+  toDepartmentId,
+  toPositionId,
+  type Department,
+  type OrgChange,
+  type OrgNode,
+  type OrgTree,
+  type OrgTreePreview,
+  type Position,
+  type PositionId,
+  type TransferRecord,
+  type UserId,
+} from './organization-types'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Result
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type Result<T, E> =
+  | { readonly ok: true; readonly value: T }
+  | { readonly ok: false; readonly error: E }
+
+function ok<T>(value: T): Result<T, never> {
+  return { ok: true, value }
+}
+
+function err<E>(error: E): Result<never, E> {
+  return { ok: false, error }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Context (audit)
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface OrganizationAuditContext {
+  readonly userId: string
+  readonly ipAddress: string
+  readonly userAgent: string
+}
+
+const UNKNOWN_IP = 'unknown'
+const UNKNOWN_UA = 'unknown'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Service interface
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface OrganizationService {
+  getCurrentTree(): Promise<OrgTree>
+  previewHierarchyChange(changes: readonly OrgChange[]): Promise<OrgTreePreview>
+  commitHierarchyChange(
+    changes: readonly OrgChange[],
+    context: OrganizationAuditContext,
+  ): Promise<Result<void, CyclicReferenceError>>
+  changePosition(
+    userId: UserId,
+    newPositionId: PositionId | null,
+    context: OrganizationAuditContext,
+  ): Promise<TransferRecord>
+  exportCsv(context: OrganizationAuditContext): Promise<{ jobId: ExportJobId }>
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Dependencies
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface OrganizationServiceDeps {
+  readonly repo: OrgRepository
+  readonly auditLogEmitter: AuditLogEmitter
+  readonly exportJob: ExportJob
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tree building (pure)
+// ─────────────────────────────────────────────────────────────────────────────
+
+function buildTree(
+  departments: readonly Department[],
+  positions: readonly Position[],
+  capturedAt: Date,
+): OrgTree {
+  const byParent = new Map<string | null, Department[]>()
+  for (const dept of departments) {
+    if (dept.deletedAt) continue
+    const key = dept.parentId ?? null
+    const bucket = byParent.get(key) ?? []
+    bucket.push(dept)
+    byParent.set(key, bucket)
+  }
+
+  const positionsByDept = new Map<string, Position[]>()
+  for (const pos of positions) {
+    const list = positionsByDept.get(pos.departmentId) ?? []
+    list.push(pos)
+    positionsByDept.set(pos.departmentId, list)
+  }
+
+  const buildNode = (dept: Department): OrgNode => ({
+    department: dept,
+    positions: positionsByDept.get(dept.id) ?? [],
+    children: (byParent.get(dept.id) ?? []).map(buildNode),
+  })
+
+  const roots = (byParent.get(null) ?? []).map(buildNode)
+  return { roots, capturedAt }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Change application (pure, over in-memory maps)
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface AppliedChanges {
+  readonly departments: Map<string, Department>
+  readonly positions: Map<string, Position>
+  readonly summary: string[]
+}
+
+function cloneDepartmentsMap(departments: readonly Department[]): Map<string, Department> {
+  const map = new Map<string, Department>()
+  for (const dept of departments) map.set(dept.id, dept)
+  return map
+}
+
+function clonePositionsMap(positions: readonly Position[]): Map<string, Position> {
+  const map = new Map<string, Position>()
+  for (const pos of positions) map.set(pos.id, pos)
+  return map
+}
+
+function applyChanges(
+  departments: readonly Department[],
+  positions: readonly Position[],
+  changes: readonly OrgChange[],
+  now: Date,
+): AppliedChanges {
+  const deptMap = cloneDepartmentsMap(departments)
+  const posMap = clonePositionsMap(positions)
+  const summary: string[] = []
+  for (const change of changes) {
+    applySingleChange(change, deptMap, posMap, summary, now)
+  }
+  return { departments: deptMap, positions: posMap, summary }
+}
+
+function applySingleChange(
+  change: OrgChange,
+  deptMap: Map<string, Department>,
+  posMap: Map<string, Position>,
+  summary: string[],
+  now: Date,
+): void {
+  switch (change.type) {
+    case 'CreateDepartment':
+      deptMap.set(change.tempId, {
+        id: toDepartmentId(change.tempId),
+        name: change.name,
+        parentId: change.parentId ? toDepartmentId(change.parentId) : null,
+        createdAt: now,
+        deletedAt: null,
+      })
+      summary.push(`Create department "${change.name}"`)
+      return
+    case 'RenameDepartment': {
+      const existing = deptMap.get(change.departmentId)
+      if (!existing) throw new DepartmentNotFoundError(change.departmentId)
+      deptMap.set(change.departmentId, { ...existing, name: change.name })
+      summary.push(`Rename department ${change.departmentId} -> "${change.name}"`)
+      return
+    }
+    case 'MoveDepartment': {
+      const existing = deptMap.get(change.departmentId)
+      if (!existing) throw new DepartmentNotFoundError(change.departmentId)
+      deptMap.set(change.departmentId, {
+        ...existing,
+        parentId: change.newParentId ? toDepartmentId(change.newParentId) : null,
+      })
+      summary.push(`Move department ${change.departmentId} under ${change.newParentId ?? 'ROOT'}`)
+      return
+    }
+    case 'DeleteDepartment': {
+      const existing = deptMap.get(change.departmentId)
+      if (!existing) throw new DepartmentNotFoundError(change.departmentId)
+      deptMap.set(change.departmentId, { ...existing, deletedAt: now })
+      summary.push(`Delete department ${change.departmentId}`)
+      return
+    }
+    case 'ChangeSupervisor': {
+      const existing = posMap.get(change.positionId)
+      if (!existing) throw new PositionNotFoundError(change.positionId)
+      posMap.set(change.positionId, {
+        ...existing,
+        supervisorPositionId: change.newSupervisorPositionId
+          ? toPositionId(change.newSupervisorPositionId)
+          : null,
+      })
+      summary.push(
+        `Change supervisor of ${change.positionId} to ${change.newSupervisorPositionId ?? 'NONE'}`,
+      )
+      return
+    }
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Cycle checks (wrap pure function)
+// ─────────────────────────────────────────────────────────────────────────────
+
+function buildDepartmentParentMap(departments: ReadonlyMap<string, Department>): ParentMap {
+  const map = new Map<string, string | null>()
+  for (const [id, dept] of departments) {
+    if (dept.deletedAt) continue
+    map.set(id, dept.parentId)
+  }
+  return map
+}
+
+function buildSupervisorParentMap(positions: ReadonlyMap<string, Position>): ParentMap {
+  const map = new Map<string, string | null>()
+  for (const [id, pos] of positions) {
+    map.set(id, pos.supervisorPositionId)
+  }
+  return map
+}
+
+function assertNoCycle(applied: AppliedChanges): CyclicReferenceError | null {
+  const deptCheck = detectCycle(buildDepartmentParentMap(applied.departments))
+  if (!deptCheck.ok) return new CyclicReferenceError('department', deptCheck.path)
+  const posCheck = detectCycle(buildSupervisorParentMap(applied.positions))
+  if (!posCheck.ok) return new CyclicReferenceError('position', posCheck.path)
+  return null
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Implementation
+// ─────────────────────────────────────────────────────────────────────────────
+
+class OrganizationServiceImpl implements OrganizationService {
+  private readonly repo: OrgRepository
+  private readonly auditLogEmitter: AuditLogEmitter
+  private readonly exportJob: ExportJob
+
+  constructor(deps: OrganizationServiceDeps) {
+    this.repo = deps.repo
+    this.auditLogEmitter = deps.auditLogEmitter
+    this.exportJob = deps.exportJob
+  }
+
+  async getCurrentTree(): Promise<OrgTree> {
+    const [departments, positions] = await Promise.all([
+      this.repo.getDepartments(),
+      this.repo.getPositions(),
+    ])
+    return buildTree(departments, positions, new Date())
+  }
+
+  async previewHierarchyChange(changes: readonly OrgChange[]): Promise<OrgTreePreview> {
+    const [departments, positions] = await Promise.all([
+      this.repo.getDepartments(),
+      this.repo.getPositions(),
+    ])
+    const now = new Date()
+    const applied = applyChanges(departments, positions, changes, now)
+
+    const cyclic = assertNoCycle(applied)
+    const summary = cyclic ? [...applied.summary, `WARNING: ${cyclic.message}`] : applied.summary
+
+    const tree = buildTree([...applied.departments.values()], [...applied.positions.values()], now)
+    return { tree, summary }
+  }
+
+  async commitHierarchyChange(
+    changes: readonly OrgChange[],
+    context: OrganizationAuditContext,
+  ): Promise<Result<void, CyclicReferenceError>> {
+    const [departments, positions] = await Promise.all([
+      this.repo.getDepartments(),
+      this.repo.getPositions(),
+    ])
+    const now = new Date()
+    const applied = applyChanges(departments, positions, changes, now)
+
+    const cyclic = assertNoCycle(applied)
+    if (cyclic) return err(cyclic)
+
+    await this.persistChanges(changes, now)
+    await this.emitOrganizationAudit(changes, context)
+    return ok(undefined)
+  }
+
+  async changePosition(
+    userId: UserId,
+    newPositionId: PositionId | null,
+    context: OrganizationAuditContext,
+  ): Promise<TransferRecord> {
+    const currentPosition = await this.repo.findPositionOfUser(userId)
+    const fromPositionId = currentPosition?.id ?? null
+
+    if (currentPosition && currentPosition.holderUserId === userId) {
+      await this.repo.updatePositionHolder(currentPosition.id, null)
+    }
+    if (newPositionId) {
+      await this.repo.updatePositionHolder(newPositionId, userId)
+    }
+
+    const transfer = await this.repo.createTransferRecord({
+      userId,
+      fromPositionId,
+      toPositionId: newPositionId,
+      effectiveDate: new Date(),
+      changedBy: context.userId,
+    })
+
+    await this.auditLogEmitter.emit({
+      userId: context.userId,
+      action: 'ORGANIZATION_CHANGE',
+      resourceType: 'POSITION',
+      resourceId: newPositionId ?? fromPositionId ?? null,
+      ipAddress: context.ipAddress || UNKNOWN_IP,
+      userAgent: context.userAgent || UNKNOWN_UA,
+      before: fromPositionId ? { positionId: fromPositionId, userId } : null,
+      after: newPositionId ? { positionId: newPositionId, userId } : null,
+    })
+
+    return transfer
+  }
+
+  async exportCsv(context: OrganizationAuditContext): Promise<{ jobId: ExportJobId }> {
+    const result = await this.exportJob.enqueue({ type: 'OrganizationCsv' })
+    await this.auditLogEmitter.emit({
+      userId: context.userId,
+      action: 'DATA_EXPORT',
+      resourceType: 'ORGANIZATION',
+      resourceId: null,
+      ipAddress: context.ipAddress || UNKNOWN_IP,
+      userAgent: context.userAgent || UNKNOWN_UA,
+      before: null,
+      after: { jobId: result.jobId, type: 'OrganizationCsv' },
+    })
+    return result
+  }
+
+  // ── Private ───────────────────────────────────────────────────────────────
+
+  private async persistChanges(changes: readonly OrgChange[], when: Date): Promise<void> {
+    for (const change of changes) {
+      await this.persistSingleChange(change, when)
+    }
+  }
+
+  private async persistSingleChange(change: OrgChange, when: Date): Promise<void> {
+    switch (change.type) {
+      case 'CreateDepartment':
+        await this.repo.createDepartment({
+          name: change.name,
+          parentId: change.parentId ? toDepartmentId(change.parentId) : null,
+        })
+        return
+      case 'RenameDepartment':
+        await this.repo.updateDepartment(toDepartmentId(change.departmentId), {
+          name: change.name,
+        })
+        return
+      case 'MoveDepartment':
+        await this.repo.updateDepartment(toDepartmentId(change.departmentId), {
+          parentId: change.newParentId ? toDepartmentId(change.newParentId) : null,
+        })
+        return
+      case 'DeleteDepartment':
+        await this.repo.softDeleteDepartment(toDepartmentId(change.departmentId), when)
+        return
+      case 'ChangeSupervisor':
+        await this.repo.updateSupervisor(
+          toPositionId(change.positionId),
+          change.newSupervisorPositionId ? toPositionId(change.newSupervisorPositionId) : null,
+        )
+        return
+    }
+  }
+
+  private async emitOrganizationAudit(
+    changes: readonly OrgChange[],
+    context: OrganizationAuditContext,
+  ): Promise<void> {
+    const entry: AuditLogEntry = {
+      userId: context.userId,
+      action: 'ORGANIZATION_CHANGE',
+      resourceType: 'ORGANIZATION',
+      resourceId: null,
+      ipAddress: context.ipAddress || UNKNOWN_IP,
+      userAgent: context.userAgent || UNKNOWN_UA,
+      before: null,
+      after: { changes: changes.map((c) => ({ ...c })) },
+    }
+    await this.auditLogEmitter.emit(entry)
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Factory
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function createOrganizationService(deps: OrganizationServiceDeps): OrganizationService {
+  return new OrganizationServiceImpl(deps)
+}

--- a/src/lib/organization/organization-types.ts
+++ b/src/lib/organization/organization-types.ts
@@ -149,6 +149,18 @@ export type ChangePositionInput = z.infer<typeof changePositionInputSchema>
  * - Department ツリー: parentId 辿りで自己に戻った場合
  * - Position の supervisor: supervisorPositionId 辿りで自己に戻った場合
  */
+/** UI ツリー操作（org-tree-ops）で発生するエラー */
+export type OrgChangeErrorCode = 'CYCLE_DETECTED' | 'SAME_PARENT' | 'NODE_NOT_FOUND'
+
+export class OrgChangeError extends Error {
+  public readonly code: OrgChangeErrorCode
+  constructor(code: OrgChangeErrorCode, message: string) {
+    super(message)
+    this.name = 'OrgChangeError'
+    this.code = code
+  }
+}
+
 export class CyclicReferenceError extends Error {
   public readonly kind: 'department' | 'position'
   public readonly path: readonly string[]

--- a/src/lib/organization/organization-types.ts
+++ b/src/lib/organization/organization-types.ts
@@ -1,0 +1,182 @@
+/**
+ * Issue #27 / Req 3.3, 3.4, 3.6, 3.7, 3.8: 組織管理ドメインの型定義
+ *
+ * - ブランド型 ID: DepartmentId / PositionId / TransferRecordId
+ * - 集約型: Department / Position / TransferRecord / OrgNode / OrgTree / OrgTreePreview
+ * - 変更コマンド (判別共用体): OrgChange
+ * - Zod スキーマ: orgChangeSchema / changePositionInputSchema
+ * - ドメインエラー: CyclicReferenceError
+ */
+import { z } from 'zod'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Branded ID types
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type DepartmentId = string & { readonly __brand: 'DepartmentId' }
+export type PositionId = string & { readonly __brand: 'PositionId' }
+export type TransferRecordId = string & { readonly __brand: 'TransferRecordId' }
+export type UserId = string & { readonly __brand: 'UserId' }
+
+export function toDepartmentId(value: string): DepartmentId {
+  return value as DepartmentId
+}
+export function toPositionId(value: string): PositionId {
+  return value as PositionId
+}
+export function toTransferRecordId(value: string): TransferRecordId {
+  return value as TransferRecordId
+}
+export function toUserId(value: string): UserId {
+  return value as UserId
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Entity shapes
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** 部署 (Requirement 3.6) */
+export interface Department {
+  readonly id: DepartmentId
+  readonly name: string
+  readonly parentId: DepartmentId | null
+  readonly createdAt: Date
+  readonly deletedAt: Date | null
+}
+
+/** ポジション (Requirement 3.6) */
+export interface Position {
+  readonly id: PositionId
+  readonly departmentId: DepartmentId
+  readonly roleId: string
+  readonly holderUserId: string | null
+  readonly supervisorPositionId: PositionId | null
+}
+
+/** 異動履歴 (Requirement 3.7) */
+export interface TransferRecord {
+  readonly id: TransferRecordId
+  readonly userId: string
+  readonly fromPositionId: PositionId | null
+  readonly toPositionId: PositionId | null
+  readonly effectiveDate: Date
+  readonly changedBy: string
+  readonly createdAt: Date
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tree shape (Requirement 3.6)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** 組織ツリーのノード (Department を中心に構成) */
+export interface OrgNode {
+  readonly department: Department
+  readonly positions: readonly Position[]
+  readonly children: readonly OrgNode[]
+}
+
+/** 組織ツリー全体 */
+export interface OrgTree {
+  readonly roots: readonly OrgNode[]
+  readonly capturedAt: Date
+}
+
+/** プレビューは OrgTree に warnings を付加した形で返す */
+export interface OrgTreePreview {
+  readonly tree: OrgTree
+  /** 適用予定変更の摘要 (UI 表示用) */
+  readonly summary: readonly string[]
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// OrgChange (判別共用体 — HR_MANAGER が送るコマンド)
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const orgChangeSchema = z.discriminatedUnion('type', [
+  z.object({
+    type: z.literal('CreateDepartment'),
+    tempId: z.string().min(1),
+    name: z.string().min(1).max(120),
+    parentId: z.string().min(1).nullable(),
+  }),
+  z.object({
+    type: z.literal('RenameDepartment'),
+    departmentId: z.string().min(1),
+    name: z.string().min(1).max(120),
+  }),
+  z.object({
+    type: z.literal('MoveDepartment'),
+    departmentId: z.string().min(1),
+    newParentId: z.string().min(1).nullable(),
+  }),
+  z.object({
+    type: z.literal('DeleteDepartment'),
+    departmentId: z.string().min(1),
+  }),
+  z.object({
+    type: z.literal('ChangeSupervisor'),
+    positionId: z.string().min(1),
+    newSupervisorPositionId: z.string().min(1).nullable(),
+  }),
+])
+
+export type OrgChange = z.infer<typeof orgChangeSchema>
+
+// ─────────────────────────────────────────────────────────────────────────────
+// changePosition input (Requirement 3.7)
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const changePositionInputSchema = z.object({
+  userId: z.string().min(1),
+  newPositionId: z.string().min(1).nullable(),
+  effectiveDate: z
+    .string()
+    .datetime()
+    .optional()
+    .transform((value) => (value ? new Date(value) : new Date())),
+})
+
+export type ChangePositionInput = z.infer<typeof changePositionInputSchema>
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Domain errors
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * 組織変更時の循環参照エラー (Requirement 3.4)
+ *
+ * path は循環が検出されたノード ID の経路。
+ * - Department ツリー: parentId 辿りで自己に戻った場合
+ * - Position の supervisor: supervisorPositionId 辿りで自己に戻った場合
+ */
+export class CyclicReferenceError extends Error {
+  public readonly kind: 'department' | 'position'
+  public readonly path: readonly string[]
+
+  constructor(kind: 'department' | 'position', path: readonly string[]) {
+    super(`Cyclic reference detected in ${kind}: ${path.join(' -> ')}`)
+    this.name = 'CyclicReferenceError'
+    this.kind = kind
+    this.path = path
+  }
+}
+
+/** Department が存在しない */
+export class DepartmentNotFoundError extends Error {
+  public readonly departmentId: string
+  constructor(departmentId: string) {
+    super(`Department not found: ${departmentId}`)
+    this.name = 'DepartmentNotFoundError'
+    this.departmentId = departmentId
+  }
+}
+
+/** Position が存在しない */
+export class PositionNotFoundError extends Error {
+  public readonly positionId: string
+  constructor(positionId: string) {
+    super(`Position not found: ${positionId}`)
+    this.name = 'PositionNotFoundError'
+    this.positionId = positionId
+  }
+}

--- a/src/lib/organization/organization-types.ts
+++ b/src/lib/organization/organization-types.ts
@@ -1,0 +1,110 @@
+/**
+ * Issue #28 / Req 3.1, 3.2, 3.5: 組織図 UI 向け型定義
+ *
+ * - OrgTree / OrgNode / OrgPosition: API `/api/organization/tree` レスポンス形状
+ * - OrgMoveOperation: ドラッグ&ドロップで発生したノード移動情報
+ * - OrgPreviewResponse / OrgCommitResponse: プレビュー / 確定 API のレスポンス
+ *
+ * 設計方針:
+ * - UI 側は OrgTree を受け取り、immutable に更新しながらプレビューを構築する
+ * - 循環参照 (Req 3.4) は Service 層でも検出するが、UI でも pre-check する
+ */
+
+// ─────────────────────────────────────────────────────────────────────────────
+// OrgTree 構造体
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** ポジション (役職) */
+export interface OrgPosition {
+  readonly id: string
+  readonly roleId: string
+  readonly holderUserId: string | null
+  readonly holderName: string | null
+}
+
+/** 組織ノード (部署 / チーム) */
+export interface OrgNode {
+  readonly id: string
+  readonly name: string
+  readonly parentId: string | null
+  readonly positions: ReadonlyArray<OrgPosition>
+  readonly children: ReadonlyArray<OrgNode>
+}
+
+/** 組織ツリールート集合 */
+export interface OrgTree {
+  readonly roots: ReadonlyArray<OrgNode>
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 操作・プレビュー
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * ノード移動操作。
+ * parentId が null のときは "ルートへ移動" を意味する。
+ */
+export interface OrgMoveOperation {
+  readonly nodeId: string
+  readonly newParentId: string | null
+}
+
+/** プレビュー API リクエストボディ */
+export interface OrgPreviewRequest {
+  readonly operations: ReadonlyArray<OrgMoveOperation>
+}
+
+/**
+ * プレビュー API レスポンス。
+ * valid=false の場合は reason に人間可読な理由 (循環参照 など) が入る。
+ */
+export interface OrgPreviewResponse {
+  readonly valid: boolean
+  readonly reason?: string
+  readonly tree: OrgTree
+}
+
+/** 確定 API レスポンス */
+export interface OrgCommitResponse {
+  readonly success: boolean
+  readonly appliedOperations: number
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ドメインエラー (UI 表示用の分類)
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type OrgChangeErrorCode =
+  | 'CYCLE_DETECTED'
+  | 'NODE_NOT_FOUND'
+  | 'SAME_PARENT'
+  | 'INVALID_OPERATION'
+
+export class OrgChangeError extends Error {
+  public readonly code: OrgChangeErrorCode
+
+  constructor(code: OrgChangeErrorCode, message: string) {
+    super(message)
+    this.name = 'OrgChangeError'
+    this.code = code
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// MANAGER 向け直属メンバー
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** 直属メンバー情報 (MANAGER の my-team 画面用) */
+export interface DirectReport {
+  readonly userId: string
+  readonly name: string
+  readonly email: string
+  readonly roleName: string
+  readonly departmentName: string
+}
+
+export interface MyTeamResponse {
+  readonly managerName: string
+  readonly departmentName: string
+  readonly directReports: ReadonlyArray<DirectReport>
+}

--- a/src/tests/lifecycle/employee-csv.test.ts
+++ b/src/tests/lifecycle/employee-csv.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Issue #29 / Req 14.9: employee-csv.ts の単体テスト
+ *
+ * - 正常ケース
+ * - 必須フィールド欠如
+ * - role 不正
+ * - 日付形式不正
+ * - 重複 email
+ */
+import { describe, it, expect } from 'vitest'
+import { parseEmployeeCsv } from '@/lib/lifecycle/employee-csv'
+
+const HEADER = 'email,firstName,lastName,role,hireDate,departmentId,positionId'
+
+describe('parseEmployeeCsv()', () => {
+  describe('正常ケース', () => {
+    it('ヘッダー + 1 行を解釈する', () => {
+      const csv = `${HEADER}\nalice@example.com,Alice,Anderson,EMPLOYEE,2026-04-01,dept-001,pos-001\n`
+      const { rows, errors } = parseEmployeeCsv(csv)
+      expect(errors).toEqual([])
+      expect(rows).toHaveLength(1)
+      expect(rows[0]).toMatchObject({
+        rowNumber: 2,
+        email: 'alice@example.com',
+        firstName: 'Alice',
+        lastName: 'Anderson',
+        role: 'EMPLOYEE',
+        departmentId: 'dept-001',
+        positionId: 'pos-001',
+      })
+      expect(rows[0]?.hireDate.toISOString()).toBe('2026-04-01T00:00:00.000Z')
+    })
+
+    it('複数行を解釈する', () => {
+      const csv =
+        `${HEADER}\n` +
+        'alice@example.com,Alice,Anderson,EMPLOYEE,2026-04-01,dept-001,pos-001\n' +
+        'bob@example.com,Bob,Brown,MANAGER,2025-10-15,dept-002,pos-002\n'
+      const { rows, errors } = parseEmployeeCsv(csv)
+      expect(errors).toEqual([])
+      expect(rows).toHaveLength(2)
+      expect(rows[1]?.role).toBe('MANAGER')
+    })
+
+    it('空行をスキップする', () => {
+      const csv =
+        `${HEADER}\n` +
+        'alice@example.com,Alice,Anderson,EMPLOYEE,2026-04-01,dept-001,pos-001\n' +
+        '\n' +
+        '   ,,,,,,\n' +
+        'bob@example.com,Bob,Brown,MANAGER,2025-10-15,dept-002,pos-002\n'
+      const { rows, errors } = parseEmployeeCsv(csv)
+      expect(errors).toEqual([])
+      expect(rows).toHaveLength(2)
+    })
+  })
+
+  describe('必須フィールド欠如', () => {
+    it('email が空ならエラー', () => {
+      const csv = `${HEADER}\n,Alice,Anderson,EMPLOYEE,2026-04-01,dept-001,pos-001\n`
+      const { rows, errors } = parseEmployeeCsv(csv)
+      expect(rows).toHaveLength(0)
+      expect(errors.some((e) => e.field === 'email')).toBe(true)
+      expect(errors[0]?.rowNumber).toBe(2)
+    })
+
+    it('firstName が空ならエラー', () => {
+      const csv = `${HEADER}\nalice@example.com,,Anderson,EMPLOYEE,2026-04-01,dept-001,pos-001\n`
+      const { rows, errors } = parseEmployeeCsv(csv)
+      expect(rows).toHaveLength(0)
+      expect(errors.some((e) => e.field === 'firstName')).toBe(true)
+    })
+
+    it('lastName が空ならエラー', () => {
+      const csv = `${HEADER}\nalice@example.com,Alice,,EMPLOYEE,2026-04-01,dept-001,pos-001\n`
+      const { rows, errors } = parseEmployeeCsv(csv)
+      expect(rows).toHaveLength(0)
+      expect(errors.some((e) => e.field === 'lastName')).toBe(true)
+    })
+
+    it('departmentId が空ならエラー', () => {
+      const csv = `${HEADER}\nalice@example.com,Alice,Anderson,EMPLOYEE,2026-04-01,,pos-001\n`
+      const { rows, errors } = parseEmployeeCsv(csv)
+      expect(rows).toHaveLength(0)
+      expect(errors.some((e) => e.field === 'departmentId')).toBe(true)
+    })
+
+    it('positionId が空ならエラー', () => {
+      const csv = `${HEADER}\nalice@example.com,Alice,Anderson,EMPLOYEE,2026-04-01,dept-001,\n`
+      const { rows, errors } = parseEmployeeCsv(csv)
+      expect(rows).toHaveLength(0)
+      expect(errors.some((e) => e.field === 'positionId')).toBe(true)
+    })
+
+    it('複数フィールド欠如は複数エラー', () => {
+      const csv = `${HEADER}\n,,,,2026-04-01,,\n`
+      const { rows, errors } = parseEmployeeCsv(csv)
+      expect(rows).toHaveLength(0)
+      const fields = new Set(errors.map((e) => e.field))
+      expect(fields.has('email')).toBe(true)
+      expect(fields.has('firstName')).toBe(true)
+      expect(fields.has('lastName')).toBe(true)
+    })
+  })
+
+  describe('email 形式不正', () => {
+    it('@ が無い email はエラー', () => {
+      const csv = `${HEADER}\nnot-an-email,Alice,Anderson,EMPLOYEE,2026-04-01,dept-001,pos-001\n`
+      const { rows, errors } = parseEmployeeCsv(csv)
+      expect(rows).toHaveLength(0)
+      const emailErr = errors.find((e) => e.field === 'email')
+      expect(emailErr?.message).toContain('不正')
+    })
+  })
+
+  describe('role 不正', () => {
+    it('未知の role はエラー', () => {
+      const csv = `${HEADER}\nalice@example.com,Alice,Anderson,INTERN,2026-04-01,dept-001,pos-001\n`
+      const { rows, errors } = parseEmployeeCsv(csv)
+      expect(rows).toHaveLength(0)
+      const roleErr = errors.find((e) => e.field === 'role')
+      expect(roleErr).toBeDefined()
+      expect(roleErr?.message).toContain('ADMIN')
+    })
+
+    it('大文字小文字違いは不可', () => {
+      const csv = `${HEADER}\nalice@example.com,Alice,Anderson,employee,2026-04-01,dept-001,pos-001\n`
+      const { rows, errors } = parseEmployeeCsv(csv)
+      expect(rows).toHaveLength(0)
+      expect(errors.some((e) => e.field === 'role')).toBe(true)
+    })
+
+    it.each(['ADMIN', 'HR_MANAGER', 'MANAGER', 'EMPLOYEE'])('%s は受け入れる', (role) => {
+      const csv = `${HEADER}\nalice@example.com,Alice,Anderson,${role},2026-04-01,dept-001,pos-001\n`
+      const { rows, errors } = parseEmployeeCsv(csv)
+      expect(errors).toEqual([])
+      expect(rows[0]?.role).toBe(role)
+    })
+  })
+
+  describe('日付形式不正', () => {
+    it('YYYY/MM/DD は不可', () => {
+      const csv = `${HEADER}\nalice@example.com,Alice,Anderson,EMPLOYEE,2026/04/01,dept-001,pos-001\n`
+      const { rows, errors } = parseEmployeeCsv(csv)
+      expect(rows).toHaveLength(0)
+      expect(errors.some((e) => e.field === 'hireDate')).toBe(true)
+    })
+
+    it('日時付き (ISO datetime) は不可', () => {
+      const csv = `${HEADER}\nalice@example.com,Alice,Anderson,EMPLOYEE,2026-04-01T00:00:00Z,dept-001,pos-001\n`
+      const { rows, errors } = parseEmployeeCsv(csv)
+      expect(rows).toHaveLength(0)
+      expect(errors.some((e) => e.field === 'hireDate')).toBe(true)
+    })
+
+    it('存在しない日付 (2026-02-30) は不可', () => {
+      const csv = `${HEADER}\nalice@example.com,Alice,Anderson,EMPLOYEE,2026-02-30,dept-001,pos-001\n`
+      const { rows, errors } = parseEmployeeCsv(csv)
+      expect(rows).toHaveLength(0)
+      expect(errors.some((e) => e.field === 'hireDate')).toBe(true)
+    })
+
+    it('空文字列はエラー', () => {
+      const csv = `${HEADER}\nalice@example.com,Alice,Anderson,EMPLOYEE,,dept-001,pos-001\n`
+      const { rows, errors } = parseEmployeeCsv(csv)
+      expect(rows).toHaveLength(0)
+      expect(errors.some((e) => e.field === 'hireDate')).toBe(true)
+    })
+  })
+
+  describe('重複 email', () => {
+    it('同一 CSV 内で重複した email は 2 件目以降がエラー', () => {
+      const csv =
+        `${HEADER}\n` +
+        'alice@example.com,Alice,Anderson,EMPLOYEE,2026-04-01,dept-001,pos-001\n' +
+        'bob@example.com,Bob,Brown,MANAGER,2025-10-15,dept-002,pos-002\n' +
+        'alice@example.com,Alice2,Anderson2,EMPLOYEE,2026-05-01,dept-003,pos-003\n'
+      const { rows, errors } = parseEmployeeCsv(csv)
+      expect(rows).toHaveLength(2)
+      const dupErr = errors.find((e) => e.field === 'email' && e.rowNumber === 4)
+      expect(dupErr?.message).toContain('重複')
+    })
+
+    it('大文字小文字違いも重複とみなす', () => {
+      const csv =
+        `${HEADER}\n` +
+        'alice@example.com,Alice,Anderson,EMPLOYEE,2026-04-01,dept-001,pos-001\n' +
+        'ALICE@example.com,Alice2,Anderson2,EMPLOYEE,2026-05-01,dept-003,pos-003\n'
+      const { rows, errors } = parseEmployeeCsv(csv)
+      expect(rows).toHaveLength(1)
+      expect(errors.some((e) => e.field === 'email' && e.rowNumber === 3)).toBe(true)
+    })
+  })
+
+  describe('ヘッダーエラー', () => {
+    it('ヘッダーが不正なら行データは処理しない', () => {
+      const csv = 'foo,bar,baz\nrow1,row2,row3\n'
+      const { rows, errors } = parseEmployeeCsv(csv)
+      expect(rows).toHaveLength(0)
+      expect(errors).toHaveLength(1)
+      expect(errors[0]?.rowNumber).toBe(1)
+    })
+
+    it('空入力はヘッダーエラー', () => {
+      const { rows, errors } = parseEmployeeCsv('')
+      expect(rows).toHaveLength(0)
+      expect(errors).toHaveLength(1)
+    })
+  })
+})

--- a/src/tests/lifecycle/employees-route.test.ts
+++ b/src/tests/lifecycle/employees-route.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Issue #29 / Req 14.1: POST /api/lifecycle/employees ルートハンドラのテスト
+ *
+ * - 201: 正常作成
+ * - 422: バリデーションエラー
+ * - 401: 未認証
+ * - 403: ADMIN / HR_MANAGER 以外
+ * - 409: email 重複
+ * - 503: サービス未初期化
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import { EmployeeAlreadyExistsError, type Employee } from '@/lib/lifecycle/lifecycle-types'
+import type { LifecycleService } from '@/lib/lifecycle/lifecycle-service'
+
+vi.mock('next-auth', () => ({
+  getServerSession: vi.fn(),
+}))
+
+const { getServerSession } = await import('next-auth')
+const mockedGetServerSession = vi.mocked(getServerSession)
+
+const { POST, setLifecycleServiceForTesting, clearLifecycleServiceForTesting } =
+  await import('@/app/api/lifecycle/employees/route')
+
+const VALID_BODY = {
+  email: 'alice@example.com',
+  firstName: 'Alice',
+  lastName: 'Anderson',
+  role: 'EMPLOYEE',
+  hireDate: '2026-04-01',
+  departmentId: 'dept-001',
+  positionId: 'pos-001',
+}
+
+function makeRequest(body: unknown): NextRequest {
+  return new NextRequest('http://localhost/api/lifecycle/employees', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+function makeSession(role: string, userId = 'actor-1') {
+  return { user: { email: 'actor@example.com' }, role, userId }
+}
+
+function makeEmployee(overrides: Partial<Employee> = {}): Employee {
+  return {
+    id: 'user-1',
+    email: 'alice@example.com',
+    firstName: 'Alice',
+    lastName: 'Anderson',
+    role: 'EMPLOYEE',
+    hireDate: new Date('2026-04-01T00:00:00.000Z'),
+    departmentId: 'dept-001',
+    positionId: 'pos-001',
+    ...overrides,
+  }
+}
+
+function makeLifecycleService(overrides?: Partial<LifecycleService>): LifecycleService {
+  return {
+    createEmployee: vi.fn().mockResolvedValue(makeEmployee()),
+    bulkImportUsers: vi.fn(),
+    ...overrides,
+  } as unknown as LifecycleService
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+afterEach(() => {
+  clearLifecycleServiceForTesting()
+})
+
+describe('POST /api/lifecycle/employees', () => {
+  it('201: ADMIN の正常作成', async () => {
+    mockedGetServerSession.mockResolvedValue(makeSession('ADMIN'))
+    setLifecycleServiceForTesting(makeLifecycleService())
+    const res = await POST(makeRequest(VALID_BODY))
+    expect(res.status).toBe(201)
+    const body = (await res.json()) as { id: string; hireDate: string }
+    expect(body.id).toBe('user-1')
+    expect(body.hireDate).toBe('2026-04-01')
+  })
+
+  it('201: HR_MANAGER も作成可能', async () => {
+    mockedGetServerSession.mockResolvedValue(makeSession('HR_MANAGER'))
+    setLifecycleServiceForTesting(makeLifecycleService())
+    const res = await POST(makeRequest(VALID_BODY))
+    expect(res.status).toBe(201)
+  })
+
+  it('401: 未認証は 401', async () => {
+    mockedGetServerSession.mockResolvedValue(null)
+    const res = await POST(makeRequest(VALID_BODY))
+    expect(res.status).toBe(401)
+  })
+
+  it('403: MANAGER は 403', async () => {
+    mockedGetServerSession.mockResolvedValue(makeSession('MANAGER'))
+    setLifecycleServiceForTesting(makeLifecycleService())
+    const res = await POST(makeRequest(VALID_BODY))
+    expect(res.status).toBe(403)
+  })
+
+  it('403: EMPLOYEE は 403', async () => {
+    mockedGetServerSession.mockResolvedValue(makeSession('EMPLOYEE'))
+    setLifecycleServiceForTesting(makeLifecycleService())
+    const res = await POST(makeRequest(VALID_BODY))
+    expect(res.status).toBe(403)
+  })
+
+  it('422: email が不正な場合', async () => {
+    mockedGetServerSession.mockResolvedValue(makeSession('ADMIN'))
+    setLifecycleServiceForTesting(makeLifecycleService())
+    const res = await POST(makeRequest({ ...VALID_BODY, email: 'not-email' }))
+    expect(res.status).toBe(422)
+  })
+
+  it('422: hireDate が不正な形式', async () => {
+    mockedGetServerSession.mockResolvedValue(makeSession('ADMIN'))
+    setLifecycleServiceForTesting(makeLifecycleService())
+    const res = await POST(makeRequest({ ...VALID_BODY, hireDate: '2026/04/01' }))
+    expect(res.status).toBe(422)
+  })
+
+  it('422: role が不正', async () => {
+    mockedGetServerSession.mockResolvedValue(makeSession('ADMIN'))
+    setLifecycleServiceForTesting(makeLifecycleService())
+    const res = await POST(makeRequest({ ...VALID_BODY, role: 'INTERN' }))
+    expect(res.status).toBe(422)
+  })
+
+  it('422: 必須フィールド欠如 (firstName)', async () => {
+    mockedGetServerSession.mockResolvedValue(makeSession('ADMIN'))
+    setLifecycleServiceForTesting(makeLifecycleService())
+    const { firstName: _omitted, ...rest } = VALID_BODY
+    void _omitted
+    const res = await POST(makeRequest(rest))
+    expect(res.status).toBe(422)
+  })
+
+  it('400: Invalid JSON は 400', async () => {
+    mockedGetServerSession.mockResolvedValue(makeSession('ADMIN'))
+    setLifecycleServiceForTesting(makeLifecycleService())
+    const req = new NextRequest('http://localhost/api/lifecycle/employees', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: 'not-json',
+    })
+    const res = await POST(req)
+    expect(res.status).toBe(400)
+  })
+
+  it('409: email 重複', async () => {
+    mockedGetServerSession.mockResolvedValue(makeSession('ADMIN'))
+    setLifecycleServiceForTesting(
+      makeLifecycleService({
+        createEmployee: vi
+          .fn()
+          .mockRejectedValue(new EmployeeAlreadyExistsError('alice@example.com')),
+      }),
+    )
+    const res = await POST(makeRequest(VALID_BODY))
+    expect(res.status).toBe(409)
+    const body = (await res.json()) as { email: string }
+    expect(body.email).toBe('alice@example.com')
+  })
+
+  it('503: サービス未初期化', async () => {
+    mockedGetServerSession.mockResolvedValue(makeSession('ADMIN'))
+    // setLifecycleServiceForTesting を呼ばない
+    const res = await POST(makeRequest(VALID_BODY))
+    expect(res.status).toBe(503)
+  })
+
+  it('500: 未知のエラーは 500', async () => {
+    mockedGetServerSession.mockResolvedValue(makeSession('ADMIN'))
+    setLifecycleServiceForTesting(
+      makeLifecycleService({
+        createEmployee: vi.fn().mockRejectedValue(new Error('boom')),
+      }),
+    )
+    const res = await POST(makeRequest(VALID_BODY))
+    expect(res.status).toBe(500)
+  })
+})

--- a/src/tests/lifecycle/lifecycle-service.test.ts
+++ b/src/tests/lifecycle/lifecycle-service.test.ts
@@ -1,0 +1,294 @@
+/**
+ * Issue #29 / Req 14.1, 14.9: LifecycleService の単体テスト
+ *
+ * - createEmployee: InvitationService.inviteUser が呼ばれる / Profile 保存
+ * - bulkImportUsers: 全行成功 / 一部失敗（エラー集約）
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { createInvitationService } from '@/lib/auth/invitation-service'
+import { createInMemoryInvitationTokenRepository } from '@/lib/auth/invitation-token-repository'
+import { createInMemoryAuthUserRepository } from '@/lib/auth/user-repository'
+import type { PasswordHasher } from '@/lib/auth/password-hasher'
+import type { InvitationEmailSender } from '@/lib/auth/invitation-service'
+import type { InvitationService } from '@/lib/auth/invitation-service'
+import { EmailAlreadyExistsError } from '@/lib/auth/invitation-types'
+import { createLifecycleService } from '@/lib/lifecycle/lifecycle-service'
+import type { EmployeeProfileRepository } from '@/lib/lifecycle/lifecycle-service'
+import { EmployeeAlreadyExistsError } from '@/lib/lifecycle/lifecycle-types'
+
+const APP_SECRET = 'test-secret-32-chars-long-enough!!'
+const HEADER = 'email,firstName,lastName,role,hireDate,departmentId,positionId'
+
+function makeHasher(): PasswordHasher {
+  return {
+    hash: vi.fn().mockResolvedValue('$2b$12$hashed'),
+    verify: vi.fn().mockResolvedValue(false),
+  }
+}
+
+function makeEmailSender(): InvitationEmailSender {
+  return { sendInvitationEmail: vi.fn().mockResolvedValue(undefined) }
+}
+
+function makeProfileRepo() {
+  const saved: Array<{
+    userId: string
+    firstName: string
+    lastName: string
+    hireDate: Date
+    departmentId: string
+    positionId: string
+  }> = []
+  const repo: EmployeeProfileRepository = {
+    async saveProfile(profile) {
+      saved.push({ ...profile })
+    },
+  }
+  return { repo, saved }
+}
+
+function makeRealSetup(jobId = 'job-abc') {
+  const tokens = createInMemoryInvitationTokenRepository()
+  const users = createInMemoryAuthUserRepository()
+  const hasher = makeHasher()
+  const emailSender = makeEmailSender()
+  let userCounter = 0
+  const invitations = createInvitationService({
+    tokens,
+    users,
+    passwordHasher: hasher,
+    emailSender,
+    appSecret: APP_SECRET,
+    userIdFactory: () => `user-${++userCounter}`,
+    tokenFactory: () => `token-${userCounter}`,
+    clock: () => new Date('2026-04-18T10:00:00.000Z'),
+  })
+  const { repo: profiles, saved } = makeProfileRepo()
+  const svc = createLifecycleService({
+    invitations,
+    users,
+    profiles,
+    appSecret: APP_SECRET,
+    jobIdFactory: () => jobId,
+  })
+  return { svc, users, invitations, emailSender, saved }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// createEmployee
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('LifecycleService.createEmployee', () => {
+  it('InvitationService.inviteUser が呼ばれて PENDING_JOIN ユーザーが作成される', async () => {
+    const { svc, users, emailSender } = makeRealSetup()
+
+    const employee = await svc.createEmployee(
+      {
+        email: 'alice@example.com',
+        firstName: 'Alice',
+        lastName: 'Anderson',
+        role: 'EMPLOYEE',
+        hireDate: new Date('2026-04-01T00:00:00.000Z'),
+        departmentId: 'dept-001',
+        positionId: 'pos-001',
+      },
+      'admin-1',
+    )
+
+    // 招待メール送信
+    expect(emailSender.sendInvitationEmail).toHaveBeenCalledWith(
+      expect.objectContaining({ to: 'alice@example.com', role: 'EMPLOYEE' }),
+    )
+
+    // PENDING_JOIN ユーザーが作成されている
+    const user = await users.findById(employee.id)
+    expect(user?.status).toBe('PENDING_JOIN')
+    expect(user?.role).toBe('EMPLOYEE')
+
+    // 返却値の検証
+    expect(employee.email).toBe('alice@example.com')
+    expect(employee.firstName).toBe('Alice')
+    expect(employee.departmentId).toBe('dept-001')
+  })
+
+  it('プロフィール（hireDate / departmentId / positionId）が保存される', async () => {
+    const { svc, saved } = makeRealSetup()
+
+    await svc.createEmployee(
+      {
+        email: 'bob@example.com',
+        firstName: 'Bob',
+        lastName: 'Brown',
+        role: 'MANAGER',
+        hireDate: new Date('2025-10-15T00:00:00.000Z'),
+        departmentId: 'dept-002',
+        positionId: 'pos-002',
+      },
+      'admin-1',
+    )
+
+    expect(saved).toHaveLength(1)
+    expect(saved[0]).toMatchObject({
+      firstName: 'Bob',
+      lastName: 'Brown',
+      departmentId: 'dept-002',
+      positionId: 'pos-002',
+    })
+    expect(saved[0]?.hireDate.toISOString()).toBe('2025-10-15T00:00:00.000Z')
+  })
+
+  it('重複 email は EmployeeAlreadyExistsError', async () => {
+    const { svc } = makeRealSetup()
+
+    const input = {
+      email: 'alice@example.com',
+      firstName: 'Alice',
+      lastName: 'Anderson',
+      role: 'EMPLOYEE' as const,
+      hireDate: new Date('2026-04-01T00:00:00.000Z'),
+      departmentId: 'dept-001',
+      positionId: 'pos-001',
+    }
+    await svc.createEmployee(input, 'admin-1')
+
+    await expect(svc.createEmployee(input, 'admin-1')).rejects.toBeInstanceOf(
+      EmployeeAlreadyExistsError,
+    )
+  })
+
+  it('InvitationService が他のエラーを投げた場合はそのまま伝播する', async () => {
+    const mockInvitations: InvitationService = {
+      inviteUser: vi.fn().mockRejectedValue(new Error('network down')),
+      acceptInvitation: vi.fn(),
+    }
+    const users = createInMemoryAuthUserRepository()
+    const { repo: profiles } = makeProfileRepo()
+    const svc = createLifecycleService({
+      invitations: mockInvitations,
+      users,
+      profiles,
+      appSecret: APP_SECRET,
+    })
+
+    await expect(
+      svc.createEmployee(
+        {
+          email: 'x@example.com',
+          firstName: 'X',
+          lastName: 'Y',
+          role: 'EMPLOYEE',
+          hireDate: new Date('2026-04-01T00:00:00.000Z'),
+          departmentId: 'd',
+          positionId: 'p',
+        },
+        'admin-1',
+      ),
+    ).rejects.toThrow('network down')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// bulkImportUsers
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('LifecycleService.bulkImportUsers', () => {
+  it('全行成功: 3 行すべて成功', async () => {
+    const { svc } = makeRealSetup('job-success')
+    const csv =
+      `${HEADER}\n` +
+      'alice@example.com,Alice,Anderson,EMPLOYEE,2026-04-01,dept-001,pos-001\n' +
+      'bob@example.com,Bob,Brown,MANAGER,2025-10-15,dept-002,pos-002\n' +
+      'carol@example.com,Carol,Chen,HR_MANAGER,2024-06-30,dept-003,pos-003\n'
+
+    const result = await svc.bulkImportUsers(Buffer.from(csv, 'utf-8'), 'admin-1')
+
+    expect(result.totalRows).toBe(3)
+    expect(result.successCount).toBe(3)
+    expect(result.failureCount).toBe(0)
+    expect(result.errors).toEqual([])
+    expect(result.jobId).toBe('job-success')
+  })
+
+  it('一部失敗: バリデーションエラー行が集約される', async () => {
+    const { svc } = makeRealSetup()
+    const csv =
+      `${HEADER}\n` +
+      'alice@example.com,Alice,Anderson,EMPLOYEE,2026-04-01,dept-001,pos-001\n' +
+      'not-an-email,Bob,Brown,MANAGER,2025-10-15,dept-002,pos-002\n' +
+      'carol@example.com,Carol,Chen,UNKNOWN_ROLE,2024-06-30,dept-003,pos-003\n' +
+      'dave@example.com,Dave,Davis,EMPLOYEE,not-a-date,dept-004,pos-004\n'
+
+    const result = await svc.bulkImportUsers(Buffer.from(csv, 'utf-8'), 'admin-1')
+
+    expect(result.successCount).toBe(1)
+    expect(result.failureCount).toBeGreaterThanOrEqual(3)
+    expect(result.totalRows).toBe(result.successCount + result.failureCount)
+    expect(result.errors.some((e) => e.field === 'email')).toBe(true)
+    expect(result.errors.some((e) => e.field === 'role')).toBe(true)
+    expect(result.errors.some((e) => e.field === 'hireDate')).toBe(true)
+  })
+
+  it('重複 email の 2 件目以降は失敗として集約される', async () => {
+    const { svc } = makeRealSetup()
+    const csv =
+      `${HEADER}\n` +
+      'alice@example.com,Alice,Anderson,EMPLOYEE,2026-04-01,dept-001,pos-001\n' +
+      'alice@example.com,Alice2,Anderson2,EMPLOYEE,2026-05-01,dept-002,pos-002\n'
+
+    const result = await svc.bulkImportUsers(Buffer.from(csv, 'utf-8'), 'admin-1')
+
+    expect(result.successCount).toBe(1)
+    expect(result.failureCount).toBe(1)
+    expect(result.totalRows).toBe(2)
+  })
+
+  it('DB 重複 (InvitationService が EmailAlreadyExistsError) はエラー集約', async () => {
+    const mockInvitations: InvitationService = {
+      inviteUser: vi.fn().mockRejectedValue(new EmailAlreadyExistsError()),
+      acceptInvitation: vi.fn(),
+    }
+    const users = createInMemoryAuthUserRepository()
+    const { repo: profiles } = makeProfileRepo()
+    const svc = createLifecycleService({
+      invitations: mockInvitations,
+      users,
+      profiles,
+      appSecret: APP_SECRET,
+      jobIdFactory: () => 'job-dup',
+    })
+
+    const csv =
+      `${HEADER}\n` + 'alice@example.com,Alice,Anderson,EMPLOYEE,2026-04-01,dept-001,pos-001\n'
+
+    const result = await svc.bulkImportUsers(Buffer.from(csv, 'utf-8'), 'admin-1')
+    expect(result.successCount).toBe(0)
+    expect(result.failureCount).toBe(1)
+    expect(result.errors[0]?.field).toBe('email')
+    expect(result.errors[0]?.message).toContain('既に登録済み')
+  })
+
+  it('ヘッダー不正は errors にヘッダーエラー 1 件だけ返り successCount=0', async () => {
+    const { svc } = makeRealSetup()
+    const result = await svc.bulkImportUsers(
+      Buffer.from('foo,bar,baz\nx,y,z\n', 'utf-8'),
+      'admin-1',
+    )
+    expect(result.successCount).toBe(0)
+    expect(result.failureCount).toBe(1)
+    expect(result.totalRows).toBe(1)
+  })
+
+  it('常に totalRows = successCount + failureCount を満たす', async () => {
+    const { svc } = makeRealSetup()
+    const csv =
+      `${HEADER}\n` +
+      'alice@example.com,Alice,Anderson,EMPLOYEE,2026-04-01,dept-001,pos-001\n' +
+      ',Bob,Brown,MANAGER,2025-10-15,dept-002,pos-002\n'
+    const result = await svc.bulkImportUsers(Buffer.from(csv, 'utf-8'), 'admin-1')
+    expect(result.totalRows).toBe(result.successCount + result.failureCount)
+  })
+})

--- a/src/tests/organization/OrgNode.test.tsx
+++ b/src/tests/organization/OrgNode.test.tsx
@@ -1,0 +1,194 @@
+/**
+ * Issue #28 / Req 3.1: OrgNodeCard レンダリング確認テスト
+ *
+ * jsdom / @testing-library/react は未導入のため、react-dom/server の
+ * renderToString で SSR 相当の HTML を文字列として取得し、
+ * - 部署名
+ * - ポジション一覧 (ホルダー名 / 未配属)
+ * - メンバー数 (合計 holderUserId 埋まり数)
+ * が含まれることを確認する。
+ *
+ * ドラッグ&ドロップ自体の動作はこのテストのスコープ外 (E2E で検証する想定)。
+ */
+import { describe, expect, it } from 'vitest'
+import { renderToString } from 'react-dom/server'
+import { OrgNodeCard } from '@/components/organization/OrgNode'
+import type { OrgNode } from '@/lib/organization/organization-types'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// フィクスチャ
+// ─────────────────────────────────────────────────────────────────────────────
+
+function makeLeaf(id: string, name: string, holderName: string | null): OrgNode {
+  return {
+    id,
+    name,
+    parentId: null,
+    children: [],
+    positions: [
+      {
+        id: `${id}-pos-1`,
+        roleId: 'ENGINEER',
+        holderUserId: holderName ? `${id}-user` : null,
+        holderName,
+      },
+    ],
+  }
+}
+
+function makeTreeWithChildren(): OrgNode {
+  const child1 = makeLeaf('child-1', 'フロントエンドチーム', '山田 太郎')
+  const child2 = makeLeaf('child-2', 'バックエンドチーム', null)
+  return {
+    id: 'root-1',
+    name: '開発部',
+    parentId: null,
+    positions: [
+      {
+        id: 'root-1-pos-1',
+        roleId: 'DIRECTOR',
+        holderUserId: 'root-1-user',
+        holderName: '佐藤 花子',
+      },
+    ],
+    children: [child1, child2],
+  }
+}
+
+function noop(): void {
+  // テスト用のダミー onX ハンドラ
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// テスト
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('OrgNodeCard rendering', () => {
+  it('部署名を表示する', () => {
+    const node = makeLeaf('n1', 'マーケティング部', '鈴木 一郎')
+    const html = renderToString(
+      <OrgNodeCard
+        node={node}
+        editable={false}
+        draggingNodeId={null}
+        onDragStart={noop}
+        onDragEnd={noop}
+        onDropOn={noop}
+      />,
+    )
+    expect(html).toContain('マーケティング部')
+  })
+
+  it('ポジションのホルダー名が埋まっていれば表示する', () => {
+    const node = makeLeaf('n2', '営業部', '田中 次郎')
+    const html = renderToString(
+      <OrgNodeCard
+        node={node}
+        editable={false}
+        draggingNodeId={null}
+        onDragStart={noop}
+        onDragEnd={noop}
+        onDropOn={noop}
+      />,
+    )
+    expect(html).toContain('田中 次郎')
+    expect(html).toContain('ENGINEER')
+  })
+
+  it('ホルダーがいない場合は「未配属」と表示する', () => {
+    const node = makeLeaf('n3', '新規事業部', null)
+    const html = renderToString(
+      <OrgNodeCard
+        node={node}
+        editable={false}
+        draggingNodeId={null}
+        onDragStart={noop}
+        onDragEnd={noop}
+        onDropOn={noop}
+      />,
+    )
+    expect(html).toContain('未配属')
+  })
+
+  it('子孫を含めた合計メンバー数 (ホルダー埋まり数) を表示する', () => {
+    // root: 1 名 + child-1: 1 名 + child-2: 0 名 = 合計 2 名
+    const node = makeTreeWithChildren()
+    const html = renderToString(
+      <OrgNodeCard
+        node={node}
+        editable={false}
+        draggingNodeId={null}
+        onDragStart={noop}
+        onDragEnd={noop}
+        onDropOn={noop}
+      />,
+    )
+    // React SSR はテキストノード間にコメントマーカーを挿入するため正規表現で照合
+    expect(html).toMatch(/メンバー\s(?:<!--\s*-->)?2(?:<!--\s*-->)?\s名/)
+  })
+
+  it('editable=false のときはドラッグハンドルを表示しない', () => {
+    const node = makeLeaf('n4', 'サポート部', '伊藤 三郎')
+    const html = renderToString(
+      <OrgNodeCard
+        node={node}
+        editable={false}
+        draggingNodeId={null}
+        onDragStart={noop}
+        onDragEnd={noop}
+        onDropOn={noop}
+      />,
+    )
+    expect(html).not.toContain('ドラッグして上長を変更')
+  })
+
+  it('editable=true のときはドラッグハンドルを表示する', () => {
+    const node = makeLeaf('n5', '財務部', '高橋 四郎')
+    const html = renderToString(
+      <OrgNodeCard
+        node={node}
+        editable={true}
+        draggingNodeId={null}
+        onDragStart={noop}
+        onDragEnd={noop}
+        onDropOn={noop}
+      />,
+    )
+    expect(html).toContain('ドラッグして上長を変更')
+  })
+
+  it('子ノードも再帰的に表示される (デフォルト展開)', () => {
+    const node = makeTreeWithChildren()
+    const html = renderToString(
+      <OrgNodeCard
+        node={node}
+        editable={false}
+        draggingNodeId={null}
+        onDragStart={noop}
+        onDragEnd={noop}
+        onDropOn={noop}
+      />,
+    )
+    expect(html).toContain('開発部')
+    expect(html).toContain('フロントエンドチーム')
+    expect(html).toContain('バックエンドチーム')
+  })
+
+  it('defaultExpanded=false のときは子ノードを描画しない', () => {
+    const node = makeTreeWithChildren()
+    const html = renderToString(
+      <OrgNodeCard
+        node={node}
+        editable={false}
+        draggingNodeId={null}
+        onDragStart={noop}
+        onDragEnd={noop}
+        onDropOn={noop}
+        defaultExpanded={false}
+      />,
+    )
+    expect(html).toContain('開発部')
+    expect(html).not.toContain('フロントエンドチーム')
+    expect(html).not.toContain('バックエンドチーム')
+  })
+})

--- a/src/tests/organization/cycle-detection.test.ts
+++ b/src/tests/organization/cycle-detection.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Issue #27 / Req 3.4: 純粋関数 detectCycle の単体テスト
+ */
+import { describe, it, expect } from 'vitest'
+import { detectCycle, type ParentMap } from '@/lib/organization/cycle-detection'
+
+function mapOf(entries: Array<[string, string | null]>): ParentMap {
+  return new Map(entries)
+}
+
+describe('detectCycle', () => {
+  it('空マップはサイクルなし', () => {
+    expect(detectCycle(mapOf([]))).toEqual({ ok: true })
+  })
+
+  it('1ノードがルート (parent=null) のみのケースはサイクルなし', () => {
+    expect(detectCycle(mapOf([['a', null]]))).toEqual({ ok: true })
+  })
+
+  it('直列の親子関係 a<-b<-c はサイクルなし', () => {
+    expect(
+      detectCycle(
+        mapOf([
+          ['c', 'b'],
+          ['b', 'a'],
+          ['a', null],
+        ]),
+      ),
+    ).toEqual({ ok: true })
+  })
+
+  it('自己参照 a->a は循環として検出される', () => {
+    const result = detectCycle(mapOf([['a', 'a']]))
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.path).toEqual(['a', 'a'])
+  })
+
+  it('2ノードの循環 a->b->a を検出する', () => {
+    const result = detectCycle(
+      mapOf([
+        ['a', 'b'],
+        ['b', 'a'],
+      ]),
+    )
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.path).toContain('a')
+      expect(result.path).toContain('b')
+    }
+  })
+
+  it('部分木が独立にある場合もサイクルがなければ ok', () => {
+    expect(
+      detectCycle(
+        mapOf([
+          ['a', null],
+          ['b', 'a'],
+          ['x', null],
+          ['y', 'x'],
+        ]),
+      ),
+    ).toEqual({ ok: true })
+  })
+
+  it('一部だけがサイクルを含むなら検出される', () => {
+    const result = detectCycle(
+      mapOf([
+        ['root', null],
+        ['a', 'root'],
+        ['b', 'c'],
+        ['c', 'b'],
+      ]),
+    )
+    expect(result.ok).toBe(false)
+  })
+})

--- a/src/tests/organization/org-tree-ops.test.ts
+++ b/src/tests/organization/org-tree-ops.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Issue #28 / Req 3.2, 3.4: org-tree-ops の純粋関数テスト
+ *
+ * - moveNode / wouldCreateCycle / applyOperations / hasStructuralDiff /
+ *   countMembers / countDirectMembers / findNode / collectDescendantIds
+ *
+ * 全て入力 OrgTree を変更しないことも合わせて検証する (immutability)。
+ */
+import { describe, expect, it } from 'vitest'
+import type { OrgNode, OrgTree } from '@/lib/organization/organization-types'
+import { OrgChangeError } from '@/lib/organization/organization-types'
+import {
+  applyOperations,
+  collectDescendantIds,
+  countDirectMembers,
+  countMembers,
+  findNode,
+  flattenNodes,
+  hasStructuralDiff,
+  moveNode,
+  wouldCreateCycle,
+} from '@/lib/organization/org-tree-ops'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// フィクスチャ
+// ─────────────────────────────────────────────────────────────────────────────
+
+function leaf(id: string, parentId: string | null, holders = 0): OrgNode {
+  const positions = Array.from({ length: Math.max(holders, 1) }, (_, i) => ({
+    id: `${id}-p-${i}`,
+    roleId: 'ROLE',
+    holderUserId: i < holders ? `${id}-u-${i}` : null,
+    holderName: i < holders ? `user-${id}-${i}` : null,
+  }))
+  return { id, parentId, name: `node-${id}`, positions, children: [] }
+}
+
+function withChildren(node: OrgNode, children: ReadonlyArray<OrgNode>): OrgNode {
+  return { ...node, children: children.map((c) => ({ ...c, parentId: node.id })) }
+}
+
+/**
+ * a (1 holder)
+ * ├── b (1 holder)
+ * │   └── c (0 holder)
+ * └── d (2 holders)
+ */
+function sampleTree(): OrgTree {
+  const c = leaf('c', 'b', 0)
+  const b = withChildren(leaf('b', 'a', 1), [c])
+  const d = leaf('d', 'a', 2)
+  const a = withChildren(leaf('a', null, 1), [b, d])
+  return { roots: [a] }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// findNode / flattenNodes / collectDescendantIds
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('findNode', () => {
+  it('存在するノードを返す', () => {
+    const tree = sampleTree()
+    expect(findNode(tree, 'c')?.name).toBe('node-c')
+  })
+  it('存在しないノードは null', () => {
+    expect(findNode(sampleTree(), 'zzz')).toBeNull()
+  })
+})
+
+describe('flattenNodes', () => {
+  it('全ノードを平坦化する', () => {
+    const ids = flattenNodes(sampleTree()).map((n) => n.id)
+    expect(ids.sort()).toEqual(['a', 'b', 'c', 'd'])
+  })
+})
+
+describe('collectDescendantIds', () => {
+  it('自身は含めず子孫 id を返す', () => {
+    const a = findNode(sampleTree(), 'a')
+    expect(a).not.toBeNull()
+    if (!a) return
+    const ids = [...collectDescendantIds(a)].sort()
+    expect(ids).toEqual(['b', 'c', 'd'])
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// countMembers
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('count members', () => {
+  it('countDirectMembers は自ノードのホルダー数を返す', () => {
+    const tree = sampleTree()
+    const b = findNode(tree, 'b')
+    expect(b).not.toBeNull()
+    if (b) expect(countDirectMembers(b)).toBe(1)
+  })
+  it('countMembers は子孫のホルダー合計を返す', () => {
+    const tree = sampleTree()
+    const a = findNode(tree, 'a')
+    expect(a).not.toBeNull()
+    if (a) expect(countMembers(a)).toBe(4) // a:1 + b:1 + c:0 + d:2
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// wouldCreateCycle
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('wouldCreateCycle', () => {
+  it('自身への移動は循環', () => {
+    expect(wouldCreateCycle(sampleTree(), 'a', 'a')).toBe(true)
+  })
+  it('子孫への移動は循環', () => {
+    expect(wouldCreateCycle(sampleTree(), 'a', 'c')).toBe(true)
+  })
+  it('ルートへの移動は循環しない', () => {
+    expect(wouldCreateCycle(sampleTree(), 'b', null)).toBe(false)
+  })
+  it('親子関係にないノード同士は循環しない', () => {
+    expect(wouldCreateCycle(sampleTree(), 'd', 'b')).toBe(false)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// moveNode
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('moveNode', () => {
+  it('別ノードの配下へ移動できる', () => {
+    const tree = sampleTree()
+    const next = moveNode(tree, 'd', 'b')
+    const moved = findNode(next, 'd')
+    expect(moved?.parentId).toBe('b')
+    const a = findNode(next, 'a')
+    expect(a?.children.map((c) => c.id)).toEqual(['b'])
+  })
+
+  it('ルートへ移動すると roots に追加される', () => {
+    const tree = sampleTree()
+    const next = moveNode(tree, 'b', null)
+    expect(next.roots.map((r) => r.id).sort()).toEqual(['a', 'b'])
+    expect(findNode(next, 'b')?.parentId).toBeNull()
+  })
+
+  it('循環する移動は OrgChangeError(CYCLE_DETECTED)', () => {
+    expect(() => moveNode(sampleTree(), 'a', 'c')).toThrowError(OrgChangeError)
+    try {
+      moveNode(sampleTree(), 'a', 'c')
+    } catch (e) {
+      expect(e).toBeInstanceOf(OrgChangeError)
+      if (e instanceof OrgChangeError) expect(e.code).toBe('CYCLE_DETECTED')
+    }
+  })
+
+  it('同じ親への移動は OrgChangeError(SAME_PARENT)', () => {
+    try {
+      moveNode(sampleTree(), 'b', 'a')
+    } catch (e) {
+      expect(e).toBeInstanceOf(OrgChangeError)
+      if (e instanceof OrgChangeError) expect(e.code).toBe('SAME_PARENT')
+    }
+  })
+
+  it('存在しないノードは OrgChangeError(NODE_NOT_FOUND)', () => {
+    try {
+      moveNode(sampleTree(), 'missing', 'a')
+    } catch (e) {
+      expect(e).toBeInstanceOf(OrgChangeError)
+      if (e instanceof OrgChangeError) expect(e.code).toBe('NODE_NOT_FOUND')
+    }
+  })
+
+  it('元のツリーは変更されない (immutable)', () => {
+    const tree = sampleTree()
+    const snapshot = JSON.stringify(tree)
+    moveNode(tree, 'd', 'b')
+    expect(JSON.stringify(tree)).toBe(snapshot)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// applyOperations / hasStructuralDiff
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('applyOperations', () => {
+  it('複数の操作を順に適用する', () => {
+    const tree = sampleTree()
+    const next = applyOperations(tree, [
+      { nodeId: 'd', newParentId: 'b' },
+      { nodeId: 'c', newParentId: null },
+    ])
+    expect(findNode(next, 'd')?.parentId).toBe('b')
+    expect(findNode(next, 'c')?.parentId).toBeNull()
+  })
+
+  it('途中でエラーが出たら throw', () => {
+    expect(() => applyOperations(sampleTree(), [{ nodeId: 'a', newParentId: 'c' }])).toThrowError(
+      OrgChangeError,
+    )
+  })
+})
+
+describe('hasStructuralDiff', () => {
+  it('同じツリーなら false', () => {
+    expect(hasStructuralDiff(sampleTree(), sampleTree())).toBe(false)
+  })
+  it('構造が違えば true', () => {
+    const base = sampleTree()
+    const moved = moveNode(base, 'd', 'b')
+    expect(hasStructuralDiff(base, moved)).toBe(true)
+  })
+})

--- a/src/tests/organization/organization-service.test.ts
+++ b/src/tests/organization/organization-service.test.ts
@@ -1,0 +1,349 @@
+/**
+ * Issue #27: OrganizationService の単体テスト
+ *
+ * - repo / auditLogEmitter / exportJob を vi.fn() でモック
+ * - getCurrentTree: 空ツリー / 階層ツリー構築
+ * - commitHierarchyChange: 正常保存 / 循環参照でエラー
+ * - changePosition: TransferRecord 記録の確認
+ * - exportCsv: ExportJob へのジョブ投入と監査ログ発行
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { AuditLogEmitter } from '@/lib/audit/audit-log-emitter'
+import type { ExportJob } from '@/lib/export/export-job'
+import type { ExportJobId } from '@/lib/export/export-types'
+import { createOrganizationService } from '@/lib/organization/organization-service'
+import type { OrgRepository } from '@/lib/organization/organization-repository'
+import {
+  toDepartmentId,
+  toPositionId,
+  toTransferRecordId,
+  toUserId,
+  type Department,
+  type Position,
+  type TransferRecord,
+} from '@/lib/organization/organization-types'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fixtures
+// ─────────────────────────────────────────────────────────────────────────────
+
+const HR_USER = 'usr_hr1'
+const AUDIT_CONTEXT = {
+  userId: HR_USER,
+  ipAddress: '10.0.0.1',
+  userAgent: 'vitest',
+} as const
+
+function makeDept(overrides: Partial<Department> = {}): Department {
+  return {
+    id: toDepartmentId('dept_root'),
+    name: 'Root',
+    parentId: null,
+    createdAt: new Date('2026-04-18T00:00:00.000Z'),
+    deletedAt: null,
+    ...overrides,
+  }
+}
+
+function makePosition(overrides: Partial<Position> = {}): Position {
+  return {
+    id: toPositionId('pos_01'),
+    departmentId: toDepartmentId('dept_root'),
+    roleId: 'role_swe',
+    holderUserId: null,
+    supervisorPositionId: null,
+    ...overrides,
+  }
+}
+
+function makeTransfer(overrides: Partial<TransferRecord> = {}): TransferRecord {
+  return {
+    id: toTransferRecordId('tr_01'),
+    userId: 'usr_001',
+    fromPositionId: null,
+    toPositionId: toPositionId('pos_01'),
+    effectiveDate: new Date('2026-05-01T00:00:00.000Z'),
+    changedBy: HR_USER,
+    createdAt: new Date('2026-04-18T12:34:56.000Z'),
+    ...overrides,
+  }
+}
+
+function makeRepoMock(overrides: Partial<OrgRepository> = {}): OrgRepository {
+  return {
+    getDepartments: vi.fn().mockResolvedValue([]),
+    findDepartmentById: vi.fn().mockResolvedValue(null),
+    createDepartment: vi.fn().mockResolvedValue(makeDept()),
+    updateDepartment: vi.fn().mockResolvedValue(makeDept()),
+    softDeleteDepartment: vi.fn().mockResolvedValue(undefined),
+    getPositions: vi.fn().mockResolvedValue([]),
+    findPositionById: vi.fn().mockResolvedValue(null),
+    updatePositionHolder: vi.fn().mockResolvedValue(makePosition()),
+    updateSupervisor: vi.fn().mockResolvedValue(makePosition()),
+    createTransferRecord: vi.fn().mockResolvedValue(makeTransfer()),
+    findPositionOfUser: vi.fn().mockResolvedValue(null),
+    ...overrides,
+  }
+}
+
+function makeEmitterMock(): AuditLogEmitter {
+  return { emit: vi.fn().mockResolvedValue(undefined) }
+}
+
+function makeExportJobMock(jobId = 'job_abc123'): ExportJob {
+  return {
+    enqueue: vi.fn().mockResolvedValue({ jobId: jobId as ExportJobId }),
+    getStatus: vi.fn().mockResolvedValue(null),
+    getDownloadUrl: vi.fn().mockResolvedValue(null),
+  }
+}
+
+function makeService(
+  repo = makeRepoMock(),
+  emitter = makeEmitterMock(),
+  exportJob = makeExportJobMock(),
+) {
+  const svc = createOrganizationService({ repo, auditLogEmitter: emitter, exportJob })
+  return { svc, repo, emitter, exportJob }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// getCurrentTree
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('OrganizationService.getCurrentTree', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('部署もポジションも無い場合は空のルート配列を返す', async () => {
+    const { svc } = makeService()
+    const tree = await svc.getCurrentTree()
+    expect(tree.roots).toEqual([])
+    expect(tree.capturedAt).toBeInstanceOf(Date)
+  })
+
+  it('親子関係のある部署を階層ツリーとして構築する', async () => {
+    const root = makeDept({ id: toDepartmentId('dept_root'), name: 'Root' })
+    const child = makeDept({
+      id: toDepartmentId('dept_eng'),
+      name: 'Engineering',
+      parentId: toDepartmentId('dept_root'),
+    })
+    const pos = makePosition({ departmentId: toDepartmentId('dept_eng') })
+
+    const repo = makeRepoMock({
+      getDepartments: vi.fn().mockResolvedValue([root, child]),
+      getPositions: vi.fn().mockResolvedValue([pos]),
+    })
+    const { svc } = makeService(repo)
+
+    const tree = await svc.getCurrentTree()
+    expect(tree.roots).toHaveLength(1)
+    const rootNode = tree.roots[0]
+    expect(rootNode).toBeDefined()
+    if (!rootNode) return
+    expect(rootNode.department.name).toBe('Root')
+    expect(rootNode.children).toHaveLength(1)
+    const childNode = rootNode.children[0]
+    expect(childNode).toBeDefined()
+    if (!childNode) return
+    expect(childNode.department.name).toBe('Engineering')
+    expect(childNode.positions).toHaveLength(1)
+  })
+
+  it('deletedAt のある部署はツリーから除外される', async () => {
+    const deleted = makeDept({
+      id: toDepartmentId('dept_old'),
+      name: 'Old',
+      deletedAt: new Date('2026-04-18T00:00:00.000Z'),
+    })
+    const repo = makeRepoMock({
+      getDepartments: vi.fn().mockResolvedValue([deleted]),
+    })
+    const { svc } = makeService(repo)
+    const tree = await svc.getCurrentTree()
+    expect(tree.roots).toEqual([])
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// commitHierarchyChange
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('OrganizationService.commitHierarchyChange', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('正常な変更は DB 保存と監査ログを発行する', async () => {
+    const root = makeDept({ id: toDepartmentId('dept_root') })
+    const child = makeDept({
+      id: toDepartmentId('dept_eng'),
+      parentId: toDepartmentId('dept_root'),
+    })
+    const repo = makeRepoMock({
+      getDepartments: vi.fn().mockResolvedValue([root, child]),
+    })
+    const { svc, emitter } = makeService(repo)
+
+    const result = await svc.commitHierarchyChange(
+      [{ type: 'RenameDepartment', departmentId: 'dept_eng', name: 'R&D' }],
+      AUDIT_CONTEXT,
+    )
+
+    expect(result.ok).toBe(true)
+    expect(repo.updateDepartment).toHaveBeenCalledWith('dept_eng', { name: 'R&D' })
+    expect(emitter.emit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: HR_USER,
+        action: 'ORGANIZATION_CHANGE',
+        resourceType: 'ORGANIZATION',
+      }),
+    )
+  })
+
+  it('循環参照が発生する変更は CyclicReferenceError を返し DB 保存しない', async () => {
+    const a = makeDept({
+      id: toDepartmentId('dept_a'),
+      parentId: toDepartmentId('dept_b'),
+    })
+    const b = makeDept({
+      id: toDepartmentId('dept_b'),
+      parentId: null,
+    })
+    const repo = makeRepoMock({
+      getDepartments: vi.fn().mockResolvedValue([a, b]),
+    })
+    const { svc, emitter } = makeService(repo)
+
+    // dept_b を dept_a の下に移動すると循環発生
+    const result = await svc.commitHierarchyChange(
+      [{ type: 'MoveDepartment', departmentId: 'dept_b', newParentId: 'dept_a' }],
+      AUDIT_CONTEXT,
+    )
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error.name).toBe('CyclicReferenceError')
+      expect(result.error.kind).toBe('department')
+    }
+    expect(repo.updateDepartment).not.toHaveBeenCalled()
+    expect(emitter.emit).not.toHaveBeenCalled()
+  })
+
+  it('Position の supervisor 循環も検出する', async () => {
+    const posA = makePosition({
+      id: toPositionId('pos_a'),
+      supervisorPositionId: toPositionId('pos_b'),
+    })
+    const posB = makePosition({
+      id: toPositionId('pos_b'),
+      supervisorPositionId: null,
+    })
+    const repo = makeRepoMock({
+      getPositions: vi.fn().mockResolvedValue([posA, posB]),
+    })
+    const { svc } = makeService(repo)
+
+    const result = await svc.commitHierarchyChange(
+      [
+        {
+          type: 'ChangeSupervisor',
+          positionId: 'pos_b',
+          newSupervisorPositionId: 'pos_a',
+        },
+      ],
+      AUDIT_CONTEXT,
+    )
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error.kind).toBe('position')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// changePosition
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('OrganizationService.changePosition', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('TransferRecord を作成しポジション保持者を更新する', async () => {
+    const currentPos = makePosition({
+      id: toPositionId('pos_a'),
+      holderUserId: 'usr_001',
+    })
+    const transfer = makeTransfer({
+      userId: 'usr_001',
+      fromPositionId: toPositionId('pos_a'),
+      toPositionId: toPositionId('pos_b'),
+    })
+    const repo = makeRepoMock({
+      findPositionOfUser: vi.fn().mockResolvedValue(currentPos),
+      updatePositionHolder: vi.fn().mockResolvedValue(currentPos),
+      createTransferRecord: vi.fn().mockResolvedValue(transfer),
+    })
+    const { svc, emitter } = makeService(repo)
+
+    const result = await svc.changePosition(
+      toUserId('usr_001'),
+      toPositionId('pos_b'),
+      AUDIT_CONTEXT,
+    )
+
+    expect(result).toEqual(transfer)
+    expect(repo.updatePositionHolder).toHaveBeenCalledWith('pos_a', null)
+    expect(repo.updatePositionHolder).toHaveBeenCalledWith('pos_b', 'usr_001')
+    expect(repo.createTransferRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'usr_001',
+        fromPositionId: 'pos_a',
+        toPositionId: 'pos_b',
+        changedBy: HR_USER,
+      }),
+    )
+    expect(emitter.emit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'ORGANIZATION_CHANGE',
+        resourceType: 'POSITION',
+      }),
+    )
+  })
+
+  it('現ポジションが無い新規配属でも TransferRecord を記録する', async () => {
+    const repo = makeRepoMock({
+      findPositionOfUser: vi.fn().mockResolvedValue(null),
+    })
+    const { svc } = makeService(repo)
+
+    await svc.changePosition(toUserId('usr_002'), toPositionId('pos_b'), AUDIT_CONTEXT)
+    expect(repo.createTransferRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'usr_002',
+        fromPositionId: null,
+        toPositionId: 'pos_b',
+      }),
+    )
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// exportCsv
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('OrganizationService.exportCsv', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('OrganizationCsv ジョブを投入し DATA_EXPORT 監査ログを発行する', async () => {
+    const exportJob = makeExportJobMock('job_xyz')
+    const { svc, emitter } = makeService(undefined, undefined, exportJob)
+
+    const result = await svc.exportCsv(AUDIT_CONTEXT)
+
+    expect(result.jobId).toBe('job_xyz')
+    expect(exportJob.enqueue).toHaveBeenCalledWith({ type: 'OrganizationCsv' })
+    expect(emitter.emit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: HR_USER,
+        action: 'DATA_EXPORT',
+        resourceType: 'ORGANIZATION',
+      }),
+    )
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -20,6 +20,11 @@ export default defineConfig({
       },
     },
   },
+  // Next.js は JSX の自動ランタイムを想定しているため、
+  // vitest の esbuild 変換にも同じ設定を与えて React 参照が不要な形でビルドする。
+  esbuild: {
+    jsx: 'automatic',
+  },
   resolve: {
     alias: {
       '@': resolve(__dirname, './src'),


### PR DESCRIPTION
このプルリクエストは、組織のデータモデルおよびAPIエンドポイントに対する大規模な機能強化を導入するものです。部門・役職の管理、従業員のライフサイクル操作、およびCSVインポート/エクスポート機能のサポートを中心としています。新しいデータベーステーブルおよびPrismaモデル（部門・役職・異動履歴）を追加し、組織構造と従業員データを管理するためのRESTful APIエンドポイントを複数実装しています。

主な変更点は以下のとおりです。

**データベース・スキーマの強化:**
* 組織階層・役職割当・異動履歴をサポートするため、`departments`・`positions`・`transfer_records` の新しいテーブルおよびPrismaモデルを追加。自己参照リレーションシップおよび論理削除にも対応しています。（`prisma/migrations/organization.sql`、`prisma/schema.prisma`）

**組織管理API:**
* 以下の組織管理エンドポイントを実装:
  - [`[/api/organization/tree](https://claude.ai/chat/9ce20af7-63cd-495a-8668-69b72f0c98ac)`](diffhunk://#diff-caa1737a41a7d0f084bf1de43e14afcd945024cf58c66a8899ca4291b535a8e6R1-R35)：現在の組織ツリーを取得。
  - [`[/api/organization/commit](https://claude.ai/chat/9ce20af7-63cd-495a-8668-69b72f0c98ac)`](diffhunk://#diff-603756151b8e8764f3c6d94d0f28189fb40dc52a0f1dadffce1076ec2f0590d1R1-R62)：循環参照チェックおよび監査ログとともに階層変更をコミット。
  - [`[/api/organization/preview](https://claude.ai/chat/9ce20af7-63cd-495a-8668-69b72f0c98ac)`](diffhunk://#diff-dee44be0fc82583a88f131038712c0dd3ba353756c17925609f2b930e0d281f3R1-R50)：循環参照の警告を含む、階層変更のプレビューを表示。
  - [`[/api/organization/export](https://claude.ai/chat/9ce20af7-63cd-495a-8668-69b72f0c98ac)`](diffhunk://#diff-8fcda8a8acc567e5972730b86f53c669f67a8254503428f1055127ad076ae271R1-R39)：組織CSVエクスポートジョブを開始。
  - `/api/organization/positions/[id]/holder`：役職の担当者を変更し、異動を記録。

**従業員ライフサイクルAPI:**
* 以下の従業員管理エンドポイントを追加:
  - [`[/api/lifecycle/employees](https://claude.ai/chat/9ce20af7-63cd-495a-8668-69b72f0c98ac)`](diffhunk://#diff-9df1071bdbf0364329ed3f1ca7e8816f933c2283b1233abe726b6e39cd751283R1-R93)：バリデーションおよびメールアドレスの重複チェックを行い、新しい従業員を登録。
  - [`[/api/lifecycle/employees/import](https://claude.ai/chat/9ce20af7-63cd-495a-8668-69b72f0c98ac)`](diffhunk://#diff-1cb5fa52572bd504a367d51e68266ee439b9d3101f89a8566c250d3e56352c06R1-R112)：CSVファイルから従業員を一括インポート（バリデーションおよびエラーハンドリング付き）。

**全般的な改善・リファクタリング:**
* すべての新規エンドポイントにおいて、`HR_MANAGER` および `ADMIN` ロールの認可チェックを強化。エラーハンドリングおよびサービス初期化チェックを標準化。

**軽微な修正・クリーンアップ:**
* マイグレーションファイルおよびスキーマファイル内のマージコンフリクトの残骸を解消し、コメントを整理。（`prisma/migrations/master-data.sql`、`prisma/schema.prisma`）

これらの変更により、堅牢な組織構造の管理、従業員データ操作のサポート、およびCSVインポート/エクスポートワークフローとの連携が実現されます。