### PR TITLE
[#38] ポスト候補者リストと採用アラート

### DIFF
--- a/src/app/api/skills/post-candidates/[positionId]/route.ts
+++ b/src/app/api/skills/post-candidates/[positionId]/route.ts
@@ -1,0 +1,53 @@
+/**
+ * Issue #38 / Req 4.6: ポスト候補者一覧 API
+ *
+ * GET /api/skills/post-candidates/[positionId]/candidates
+ * - 役職要件に対する候補者一覧とスキル充足率を返す (Req 4.6)
+ * - HR_MANAGER / ADMIN のみ許可
+ */
+import { type NextRequest, NextResponse } from 'next/server'
+import { requireAuthenticated } from '@/lib/skill/skill-route-helpers'
+import { getPostCandidateService } from '@/lib/skill/post-candidate-service-di'
+
+export {
+  setPostCandidateServiceForTesting,
+  clearPostCandidateServiceForTesting,
+} from '@/lib/skill/post-candidate-service-di'
+
+const HR_MANAGER_ROLES = ['HR_MANAGER', 'ADMIN'] as const
+
+function isHrManagerOrAbove(role: string): boolean {
+  return (HR_MANAGER_ROLES as readonly string[]).includes(role)
+}
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ positionId: string }> },
+): Promise<NextResponse> {
+  const guard = await requireAuthenticated()
+  if (!guard.ok) return guard.response
+
+  if (!isHrManagerOrAbove(guard.session.role)) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const { positionId } = await params
+
+  let svc: ReturnType<typeof getPostCandidateService>
+  try {
+    svc = getPostCandidateService()
+  } catch {
+    return NextResponse.json({ error: 'Post candidate service not initialized' }, { status: 503 })
+  }
+
+  try {
+    const data = await svc.listCandidatesForPost(positionId)
+    return NextResponse.json({ success: true, data })
+  } catch (err) {
+    if (err instanceof Error && err.message === 'Position not found') {
+      return NextResponse.json({ error: 'Position not found' }, { status: 404 })
+    }
+    console.error('[post-candidates] listCandidatesForPost error', err)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/api/skills/post-candidates/route.ts
+++ b/src/app/api/skills/post-candidates/route.ts
@@ -1,0 +1,85 @@
+/**
+ * Issue #38 / Req 4.7, 4.8: ポスト充足アラート / スキルギャップランキング API
+ *
+ * - GET /api/skills/post-candidates/understaffed?threshold=0.6 — 充足率不足ポスト一覧 (Req 4.7)
+ * - GET /api/skills/post-candidates/gap-ranking               — スキルギャップランキング (Req 4.8)
+ *
+ * 両エンドポイントとも HR_MANAGER / ADMIN のみ許可。
+ */
+import { type NextRequest, NextResponse } from 'next/server'
+import { requireAuthenticated } from '@/lib/skill/skill-route-helpers'
+import { getPostCandidateService } from '@/lib/skill/post-candidate-service-di'
+
+export {
+  setPostCandidateServiceForTesting,
+  clearPostCandidateServiceForTesting,
+} from '@/lib/skill/post-candidate-service-di'
+
+const HR_MANAGER_ROLES = ['HR_MANAGER', 'ADMIN'] as const
+
+function isHrManagerOrAbove(role: string): boolean {
+  return (HR_MANAGER_ROLES as readonly string[]).includes(role)
+}
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const guard = await requireAuthenticated()
+  if (!guard.ok) return guard.response
+
+  if (!isHrManagerOrAbove(guard.session.role)) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const path = request.nextUrl.pathname
+
+  let svc: ReturnType<typeof getPostCandidateService>
+  try {
+    svc = getPostCandidateService()
+  } catch {
+    return NextResponse.json({ error: 'Post candidate service not initialized' }, { status: 503 })
+  }
+
+  if (path.endsWith('/understaffed')) {
+    return handleUnderstaffed(request, svc)
+  }
+
+  if (path.endsWith('/gap-ranking')) {
+    return handleGapRanking(svc)
+  }
+
+  return NextResponse.json({ error: 'Not found' }, { status: 404 })
+}
+
+async function handleUnderstaffed(
+  request: NextRequest,
+  svc: ReturnType<typeof getPostCandidateService>,
+): Promise<NextResponse> {
+  const thresholdParam = request.nextUrl.searchParams.get('threshold')
+  const threshold = thresholdParam !== null ? parseFloat(thresholdParam) : undefined
+
+  if (threshold !== undefined && (isNaN(threshold) || threshold < 0 || threshold > 1)) {
+    return NextResponse.json(
+      { error: 'threshold must be a number between 0 and 1' },
+      { status: 400 },
+    )
+  }
+
+  try {
+    const data = await svc.listUnderstaffedPosts(threshold)
+    return NextResponse.json({ success: true, data })
+  } catch (err) {
+    console.error('[post-candidates] listUnderstaffedPosts error', err)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}
+
+async function handleGapRanking(
+  svc: ReturnType<typeof getPostCandidateService>,
+): Promise<NextResponse> {
+  try {
+    const data = await svc.getSkillGapRanking()
+    return NextResponse.json({ success: true, data })
+  } catch (err) {
+    console.error('[post-candidates] getSkillGapRanking error', err)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/lib/skill/post-candidate-service-di.ts
+++ b/src/lib/skill/post-candidate-service-di.ts
@@ -1,0 +1,30 @@
+/**
+ * Issue #38: PostCandidateService のシングルトン DI モジュール。
+ *
+ * skill-service-di.ts と同一パターン。テストでは set/clear で差し替え、
+ * プロダクションでは init* で注入する。
+ */
+import type { PostCandidateService } from './post-candidate-service'
+
+let _service: PostCandidateService | null = null
+
+export function setPostCandidateServiceForTesting(svc: PostCandidateService): void {
+  _service = svc
+}
+
+export function clearPostCandidateServiceForTesting(): void {
+  _service = null
+}
+
+export function initPostCandidateService(svc: PostCandidateService): void {
+  _service = svc
+}
+
+export function getPostCandidateService(): PostCandidateService {
+  if (_service) return _service
+  throw new Error(
+    'PostCandidateService is not initialized. ' +
+      'テストでは setPostCandidateServiceForTesting() を呼んでください。' +
+      'プロダクションではサーバー起動前に initPostCandidateService() を呼んでください。',
+  )
+}

--- a/src/lib/skill/post-candidate-service.ts
+++ b/src/lib/skill/post-candidate-service.ts
@@ -1,0 +1,443 @@
+/**
+ * Issue #38 / Req 4.6, 4.7, 4.8: ポスト候補者リストと採用アラート
+ *
+ * - listCandidatesForPost: 役職要件に対する候補者一覧とスキル充足率 (Req 4.6)
+ * - listUnderstaffedPosts: 充足率が閾値を下回るポストの自動アラート (Req 4.7)
+ * - getSkillGapRanking:   組織目標に対するスキルギャップランキング (Req 4.8)
+ */
+import type { PrismaClient } from '@prisma/client'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Repository row types
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface PositionRow {
+  readonly id: string
+  readonly roleId: string
+  readonly roleName: string
+  readonly holderUserId: string | null
+}
+
+export interface RoleSkillRequirementRow {
+  readonly id: string
+  readonly roleId: string
+  readonly skillId: string
+  readonly skillName: string
+  readonly requiredLevel: number
+}
+
+export interface EmployeeSkillRow {
+  readonly id: string
+  readonly userId: string
+  readonly skillId: string
+  readonly level: number
+  readonly approved: boolean
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Repository port
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface PostCandidateRepository {
+  listPositions(): Promise<PositionRow[]>
+  listPositionById(positionId: string): Promise<PositionRow | null>
+  listRoleSkillRequirements(): Promise<RoleSkillRequirementRow[]>
+  listEmployeeSkills(): Promise<EmployeeSkillRow[]>
+  listActiveUserIds(): Promise<string[]>
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Service result types
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface CandidateScore {
+  readonly userId: string
+  readonly fulfillmentRate: number
+  readonly matchedSkills: number
+  readonly totalRequired: number
+}
+
+export interface PostCandidateResult {
+  readonly positionId: string
+  readonly roleId: string
+  readonly roleName: string
+  readonly candidates: CandidateScore[]
+  readonly fulfillmentRate: number
+}
+
+export interface UnderstaffedPost {
+  readonly positionId: string
+  readonly roleId: string
+  readonly roleName: string
+  readonly fulfillmentRate: number
+}
+
+export interface SkillGapRankItem {
+  readonly skillId: string
+  readonly skillName: string
+  readonly averageGap: number
+  readonly affectedEmployeeCount: number
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Service port
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface PostCandidateService {
+  listCandidatesForPost(positionId: string): Promise<PostCandidateResult>
+  listUnderstaffedPosts(threshold?: number): Promise<UnderstaffedPost[]>
+  getSkillGapRanking(): Promise<SkillGapRankItem[]>
+}
+
+const DEFAULT_THRESHOLD = 0.6
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Service implementation
+// ─────────────────────────────────────────────────────────────────────────────
+
+class PostCandidateServiceImpl implements PostCandidateService {
+  constructor(private readonly repo: PostCandidateRepository) {}
+
+  async listCandidatesForPost(positionId: string): Promise<PostCandidateResult> {
+    const position = await this.repo.listPositionById(positionId)
+    if (!position) throw new Error('Position not found')
+
+    const [requirements, employeeSkills, userIds] = await Promise.all([
+      this.repo.listRoleSkillRequirements(),
+      this.repo.listEmployeeSkills(),
+      this.repo.listActiveUserIds(),
+    ])
+
+    const roleRequirements = requirements.filter((r) => r.roleId === position.roleId)
+    const skillsByUser = groupByUser(employeeSkills)
+
+    const candidates = userIds.map((userId) =>
+      scoreCandidateForRole(userId, roleRequirements, skillsByUser.get(userId) ?? []),
+    )
+    candidates.sort((a, b) => b.fulfillmentRate - a.fulfillmentRate)
+
+    const fulfillmentRate = computeAverageFulfillmentRate(candidates, roleRequirements.length)
+
+    return {
+      positionId: position.id,
+      roleId: position.roleId,
+      roleName: position.roleName,
+      candidates,
+      fulfillmentRate,
+    }
+  }
+
+  async listUnderstaffedPosts(threshold = DEFAULT_THRESHOLD): Promise<UnderstaffedPost[]> {
+    const [positions, requirements, employeeSkills, userIds] = await Promise.all([
+      this.repo.listPositions(),
+      this.repo.listRoleSkillRequirements(),
+      this.repo.listEmployeeSkills(),
+      this.repo.listActiveUserIds(),
+    ])
+
+    const requirementsByRole = groupByRole(requirements)
+    const skillsByUser = groupByUser(employeeSkills)
+
+    const understaffed: UnderstaffedPost[] = []
+    for (const position of positions) {
+      const roleRequirements = requirementsByRole.get(position.roleId) ?? []
+      const candidates = userIds.map((userId) =>
+        scoreCandidateForRole(userId, roleRequirements, skillsByUser.get(userId) ?? []),
+      )
+      const rate = computeAverageFulfillmentRate(candidates, roleRequirements.length)
+      if (rate < threshold) {
+        understaffed.push({
+          positionId: position.id,
+          roleId: position.roleId,
+          roleName: position.roleName,
+          fulfillmentRate: rate,
+        })
+      }
+    }
+
+    return understaffed
+  }
+
+  async getSkillGapRanking(): Promise<SkillGapRankItem[]> {
+    const [requirements, employeeSkills, userIds] = await Promise.all([
+      this.repo.listRoleSkillRequirements(),
+      this.repo.listEmployeeSkills(),
+      this.repo.listActiveUserIds(),
+    ])
+
+    if (requirements.length === 0 || userIds.length === 0) return []
+
+    const maxRequiredBySkill = computeMaxRequiredBySkill(requirements)
+    const skillNameById = buildSkillNameIndex(requirements)
+    const skillLevelByUser = buildSkillLevelIndex(employeeSkills)
+
+    const items: SkillGapRankItem[] = []
+    for (const [skillId, maxRequired] of maxRequiredBySkill) {
+      const { totalGap, affectedCount } = computeGapStats(
+        skillId,
+        maxRequired,
+        userIds,
+        skillLevelByUser,
+      )
+      if (affectedCount === 0) continue
+      items.push({
+        skillId,
+        skillName: skillNameById.get(skillId) ?? skillId,
+        averageGap: totalGap / affectedCount,
+        affectedEmployeeCount: affectedCount,
+      })
+    }
+
+    items.sort((a, b) =>
+      b.averageGap === a.averageGap
+        ? a.skillName.localeCompare(b.skillName)
+        : b.averageGap - a.averageGap,
+    )
+
+    return items
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Pure helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+function groupByUser(skills: readonly EmployeeSkillRow[]): Map<string, EmployeeSkillRow[]> {
+  const out = new Map<string, EmployeeSkillRow[]>()
+  for (const s of skills) {
+    const list = out.get(s.userId) ?? []
+    list.push(s)
+    out.set(s.userId, list)
+  }
+  return out
+}
+
+function groupByRole(
+  requirements: readonly RoleSkillRequirementRow[],
+): Map<string, RoleSkillRequirementRow[]> {
+  const out = new Map<string, RoleSkillRequirementRow[]>()
+  for (const r of requirements) {
+    const list = out.get(r.roleId) ?? []
+    list.push(r)
+    out.set(r.roleId, list)
+  }
+  return out
+}
+
+function scoreCandidateForRole(
+  userId: string,
+  requirements: readonly RoleSkillRequirementRow[],
+  userSkills: readonly EmployeeSkillRow[],
+): CandidateScore {
+  const totalRequired = requirements.length
+  if (totalRequired === 0) {
+    return { userId, fulfillmentRate: 1.0, matchedSkills: 0, totalRequired: 0 }
+  }
+
+  const levelBySkill = new Map(userSkills.map((s) => [s.skillId, s.level]))
+  let matchedSkills = 0
+  for (const req of requirements) {
+    const level = levelBySkill.get(req.skillId) ?? 0
+    if (level >= req.requiredLevel) matchedSkills++
+  }
+
+  return {
+    userId,
+    fulfillmentRate: matchedSkills / totalRequired,
+    matchedSkills,
+    totalRequired,
+  }
+}
+
+function computeAverageFulfillmentRate(
+  candidates: readonly CandidateScore[],
+  totalRequired: number,
+): number {
+  if (candidates.length === 0) return totalRequired === 0 ? 1.0 : 0.0
+  const sum = candidates.reduce((acc, c) => acc + c.fulfillmentRate, 0)
+  return sum / candidates.length
+}
+
+function computeMaxRequiredBySkill(
+  requirements: readonly RoleSkillRequirementRow[],
+): Map<string, number> {
+  const out = new Map<string, number>()
+  for (const r of requirements) {
+    const current = out.get(r.skillId) ?? 0
+    if (r.requiredLevel > current) out.set(r.skillId, r.requiredLevel)
+  }
+  return out
+}
+
+function buildSkillNameIndex(
+  requirements: readonly RoleSkillRequirementRow[],
+): Map<string, string> {
+  const out = new Map<string, string>()
+  for (const r of requirements) {
+    if (!out.has(r.skillId)) out.set(r.skillId, r.skillName)
+  }
+  return out
+}
+
+function buildSkillLevelIndex(
+  skills: readonly EmployeeSkillRow[],
+): Map<string, Map<string, number>> {
+  const out = new Map<string, Map<string, number>>()
+  for (const s of skills) {
+    const userMap = out.get(s.userId) ?? new Map<string, number>()
+    userMap.set(s.skillId, s.level)
+    out.set(s.userId, userMap)
+  }
+  return out
+}
+
+function computeGapStats(
+  skillId: string,
+  maxRequired: number,
+  userIds: readonly string[],
+  skillLevelByUser: ReadonlyMap<string, ReadonlyMap<string, number>>,
+): { totalGap: number; affectedCount: number } {
+  let totalGap = 0
+  let affectedCount = 0
+  for (const userId of userIds) {
+    const level = skillLevelByUser.get(userId)?.get(skillId) ?? 0
+    const gap = maxRequired - level
+    if (gap > 0) {
+      totalGap += gap
+      affectedCount++
+    }
+  }
+  return { totalGap, affectedCount }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Prisma delegate shim
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface PositionPrismaRow {
+  id: string
+  roleId: string
+  holderUserId: string | null
+  role: { id: string; name: string }
+}
+
+interface RoleSkillRequirementPrismaRow {
+  id: string
+  roleId: string
+  skillId: string
+  requiredLevel: number
+  skill: { id: string; name: string }
+}
+
+interface EmployeeSkillPrismaRow {
+  id: string
+  userId: string
+  skillId: string
+  level: number
+  approvedAt: Date | null
+}
+
+interface UserPrismaRow {
+  id: string
+}
+
+interface PostCandidateDelegates {
+  position: {
+    findMany(args?: unknown): Promise<PositionPrismaRow[]>
+    findUnique(args: unknown): Promise<PositionPrismaRow | null>
+  }
+  roleSkillRequirement: {
+    findMany(args?: unknown): Promise<RoleSkillRequirementPrismaRow[]>
+  }
+  employeeSkill: {
+    findMany(args?: unknown): Promise<EmployeeSkillPrismaRow[]>
+  }
+  user: {
+    findMany(args?: unknown): Promise<UserPrismaRow[]>
+  }
+}
+
+function asDelegates(db: PrismaClient): PostCandidateDelegates {
+  return db as unknown as PostCandidateDelegates
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Prisma repository implementation
+// ─────────────────────────────────────────────────────────────────────────────
+
+class PrismaPostCandidateRepository implements PostCandidateRepository {
+  private readonly d: PostCandidateDelegates
+
+  constructor(db: PrismaClient) {
+    this.d = asDelegates(db)
+  }
+
+  async listPositions(): Promise<PositionRow[]> {
+    const rows = await this.d.position.findMany({
+      include: { role: true },
+    })
+    return rows.map(mapPosition)
+  }
+
+  async listPositionById(positionId: string): Promise<PositionRow | null> {
+    const row = await this.d.position.findUnique({
+      where: { id: positionId },
+      include: { role: true },
+    })
+    return row ? mapPosition(row) : null
+  }
+
+  async listRoleSkillRequirements(): Promise<RoleSkillRequirementRow[]> {
+    const rows = await this.d.roleSkillRequirement.findMany({
+      include: { skill: true },
+    })
+    return rows.map(
+      (r): RoleSkillRequirementRow => ({
+        id: r.id,
+        roleId: r.roleId,
+        skillId: r.skillId,
+        skillName: r.skill.name,
+        requiredLevel: r.requiredLevel,
+      }),
+    )
+  }
+
+  async listEmployeeSkills(): Promise<EmployeeSkillRow[]> {
+    const rows = await this.d.employeeSkill.findMany({})
+    return rows.map(
+      (r): EmployeeSkillRow => ({
+        id: r.id,
+        userId: r.userId,
+        skillId: r.skillId,
+        level: r.level,
+        approved: r.approvedAt !== null,
+      }),
+    )
+  }
+
+  async listActiveUserIds(): Promise<string[]> {
+    const rows = await this.d.user.findMany({ where: { status: 'ACTIVE' } })
+    return rows.map((r) => r.id)
+  }
+}
+
+function mapPosition(row: PositionPrismaRow): PositionRow {
+  return {
+    id: row.id,
+    roleId: row.roleId,
+    roleName: row.role.name,
+    holderUserId: row.holderUserId,
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Factories
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function createPrismaPostCandidateRepository(db: PrismaClient): PostCandidateRepository {
+  return new PrismaPostCandidateRepository(db)
+}
+
+export function createPostCandidateService(repo: PostCandidateRepository): PostCandidateService {
+  return new PostCandidateServiceImpl(repo)
+}

--- a/src/tests/skill/post-candidate-service.test.ts
+++ b/src/tests/skill/post-candidate-service.test.ts
@@ -1,0 +1,444 @@
+/**
+ * Issue #38 / Req 4.6, 4.7, 4.8: PostCandidateService の単体テスト
+ *
+ * - listCandidatesForPost: 候補者一覧とスキル充足率
+ * - listUnderstaffedPosts: 閾値未満ポストのアラート
+ * - getSkillGapRanking: スキルギャップランキング
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { createPostCandidateService } from '@/lib/skill/post-candidate-service'
+import type {
+  PostCandidateRepository,
+  PositionRow,
+  RoleSkillRequirementRow,
+  EmployeeSkillRow,
+} from '@/lib/skill/post-candidate-service'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fixtures
+// ─────────────────────────────────────────────────────────────────────────────
+
+function makePosition(overrides: Partial<PositionRow> = {}): PositionRow {
+  return {
+    id: 'pos-1',
+    roleId: 'role-engineer',
+    roleName: 'Engineer',
+    holderUserId: null,
+    ...overrides,
+  }
+}
+
+function makeRequirement(
+  overrides: Partial<RoleSkillRequirementRow> = {},
+): RoleSkillRequirementRow {
+  return {
+    id: 'req-1',
+    roleId: 'role-engineer',
+    skillId: 'skill-ts',
+    requiredLevel: 3,
+    skillName: 'TypeScript',
+    ...overrides,
+  }
+}
+
+function makeEmployeeSkill(overrides: Partial<EmployeeSkillRow> = {}): EmployeeSkillRow {
+  return {
+    id: 'es-1',
+    userId: 'user-1',
+    skillId: 'skill-ts',
+    level: 4,
+    approved: true,
+    ...overrides,
+  }
+}
+
+function makeRepo(overrides: Partial<PostCandidateRepository> = {}): PostCandidateRepository {
+  return {
+    listPositions: vi.fn().mockResolvedValue([]),
+    listPositionById: vi.fn().mockResolvedValue(null),
+    listRoleSkillRequirements: vi.fn().mockResolvedValue([]),
+    listEmployeeSkills: vi.fn().mockResolvedValue([]),
+    listActiveUserIds: vi.fn().mockResolvedValue([]),
+    ...overrides,
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// listCandidatesForPost
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('listCandidatesForPost', () => {
+  it('ポジションが存在しない場合はエラーをスローする', async () => {
+    const repo = makeRepo({
+      listPositionById: vi.fn().mockResolvedValue(null),
+    })
+    const svc = createPostCandidateService(repo)
+
+    await expect(svc.listCandidatesForPost('pos-unknown')).rejects.toThrow('Position not found')
+  })
+
+  it('スキル要件がない場合、候補者は充足率1.0で返る', async () => {
+    const repo = makeRepo({
+      listPositionById: vi.fn().mockResolvedValue(makePosition()),
+      listRoleSkillRequirements: vi.fn().mockResolvedValue([]),
+      listActiveUserIds: vi.fn().mockResolvedValue(['user-1', 'user-2']),
+      listEmployeeSkills: vi.fn().mockResolvedValue([]),
+    })
+    const svc = createPostCandidateService(repo)
+
+    const result = await svc.listCandidatesForPost('pos-1')
+
+    expect(result.positionId).toBe('pos-1')
+    expect(result.roleId).toBe('role-engineer')
+    expect(result.roleName).toBe('Engineer')
+    expect(result.fulfillmentRate).toBe(1.0)
+    expect(result.candidates).toHaveLength(2)
+    expect(result.candidates[0]?.fulfillmentRate).toBe(1.0)
+    expect(result.candidates[0]?.matchedSkills).toBe(0)
+    expect(result.candidates[0]?.totalRequired).toBe(0)
+  })
+
+  it('候補者スキルが要件を一部満たす場合、充足スキル数が正しく計算される', async () => {
+    const position = makePosition()
+    const requirements = [
+      makeRequirement({ skillId: 'skill-ts', requiredLevel: 3 }),
+      makeRequirement({ id: 'req-2', skillId: 'skill-py', requiredLevel: 2, skillName: 'Python' }),
+    ]
+    const skills: EmployeeSkillRow[] = [
+      makeEmployeeSkill({ userId: 'user-1', skillId: 'skill-ts', level: 4 }),
+      makeEmployeeSkill({ id: 'es-2', userId: 'user-1', skillId: 'skill-py', level: 1 }),
+    ]
+    const repo = makeRepo({
+      listPositionById: vi.fn().mockResolvedValue(position),
+      listRoleSkillRequirements: vi.fn().mockResolvedValue(requirements),
+      listActiveUserIds: vi.fn().mockResolvedValue(['user-1']),
+      listEmployeeSkills: vi.fn().mockResolvedValue(skills),
+    })
+    const svc = createPostCandidateService(repo)
+
+    const result = await svc.listCandidatesForPost('pos-1')
+
+    const candidate = result.candidates.find((c) => c.userId === 'user-1')
+    expect(candidate).toBeDefined()
+    expect(candidate?.totalRequired).toBe(2)
+    expect(candidate?.matchedSkills).toBe(1) // skill-ts 満たす、skill-py 不足
+    expect(candidate?.fulfillmentRate).toBeCloseTo(0.5, 5)
+  })
+
+  it('候補者が全スキル要件を満たす場合、充足率は1.0になる', async () => {
+    const position = makePosition()
+    const requirements = [makeRequirement({ skillId: 'skill-ts', requiredLevel: 3 })]
+    const skills: EmployeeSkillRow[] = [
+      makeEmployeeSkill({ userId: 'user-1', skillId: 'skill-ts', level: 5 }),
+    ]
+    const repo = makeRepo({
+      listPositionById: vi.fn().mockResolvedValue(position),
+      listRoleSkillRequirements: vi.fn().mockResolvedValue(requirements),
+      listActiveUserIds: vi.fn().mockResolvedValue(['user-1']),
+      listEmployeeSkills: vi.fn().mockResolvedValue(skills),
+    })
+    const svc = createPostCandidateService(repo)
+
+    const result = await svc.listCandidatesForPost('pos-1')
+
+    expect(result.candidates[0]?.fulfillmentRate).toBe(1.0)
+    expect(result.candidates[0]?.matchedSkills).toBe(1)
+  })
+
+  it('候補者が複数いる場合、充足率の降順でソートされる', async () => {
+    const position = makePosition()
+    const requirements = [makeRequirement({ skillId: 'skill-ts', requiredLevel: 3 })]
+    const skills: EmployeeSkillRow[] = [
+      makeEmployeeSkill({ id: 'es-1', userId: 'user-a', skillId: 'skill-ts', level: 1 }),
+      makeEmployeeSkill({ id: 'es-2', userId: 'user-b', skillId: 'skill-ts', level: 4 }),
+    ]
+    const repo = makeRepo({
+      listPositionById: vi.fn().mockResolvedValue(position),
+      listRoleSkillRequirements: vi.fn().mockResolvedValue(requirements),
+      listActiveUserIds: vi.fn().mockResolvedValue(['user-a', 'user-b']),
+      listEmployeeSkills: vi.fn().mockResolvedValue(skills),
+    })
+    const svc = createPostCandidateService(repo)
+
+    const result = await svc.listCandidatesForPost('pos-1')
+
+    expect(result.candidates[0]?.userId).toBe('user-b')
+    expect(result.candidates[1]?.userId).toBe('user-a')
+  })
+
+  it('ポジションのfulfillmentRateは全候補者の平均となる', async () => {
+    const position = makePosition()
+    const requirements = [makeRequirement({ skillId: 'skill-ts', requiredLevel: 3 })]
+    const skills: EmployeeSkillRow[] = [
+      makeEmployeeSkill({ id: 'es-1', userId: 'user-a', skillId: 'skill-ts', level: 4 }),
+      makeEmployeeSkill({ id: 'es-2', userId: 'user-b', skillId: 'skill-ts', level: 1 }),
+    ]
+    const repo = makeRepo({
+      listPositionById: vi.fn().mockResolvedValue(position),
+      listRoleSkillRequirements: vi.fn().mockResolvedValue(requirements),
+      listActiveUserIds: vi.fn().mockResolvedValue(['user-a', 'user-b']),
+      listEmployeeSkills: vi.fn().mockResolvedValue(skills),
+    })
+    const svc = createPostCandidateService(repo)
+
+    const result = await svc.listCandidatesForPost('pos-1')
+
+    // user-a: 充足率 1.0, user-b: 充足率 0.0 → 平均 0.5
+    expect(result.fulfillmentRate).toBeCloseTo(0.5, 5)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// listUnderstaffedPosts
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('listUnderstaffedPosts', () => {
+  it('空のポジションリストの場合、空配列を返す', async () => {
+    const repo = makeRepo({ listPositions: vi.fn().mockResolvedValue([]) })
+    const svc = createPostCandidateService(repo)
+
+    const result = await svc.listUnderstaffedPosts()
+
+    expect(result).toEqual([])
+  })
+
+  it('デフォルト閾値(0.6)未満のポストのみ返す', async () => {
+    const positions = [
+      makePosition({ id: 'pos-1', roleId: 'role-eng', roleName: 'Engineer' }),
+      makePosition({ id: 'pos-2', roleId: 'role-eng', roleName: 'Engineer' }),
+    ]
+    const requirements = [
+      makeRequirement({ roleId: 'role-eng', skillId: 'skill-ts', requiredLevel: 3 }),
+    ]
+    const skills: EmployeeSkillRow[] = [
+      makeEmployeeSkill({ userId: 'user-a', skillId: 'skill-ts', level: 4 }),
+      makeEmployeeSkill({ id: 'es-2', userId: 'user-b', skillId: 'skill-ts', level: 1 }),
+    ]
+    const repo = makeRepo({
+      listPositions: vi.fn().mockResolvedValue(positions),
+      listRoleSkillRequirements: vi.fn().mockResolvedValue(requirements),
+      listActiveUserIds: vi.fn().mockResolvedValue(['user-a', 'user-b']),
+      listEmployeeSkills: vi.fn().mockResolvedValue(skills),
+    })
+    const svc = createPostCandidateService(repo)
+
+    const result = await svc.listUnderstaffedPosts()
+
+    // user-a: 充足率1.0, user-b: 充足率0.0 → 平均0.5 < 0.6 → アラート対象
+    expect(result).toHaveLength(2)
+    expect(result[0]?.positionId).toBeDefined()
+  })
+
+  it('全ポストが閾値以上の場合、空配列を返す', async () => {
+    const positions = [makePosition({ id: 'pos-1', roleId: 'role-eng', roleName: 'Engineer' })]
+    const requirements = [
+      makeRequirement({ roleId: 'role-eng', skillId: 'skill-ts', requiredLevel: 3 }),
+    ]
+    const skills: EmployeeSkillRow[] = [
+      makeEmployeeSkill({ userId: 'user-a', skillId: 'skill-ts', level: 4 }),
+      makeEmployeeSkill({ id: 'es-2', userId: 'user-b', skillId: 'skill-ts', level: 3 }),
+    ]
+    const repo = makeRepo({
+      listPositions: vi.fn().mockResolvedValue(positions),
+      listRoleSkillRequirements: vi.fn().mockResolvedValue(requirements),
+      listActiveUserIds: vi.fn().mockResolvedValue(['user-a', 'user-b']),
+      listEmployeeSkills: vi.fn().mockResolvedValue(skills),
+    })
+    const svc = createPostCandidateService(repo)
+
+    const result = await svc.listUnderstaffedPosts()
+
+    expect(result).toHaveLength(0)
+  })
+
+  it('カスタム閾値を指定できる', async () => {
+    const positions = [makePosition({ id: 'pos-1', roleId: 'role-eng', roleName: 'Engineer' })]
+    const requirements = [
+      makeRequirement({ roleId: 'role-eng', skillId: 'skill-ts', requiredLevel: 3 }),
+    ]
+    const skills: EmployeeSkillRow[] = [
+      makeEmployeeSkill({ userId: 'user-a', skillId: 'skill-ts', level: 4 }),
+    ]
+    const repo = makeRepo({
+      listPositions: vi.fn().mockResolvedValue(positions),
+      listRoleSkillRequirements: vi.fn().mockResolvedValue(requirements),
+      listActiveUserIds: vi.fn().mockResolvedValue(['user-a']),
+      listEmployeeSkills: vi.fn().mockResolvedValue(skills),
+    })
+    const svc = createPostCandidateService(repo)
+
+    // user-a は充足率1.0 → 閾値1.1未満 → アラート対象
+    const result = await svc.listUnderstaffedPosts(1.1)
+    expect(result).toHaveLength(1)
+
+    // 閾値0.5以下は対象外
+    const result2 = await svc.listUnderstaffedPosts(0.5)
+    expect(result2).toHaveLength(0)
+  })
+
+  it('返却するアラート情報には positionId, roleId, roleName, fulfillmentRate が含まれる', async () => {
+    const positions = [makePosition({ id: 'pos-1', roleId: 'role-eng', roleName: 'Engineer' })]
+    const requirements = [
+      makeRequirement({ roleId: 'role-eng', skillId: 'skill-ts', requiredLevel: 3 }),
+    ]
+    const repo = makeRepo({
+      listPositions: vi.fn().mockResolvedValue(positions),
+      listRoleSkillRequirements: vi.fn().mockResolvedValue(requirements),
+      listActiveUserIds: vi.fn().mockResolvedValue([]),
+      listEmployeeSkills: vi.fn().mockResolvedValue([]),
+    })
+    const svc = createPostCandidateService(repo)
+
+    // 候補者なし → 充足率0.0 → 閾値0.6未満
+    const result = await svc.listUnderstaffedPosts(0.6)
+
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({
+      positionId: 'pos-1',
+      roleId: 'role-eng',
+      roleName: 'Engineer',
+      fulfillmentRate: expect.any(Number),
+    })
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// getSkillGapRanking
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('getSkillGapRanking', () => {
+  it('スキル要件もスキルも存在しない場合、空配列を返す', async () => {
+    const svc = createPostCandidateService(makeRepo())
+    const result = await svc.getSkillGapRanking()
+    expect(result).toEqual([])
+  })
+
+  it('要件あり・保有スキルなしの場合、全員がギャップを持つ', async () => {
+    const requirements = [
+      makeRequirement({ skillId: 'skill-ts', skillName: 'TypeScript', requiredLevel: 3 }),
+    ]
+    const repo = makeRepo({
+      listRoleSkillRequirements: vi.fn().mockResolvedValue(requirements),
+      listActiveUserIds: vi.fn().mockResolvedValue(['user-a', 'user-b']),
+      listEmployeeSkills: vi.fn().mockResolvedValue([]),
+    })
+    const svc = createPostCandidateService(repo)
+
+    const result = await svc.getSkillGapRanking()
+
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({
+      skillId: 'skill-ts',
+      skillName: 'TypeScript',
+      averageGap: 3, // 要件3 - 実際0 = 3
+      affectedEmployeeCount: 2,
+    })
+  })
+
+  it('スキルが要件を満たす場合、ギャップは0でランキングから除外される', async () => {
+    const requirements = [
+      makeRequirement({ skillId: 'skill-ts', skillName: 'TypeScript', requiredLevel: 3 }),
+    ]
+    const skills: EmployeeSkillRow[] = [
+      makeEmployeeSkill({ userId: 'user-a', skillId: 'skill-ts', level: 4 }),
+    ]
+    const repo = makeRepo({
+      listRoleSkillRequirements: vi.fn().mockResolvedValue(requirements),
+      listActiveUserIds: vi.fn().mockResolvedValue(['user-a']),
+      listEmployeeSkills: vi.fn().mockResolvedValue(skills),
+    })
+    const svc = createPostCandidateService(repo)
+
+    const result = await svc.getSkillGapRanking()
+
+    expect(result).toHaveLength(0)
+  })
+
+  it('複数スキルのギャップが平均不足レベルの降順でソートされる', async () => {
+    const requirements = [
+      makeRequirement({
+        id: 'req-ts',
+        skillId: 'skill-ts',
+        skillName: 'TypeScript',
+        requiredLevel: 5,
+      }),
+      makeRequirement({ id: 'req-py', skillId: 'skill-py', skillName: 'Python', requiredLevel: 3 }),
+    ]
+    const skills: EmployeeSkillRow[] = [
+      makeEmployeeSkill({ id: 'es-1', userId: 'user-a', skillId: 'skill-ts', level: 2 }),
+      makeEmployeeSkill({ id: 'es-2', userId: 'user-a', skillId: 'skill-py', level: 1 }),
+    ]
+    const repo = makeRepo({
+      listRoleSkillRequirements: vi.fn().mockResolvedValue(requirements),
+      listActiveUserIds: vi.fn().mockResolvedValue(['user-a']),
+      listEmployeeSkills: vi.fn().mockResolvedValue(skills),
+    })
+    const svc = createPostCandidateService(repo)
+
+    const result = await svc.getSkillGapRanking()
+
+    // TypeScript: gap = 5 - 2 = 3, Python: gap = 3 - 1 = 2 → TS が上位
+    expect(result).toHaveLength(2)
+    expect(result[0]?.skillId).toBe('skill-ts')
+    expect(result[0]?.averageGap).toBeCloseTo(3, 5)
+    expect(result[1]?.skillId).toBe('skill-py')
+    expect(result[1]?.averageGap).toBeCloseTo(2, 5)
+  })
+
+  it('複数のロールで同じスキルが要求される場合、最大要求レベルで計算する', async () => {
+    const requirements = [
+      makeRequirement({
+        id: 'req-1',
+        roleId: 'role-a',
+        skillId: 'skill-ts',
+        skillName: 'TypeScript',
+        requiredLevel: 3,
+      }),
+      makeRequirement({
+        id: 'req-2',
+        roleId: 'role-b',
+        skillId: 'skill-ts',
+        skillName: 'TypeScript',
+        requiredLevel: 5,
+      }),
+    ]
+    const skills: EmployeeSkillRow[] = [
+      makeEmployeeSkill({ userId: 'user-a', skillId: 'skill-ts', level: 2 }),
+    ]
+    const repo = makeRepo({
+      listRoleSkillRequirements: vi.fn().mockResolvedValue(requirements),
+      listActiveUserIds: vi.fn().mockResolvedValue(['user-a']),
+      listEmployeeSkills: vi.fn().mockResolvedValue(skills),
+    })
+    const svc = createPostCandidateService(repo)
+
+    const result = await svc.getSkillGapRanking()
+
+    expect(result).toHaveLength(1)
+    // 最大要求レベル5, 実際2 → gap = 3
+    expect(result[0]?.averageGap).toBeCloseTo(3, 5)
+  })
+
+  it('affectedEmployeeCount はギャップを持つ社員数のみカウントする', async () => {
+    const requirements = [
+      makeRequirement({ skillId: 'skill-ts', skillName: 'TypeScript', requiredLevel: 3 }),
+    ]
+    const skills: EmployeeSkillRow[] = [
+      makeEmployeeSkill({ id: 'es-1', userId: 'user-a', skillId: 'skill-ts', level: 4 }),
+      makeEmployeeSkill({ id: 'es-2', userId: 'user-b', skillId: 'skill-ts', level: 1 }),
+    ]
+    const repo = makeRepo({
+      listRoleSkillRequirements: vi.fn().mockResolvedValue(requirements),
+      listActiveUserIds: vi.fn().mockResolvedValue(['user-a', 'user-b']),
+      listEmployeeSkills: vi.fn().mockResolvedValue(skills),
+    })
+    const svc = createPostCandidateService(repo)
+
+    const result = await svc.getSkillGapRanking()
+
+    expect(result).toHaveLength(1)
+    // user-a は充足 (4 >= 3)、user-b は不足 (1 < 3)
+    expect(result[0]?.affectedEmployeeCount).toBe(1)
+    expect(result[0]?.averageGap).toBeCloseTo(2, 5) // (3 - 1) / 1
+  })
+})


### PR DESCRIPTION
## Summary
- 役職要件に対する候補者一覧とスキル充足率を返すサービスを実装（Req 4.6）
- 充足率が閾値（デフォルト60%）を下回るポストの自動アラート（Req 4.7）
- 組織目標に対するスキルギャップランキング（Req 4.8）

## 追加ファイル
- `src/lib/skill/post-candidate-service.ts` — PostCandidateService + PrismaRepository
- `src/lib/skill/post-candidate-service-di.ts` — DIシングルトン
- `src/app/api/skills/post-candidates/route.ts` — understaffed / gap-ranking エンドポイント
- `src/app/api/skills/post-candidates/[positionId]/route.ts` — ポジション別候補者一覧
- `src/tests/skill/post-candidate-service.test.ts` — 17件テスト全通過

## Test plan
- [ ] `GET /api/skills/post-candidates/understaffed?threshold=0.6` — HR_MANAGER以上のみアクセス可能
- [ ] `GET /api/skills/post-candidates/gap-ranking` — スキルギャップ降順
- [ ] `GET /api/skills/post-candidates/{positionId}` — 候補者一覧と充足率
- [ ] 権限なしユーザー → 403

Closes #38