### PR TITLE
feat: [Task 11.1] 共有 SkillGapCalculator を実装 (Issue #35)

### DIFF
--- a/prisma/migrations/employee-skill.sql
+++ b/prisma/migrations/employee-skill.sql
@@ -1,0 +1,26 @@
+-- 社員スキル管理テーブル (Requirement 4)
+-- Issue #35: 共有 SkillGapCalculator のためのスキーマ（Task 11.1）
+--
+-- 社員が保有するスキルを表現する。
+-- - (userId, skillId) の一意制約で「同一社員が同一スキルを複数持てない」ことを保証
+-- - (skillId, level) の複合インデックスで「このスキルを level 以上で保有する人」の検索を高速化
+-- - マネージャー承認ワークフロー（Task 11.2）のため approvedByManagerId / approvedAt を保持
+--
+-- SkillGapCalculator は DB 非依存の純関数として実装する（Task 11.1）。
+-- 呼び出し元（CareerService / SkillAnalytics）がこのテーブルから取得した行を
+-- EmployeeSkill 型に変換して渡す想定。
+
+CREATE TABLE IF NOT EXISTS employee_skills (
+  id                    TEXT         NOT NULL PRIMARY KEY,
+  "userId"              TEXT         NOT NULL,
+  "skillId"             TEXT         NOT NULL,
+  -- 保有スキルレベル 1〜5
+  level                 INTEGER      NOT NULL,
+  "acquiredAt"          TIMESTAMP(3) NOT NULL,
+  "approvedByManagerId" TEXT,
+  "approvedAt"          TIMESTAMP(3),
+  CONSTRAINT employee_skills_user_id_skill_id_key UNIQUE ("userId", "skillId")
+);
+
+CREATE INDEX IF NOT EXISTS employee_skills_skill_id_level_idx
+  ON employee_skills ("skillId", level);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -312,6 +312,28 @@ model GradeWeightHistory {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// 社員スキル (Requirement 4)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// 社員保有スキル (Requirement 4.4, 4.5)
+/// - マネージャー承認済み / 未承認を区別するため approvedByManagerId / approvedAt を保持
+/// - SkillGapCalculator はこのモデルを読み取って役職要件との差分を計算する（Task 11.1）
+model EmployeeSkill {
+  id                  String    @id @default(cuid())
+  userId              String
+  skillId             String
+  /// 保有スキルレベル 1〜5
+  level               Int
+  acquiredAt          DateTime
+  approvedByManagerId String?
+  approvedAt          DateTime?
+
+  @@unique([userId, skillId])
+  @@index([skillId, level])
+  @@map("employee_skills")
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // 組織管理 (Requirement 3)
 // ─────────────────────────────────────────────────────────────────────────────
 

--- a/src/lib/shared/skill-gap-calculator.ts
+++ b/src/lib/shared/skill-gap-calculator.ts
@@ -1,0 +1,185 @@
+/**
+ * Issue #35 / Task 11.1: 共有 SkillGapCalculator
+ *
+ * 役職（ポジション）が要求するスキル要件と、社員が保有するスキルの差分を
+ * 計算する純関数群。DB やリポジトリには一切依存しない。
+ *
+ * 呼び出し側（CareerService / SkillAnalytics / HR ダッシュボード）が
+ * 事前に必要なデータを取得し、このモジュールへ渡すことでドメイン境界越えを排除する。
+ *
+ * Requirements:
+ * - 4.6: HR_MANAGER が特定ポストを選択したとき、充足率(%)と候補者一覧を表示
+ * - 4.7: スキル充足率が閾値（デフォルト 60%）を下回るポストを採用アラートへ
+ * - 4.8: スキルギャップ分析で不足スキルカテゴリをランキング表示
+ */
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 定数
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** 未保有スキルのレベル */
+const LEVEL_NOT_HELD = 0
+
+/** 必要スキルが 0 件のときの充足率 */
+const FULFILLMENT_RATE_WHEN_NO_REQUIREMENT = 1
+
+/** 採用アラート判定のデフォルト閾値 (60%)（Requirement 4.7） */
+export const DEFAULT_HIRING_ALERT_THRESHOLD = 0.6
+
+/** 呼び出し元が skillName / category を渡さなかった場合の既定値 */
+const UNKNOWN_SKILL_NAME = ''
+const UNKNOWN_CATEGORY = ''
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 型定義
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * 社員が保有するスキル（Prisma EmployeeSkill モデルと 1:1 対応）。
+ *
+ * 承認済み / 未承認の判定は呼び出し元の責務。必要ならこのモジュールへ渡す前に
+ * `approvedAt !== null` 等でフィルタしておくこと。
+ */
+export interface EmployeeSkill {
+  readonly id: string
+  readonly userId: string
+  readonly skillId: string
+  /** 保有レベル 1〜5 */
+  readonly level: number
+  readonly acquiredAt: Date
+  readonly approvedByManagerId: string | null
+  readonly approvedAt: Date | null
+}
+
+/**
+ * スキル要件 1 件に対する差分情報。
+ *
+ * `gap` は常に非負。完全充足または過剰保有の場合は `calculateGap` の結果から除外される。
+ */
+export interface SkillGap {
+  readonly skillId: string
+  /** 表示用の名称（呼び出し元が渡す） */
+  readonly skillName: string
+  /** 表示用のカテゴリ（呼び出し元が渡す） */
+  readonly category: string
+  /** 現在の保有レベル。未保有なら 0 */
+  readonly currentLevel: number
+  /** 必要レベル 1〜5 */
+  readonly requiredLevel: number
+  /** requiredLevel - currentLevel（0 以上） */
+  readonly gap: number
+}
+
+/**
+ * SkillGapCalculator 入力。
+ *
+ * requiredSkills は `RoleSkillRequirement` と同形だが、ドメイン層の型に依存しないよう
+ * プレーンオブジェクトで受け取る。表示用の skillName / category は任意で渡せる。
+ */
+export interface SkillGapCalculatorInput {
+  readonly holderSkills: readonly EmployeeSkill[]
+  readonly requiredSkills: ReadonlyArray<{
+    readonly skillId: string
+    readonly requiredLevel: number
+    readonly skillName?: string
+    readonly category?: string
+  }>
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 内部ヘルパー
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * holderSkills を skillId → level の Map に畳み込む。
+ * 同一 skillId が重複した場合は最大レベルを採用する（防御的）。
+ * Prisma 側では (userId, skillId) に UNIQUE を張っているため通常は重複しない。
+ */
+function buildHolderLevelMap(holderSkills: readonly EmployeeSkill[]): Map<string, number> {
+  const map = new Map<string, number>()
+  for (const skill of holderSkills) {
+    const existing = map.get(skill.skillId) ?? LEVEL_NOT_HELD
+    if (skill.level > existing) {
+      map.set(skill.skillId, skill.level)
+    }
+  }
+  return map
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 公開 API
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * 不足スキル一覧を返す。
+ *
+ * - 未保有スキルは `currentLevel = 0`, `gap = requiredLevel` として含まれる
+ * - 必要レベルを満たす／超えるスキルは結果に含めない（gap > 0 のみ）
+ * - 結果は `gap` 降順、次に `requiredLevel` 降順、最後に `skillId` 昇順で安定ソート
+ *   （Requirement 4.8: ランキング表示）
+ */
+export function calculateGap(input: SkillGapCalculatorInput): SkillGap[] {
+  const holderLevels = buildHolderLevelMap(input.holderSkills)
+  const gaps: SkillGap[] = []
+
+  for (const req of input.requiredSkills) {
+    const currentLevel = holderLevels.get(req.skillId) ?? LEVEL_NOT_HELD
+    const gap = req.requiredLevel - currentLevel
+    if (gap <= 0) continue
+
+    gaps.push({
+      skillId: req.skillId,
+      skillName: req.skillName ?? UNKNOWN_SKILL_NAME,
+      category: req.category ?? UNKNOWN_CATEGORY,
+      currentLevel,
+      requiredLevel: req.requiredLevel,
+      gap,
+    })
+  }
+
+  gaps.sort((a, b) => {
+    if (b.gap !== a.gap) return b.gap - a.gap
+    if (b.requiredLevel !== a.requiredLevel) return b.requiredLevel - a.requiredLevel
+    return a.skillId.localeCompare(b.skillId)
+  })
+
+  return gaps
+}
+
+/**
+ * 充足率を 0.0〜1.0 で返す。
+ *
+ * 計算式: `Σ min(currentLevel, requiredLevel) / Σ requiredLevel`
+ *
+ * - 必要スキルが 0 件なら 1.0（「要件なし＝完全充足」とみなす）
+ * - requiredLevel が 0 以下の要件は無視する（定義上 1〜5 のはずだが防御的に除外）
+ */
+export function calculateFulfillmentRate(input: SkillGapCalculatorInput): number {
+  const holderLevels = buildHolderLevelMap(input.holderSkills)
+  let totalRequired = 0
+  let totalFulfilled = 0
+
+  for (const req of input.requiredSkills) {
+    if (req.requiredLevel <= 0) continue
+    const currentLevel = holderLevels.get(req.skillId) ?? LEVEL_NOT_HELD
+    totalRequired += req.requiredLevel
+    totalFulfilled += Math.min(currentLevel, req.requiredLevel)
+  }
+
+  if (totalRequired === 0) return FULFILLMENT_RATE_WHEN_NO_REQUIREMENT
+  return totalFulfilled / totalRequired
+}
+
+/**
+ * 採用アラートが必要か判定する（Requirement 4.7）。
+ *
+ * - 充足率が閾値を **下回る** (`<`) 場合に true
+ * - 閾値ちょうどの場合は false（「60% 以上なら OK」のセマンティクス）
+ * - デフォルト閾値 0.6
+ */
+export function isHiringAlertNeeded(
+  fulfillmentRate: number,
+  threshold: number = DEFAULT_HIRING_ALERT_THRESHOLD,
+): boolean {
+  return fulfillmentRate < threshold
+}

--- a/src/tests/shared/skill-gap-calculator.test.ts
+++ b/src/tests/shared/skill-gap-calculator.test.ts
@@ -1,0 +1,298 @@
+/**
+ * Issue #35 / Task 11.1: 共有 SkillGapCalculator のテスト
+ *
+ * 純関数なので DB もモックも不要。入力配列 → 出力の変換を網羅的に検証する。
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  DEFAULT_HIRING_ALERT_THRESHOLD,
+  calculateFulfillmentRate,
+  calculateGap,
+  isHiringAlertNeeded,
+  type EmployeeSkill,
+} from '@/lib/shared/skill-gap-calculator'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// テストフィクスチャ
+// ─────────────────────────────────────────────────────────────────────────────
+
+const USER_ID = 'user_001'
+const FIXED_ACQUIRED_AT = new Date('2026-04-01T00:00:00.000Z')
+const FIXED_APPROVED_AT = new Date('2026-04-05T12:34:56.000Z')
+
+function makeHolderSkill(skillId: string, level: number, approved = true): EmployeeSkill {
+  return {
+    id: `emp_skill_${skillId}`,
+    userId: USER_ID,
+    skillId,
+    level,
+    acquiredAt: FIXED_ACQUIRED_AT,
+    approvedByManagerId: approved ? 'mgr_010' : null,
+    approvedAt: approved ? FIXED_APPROVED_AT : null,
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// calculateGap
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('calculateGap', () => {
+  it('全スキルが必要レベル以上の場合は空配列を返す（全充足）', () => {
+    const gaps = calculateGap({
+      holderSkills: [
+        makeHolderSkill('ts', 5),
+        makeHolderSkill('react', 4),
+        makeHolderSkill('sql', 3),
+      ],
+      requiredSkills: [
+        { skillId: 'ts', requiredLevel: 3 },
+        { skillId: 'react', requiredLevel: 4 },
+        { skillId: 'sql', requiredLevel: 3 },
+      ],
+    })
+    expect(gaps).toEqual([])
+  })
+
+  it('部分不足のスキルのみを返し、充足済みスキルは含まない', () => {
+    const gaps = calculateGap({
+      holderSkills: [makeHolderSkill('ts', 5), makeHolderSkill('react', 2)],
+      requiredSkills: [
+        { skillId: 'ts', requiredLevel: 3, skillName: 'TypeScript', category: 'Language' },
+        { skillId: 'react', requiredLevel: 4, skillName: 'React', category: 'Framework' },
+      ],
+    })
+    expect(gaps).toHaveLength(1)
+    expect(gaps[0]).toEqual({
+      skillId: 'react',
+      skillName: 'React',
+      category: 'Framework',
+      currentLevel: 2,
+      requiredLevel: 4,
+      gap: 2,
+    })
+  })
+
+  it('未保有スキルは currentLevel=0, gap=requiredLevel として含まれる', () => {
+    const gaps = calculateGap({
+      holderSkills: [makeHolderSkill('ts', 3)],
+      requiredSkills: [
+        { skillId: 'ts', requiredLevel: 3 },
+        { skillId: 'kubernetes', requiredLevel: 4, skillName: 'Kubernetes', category: 'Infra' },
+      ],
+    })
+    expect(gaps).toHaveLength(1)
+    expect(gaps[0]).toMatchObject({
+      skillId: 'kubernetes',
+      skillName: 'Kubernetes',
+      category: 'Infra',
+      currentLevel: 0,
+      requiredLevel: 4,
+      gap: 4,
+    })
+  })
+
+  it('必要スキルが 0 件なら空配列を返す', () => {
+    const gaps = calculateGap({
+      holderSkills: [makeHolderSkill('ts', 5)],
+      requiredSkills: [],
+    })
+    expect(gaps).toEqual([])
+  })
+
+  it('保有スキルが 0 件なら全必要スキルがそのまま gap として返る', () => {
+    const gaps = calculateGap({
+      holderSkills: [],
+      requiredSkills: [
+        { skillId: 'ts', requiredLevel: 3 },
+        { skillId: 'sql', requiredLevel: 2 },
+      ],
+    })
+    expect(gaps).toHaveLength(2)
+    expect(gaps.map((g) => g.skillId).sort()).toEqual(['sql', 'ts'])
+    for (const g of gaps) {
+      expect(g.currentLevel).toBe(0)
+      expect(g.gap).toBe(g.requiredLevel)
+    }
+  })
+
+  it('承認済み / 未承認を区別せず両方ともレベル計算に使う（呼び出し元責務）', () => {
+    const gaps = calculateGap({
+      holderSkills: [
+        makeHolderSkill('ts', 2, false), // 未承認でも採用
+        makeHolderSkill('react', 4, true),
+      ],
+      requiredSkills: [
+        { skillId: 'ts', requiredLevel: 3 },
+        { skillId: 'react', requiredLevel: 3 },
+      ],
+    })
+    // react は充足、ts だけ gap=1 が残る
+    expect(gaps).toHaveLength(1)
+    expect(gaps[0]?.skillId).toBe('ts')
+    expect(gaps[0]?.gap).toBe(1)
+  })
+
+  it('ギャップは gap 降順でソートされる（Req 4.8 ランキング）', () => {
+    const gaps = calculateGap({
+      holderSkills: [],
+      requiredSkills: [
+        { skillId: 'small', requiredLevel: 1 },
+        { skillId: 'huge', requiredLevel: 5 },
+        { skillId: 'mid', requiredLevel: 3 },
+      ],
+    })
+    expect(gaps.map((g) => g.skillId)).toEqual(['huge', 'mid', 'small'])
+  })
+
+  it('gap が同値なら requiredLevel 降順、さらに同値なら skillId 昇順で安定ソート', () => {
+    const gaps = calculateGap({
+      holderSkills: [
+        makeHolderSkill('a', 2), // gap = 4 - 2 = 2
+      ],
+      requiredSkills: [
+        { skillId: 'a', requiredLevel: 4 },
+        { skillId: 'b', requiredLevel: 2 },
+        { skillId: 'c', requiredLevel: 2 },
+      ],
+    })
+    // a: gap=2 (req=4), b: gap=2 (req=2), c: gap=2 (req=2)
+    // 期待順: gap=2 同値 → requiredLevel 降順 → a(req4) が先頭
+    //        → b と c は req=2 同値 → skillId 昇順で b, c の順
+    expect(gaps.map((g) => g.skillId)).toEqual(['a', 'b', 'c'])
+  })
+
+  it('skillName / category が未指定なら空文字で埋める', () => {
+    const gaps = calculateGap({
+      holderSkills: [],
+      requiredSkills: [{ skillId: 'ts', requiredLevel: 3 }],
+    })
+    expect(gaps[0]?.skillName).toBe('')
+    expect(gaps[0]?.category).toBe('')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// calculateFulfillmentRate
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('calculateFulfillmentRate', () => {
+  it('保有スキルが要件を完全に満たすなら 1.0 (100%)', () => {
+    const rate = calculateFulfillmentRate({
+      holderSkills: [makeHolderSkill('ts', 5), makeHolderSkill('react', 4)],
+      requiredSkills: [
+        { skillId: 'ts', requiredLevel: 3 },
+        { skillId: 'react', requiredLevel: 4 },
+      ],
+    })
+    expect(rate).toBe(1)
+  })
+
+  it('保有スキルがすべて未保有なら 0.0 (0%)', () => {
+    const rate = calculateFulfillmentRate({
+      holderSkills: [],
+      requiredSkills: [
+        { skillId: 'ts', requiredLevel: 3 },
+        { skillId: 'react', requiredLevel: 4 },
+      ],
+    })
+    expect(rate).toBe(0)
+  })
+
+  it('50% の充足率を正しく計算する', () => {
+    // required: ts=4, react=4 → total=8
+    // held:     ts=2, react=2 → fulfilled=4
+    const rate = calculateFulfillmentRate({
+      holderSkills: [makeHolderSkill('ts', 2), makeHolderSkill('react', 2)],
+      requiredSkills: [
+        { skillId: 'ts', requiredLevel: 4 },
+        { skillId: 'react', requiredLevel: 4 },
+      ],
+    })
+    expect(rate).toBe(0.5)
+  })
+
+  it('必要スキルが 0 件なら 1.0 を返す', () => {
+    const rate = calculateFulfillmentRate({
+      holderSkills: [makeHolderSkill('ts', 3)],
+      requiredSkills: [],
+    })
+    expect(rate).toBe(1)
+  })
+
+  it('要件超過のレベルは要件レベル止まりで評価される（上限クリップ）', () => {
+    // required: ts=3 → total=3
+    // held:     ts=5 (超過) → min(5, 3) = 3 → fulfilled=3
+    const rate = calculateFulfillmentRate({
+      holderSkills: [makeHolderSkill('ts', 5)],
+      requiredSkills: [{ skillId: 'ts', requiredLevel: 3 }],
+    })
+    expect(rate).toBe(1)
+  })
+
+  it('小数精度: 3 スキル中 2 スキルのみ満たす場合の比率 (≒ 0.6667)', () => {
+    // required: a=3, b=3, c=3 → total=9
+    // held:     a=3, b=3, c=0 → fulfilled=6
+    const rate = calculateFulfillmentRate({
+      holderSkills: [makeHolderSkill('a', 3), makeHolderSkill('b', 3)],
+      requiredSkills: [
+        { skillId: 'a', requiredLevel: 3 },
+        { skillId: 'b', requiredLevel: 3 },
+        { skillId: 'c', requiredLevel: 3 },
+      ],
+    })
+    expect(rate).toBeCloseTo(6 / 9, 10)
+  })
+
+  it('結果は常に 0.0〜1.0 の範囲に収まる', () => {
+    const rate = calculateFulfillmentRate({
+      holderSkills: [makeHolderSkill('ts', 5), makeHolderSkill('react', 5)],
+      requiredSkills: [
+        { skillId: 'ts', requiredLevel: 1 },
+        { skillId: 'react', requiredLevel: 1 },
+      ],
+    })
+    expect(rate).toBeGreaterThanOrEqual(0)
+    expect(rate).toBeLessThanOrEqual(1)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// isHiringAlertNeeded
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('isHiringAlertNeeded', () => {
+  it('デフォルト閾値は 0.6', () => {
+    expect(DEFAULT_HIRING_ALERT_THRESHOLD).toBe(0.6)
+  })
+
+  it('デフォルト閾値未満（0.59）なら true', () => {
+    expect(isHiringAlertNeeded(0.59)).toBe(true)
+  })
+
+  it('デフォルト閾値ちょうど（0.6）なら false', () => {
+    expect(isHiringAlertNeeded(0.6)).toBe(false)
+  })
+
+  it('デフォルト閾値超過（0.8）なら false', () => {
+    expect(isHiringAlertNeeded(0.8)).toBe(false)
+  })
+
+  it('0% 充足なら必ずアラート対象', () => {
+    expect(isHiringAlertNeeded(0)).toBe(true)
+  })
+
+  it('100% 充足なら絶対にアラート対象にならない', () => {
+    expect(isHiringAlertNeeded(1)).toBe(false)
+  })
+
+  it('カスタム閾値 0.8 を渡すと判定が厳しくなる', () => {
+    expect(isHiringAlertNeeded(0.7, 0.8)).toBe(true)
+    expect(isHiringAlertNeeded(0.8, 0.8)).toBe(false)
+    expect(isHiringAlertNeeded(0.9, 0.8)).toBe(false)
+  })
+
+  it('カスタム閾値 0 を渡すと 0 以上の充足率は false', () => {
+    expect(isHiringAlertNeeded(0, 0)).toBe(false)
+    expect(isHiringAlertNeeded(0.01, 0)).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

Issue #35 / Task 11.1 — 役職のスキル要件と社員の保有スキルとの差分を計算する、DB 非依存の純関数モジュールを `src/lib/shared/` に追加。`career` / `skill` ドメイン双方から共通利用することでドメイン境界越えを排除する。

- **`src/lib/shared/skill-gap-calculator.ts`**
  - `calculateGap(input)` — 不足スキル一覧を返す。`gap > 0` のみ、`gap 降順 → requiredLevel 降順 → skillId 昇順` で安定ソート（Req 4.8 ランキング表示）
  - `calculateFulfillmentRate(input)` — `Σ min(currentLevel, requiredLevel) / Σ requiredLevel` による充足率（0.0〜1.0）。必要スキル 0 件なら 1.0
  - `isHiringAlertNeeded(rate, threshold?)` — 充足率が閾値未満なら true。デフォルト閾値 `0.6`（Req 4.7）
  - 承認済み／未承認の区別は呼び出し元責務（`approvedAt !== null` 等のフィルタ済みデータを渡す）
- **`prisma/schema.prisma`** — `EmployeeSkill` モデル追加。`@@unique([userId, skillId])` と `@@index([skillId, level])`
- **`prisma/migrations/employee-skill.sql`** — `employee_skills` テーブル DDL（既存マイグレーション命名規約に合わせる）
- **`src/tests/shared/skill-gap-calculator.test.ts`** — 24 ケース

## Requirements

- 4.6: HR_MANAGER が特定ポストを選択したときの候補者充足率(%)表示
- 4.7: 閾値 60% 未満のポストを採用アラートに自動表示
- 4.8: 不足スキルカテゴリのランキング表示

## Design Decisions

- **純関数 (KISS/YAGNI)**: DB / リポジトリ非依存。呼び出し元（`CareerService`, `SkillAnalytics`）が事前取得したデータを渡すことでテスト容易性と再利用性を確保
- **空要件 → 1.0**: 「要件なし＝完全充足」として扱い、ゼロ除算を回避
- **閾値ちょうどは非アラート**: `<` 比較で「60% 以上なら OK」のセマンティクス
- **安定ソート**: 複数タイブレーク条件により UI 側で順序が blinking しない

## Test plan

- [x] `pnpm vitest run src/tests/shared/` — 56 tests passed (24 new + 32 existing)
- [x] `pnpm eslint src/lib/shared/skill-gap-calculator.ts src/tests/shared/skill-gap-calculator.test.ts` — 0 issues
- [x] 型チェック: 新規ファイルは strict 準拠、`any` 不使用（既存 pre-existing エラーはこの PR と無関係）
- [x] ファイルサイズ: すべて 800 行以内、関数 50 行以内
- [ ] 次タスク (Task 11.2 社員スキル登録／11.3 ヒートマップ) から本モジュールを呼び出し動作確認

### Test Coverage Matrix

| 関数 | ケース |
|---|---|
| `calculateGap` | 全充足 / 部分不足 / 未保有 / 必要 0 件 / 保有 0 件 / 承認区別なし / gap ソート / タイブレークソート / 表示用フィールド未指定 |
| `calculateFulfillmentRate` | 100% / 0% / 50% / 必要 0 件 / 上限クリップ / 小数精度 (≒0.6667) / 値域 [0,1] |
| `isHiringAlertNeeded` | デフォルト閾値定数 / 境界値 (0.59, 0.6, 0.8) / 0% / 100% / カスタム閾値 0.8 / カスタム閾値 0 |