### PR TITLE
[#39] キャリア希望の登録と履歴管理

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -106,6 +106,7 @@ model User {
   profile         Profile?
   passwordHistory PasswordHistory[]
   sessions        Session[]
+  careerWishes    CareerWish[]
 
   @@index([emailHash])
   @@index([status])
@@ -260,6 +261,7 @@ model RoleMaster {
   name              String                 @unique
   gradeId           String
   skillRequirements RoleSkillRequirement[]
+  careerWishes      CareerWish[]
 
   @@index([gradeId])
   @@map("role_masters")
@@ -380,4 +382,27 @@ model TransferRecord {
 
   @@index([userId, effectiveDate])
   @@map("transfer_records")
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// キャリア希望管理 (Requirement 5.2, 5.6, 5.7)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// キャリア希望 (Requirement 5.2)
+/// supersededAt が null のレコードが現在有効な希望。更新時に旧レコードに supersededAt をセットして履歴保持。
+model CareerWish {
+  id            String    @id @default(cuid())
+  userId        String
+  desiredRoleId String
+  desiredAt     DateTime
+  comment       String?
+  supersededAt  DateTime?
+  createdAt     DateTime  @default(now())
+
+  user        User       @relation(fields: [userId], references: [id], onDelete: Cascade)
+  desiredRole RoleMaster @relation(fields: [desiredRoleId], references: [id])
+
+  @@index([userId])
+  @@index([userId, supersededAt])
+  @@map("career_wishes")
 }

--- a/src/app/api/career/wishes/[userId]/history/route.ts
+++ b/src/app/api/career/wishes/[userId]/history/route.ts
@@ -1,0 +1,42 @@
+/**
+ * Issue #39 / Task 12.1: キャリア希望履歴 API (Req 5.6, 5.7)
+ *
+ * - GET /api/career/wishes/[userId]/history — 全履歴取得（HR_MANAGER以上のみ）
+ */
+import { type NextRequest, NextResponse } from 'next/server'
+import { requireAuthenticated } from '@/lib/skill/skill-route-helpers'
+import { getCareerWishService } from '@/lib/career/career-wish-service-di'
+
+const HR_MANAGER_OR_ABOVE: readonly string[] = ['HR_MANAGER', 'ADMIN']
+
+function isHrManagerOrAbove(role: string): boolean {
+  return HR_MANAGER_OR_ABOVE.includes(role)
+}
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ userId: string }> },
+): Promise<NextResponse> {
+  const guard = await requireAuthenticated()
+  if (!guard.ok) return guard.response
+
+  if (!isHrManagerOrAbove(guard.session.role)) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const { userId } = await params
+
+  let svc: ReturnType<typeof getCareerWishService>
+  try {
+    svc = getCareerWishService()
+  } catch {
+    return NextResponse.json({ error: 'CareerWish service not initialized' }, { status: 503 })
+  }
+
+  try {
+    const history = await svc.getWishHistory(userId)
+    return NextResponse.json({ success: true, data: history })
+  } catch {
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/api/career/wishes/all/route.ts
+++ b/src/app/api/career/wishes/all/route.ts
@@ -1,0 +1,37 @@
+/**
+ * Issue #39 / Task 12.1: 全社員キャリア希望一覧 API (Req 5.7)
+ *
+ * - GET /api/career/wishes/all — 全社員の現在の希望一覧（HR_MANAGER以上のみ）
+ */
+import { type NextRequest, NextResponse } from 'next/server'
+import { requireAuthenticated } from '@/lib/skill/skill-route-helpers'
+import { getCareerWishService } from '@/lib/career/career-wish-service-di'
+
+const HR_MANAGER_OR_ABOVE: readonly string[] = ['HR_MANAGER', 'ADMIN']
+
+function isHrManagerOrAbove(role: string): boolean {
+  return HR_MANAGER_OR_ABOVE.includes(role)
+}
+
+export async function GET(_request: NextRequest): Promise<NextResponse> {
+  const guard = await requireAuthenticated()
+  if (!guard.ok) return guard.response
+
+  if (!isHrManagerOrAbove(guard.session.role)) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  let svc: ReturnType<typeof getCareerWishService>
+  try {
+    svc = getCareerWishService()
+  } catch {
+    return NextResponse.json({ error: 'CareerWish service not initialized' }, { status: 503 })
+  }
+
+  try {
+    const wishes = await svc.listAllCurrentWishes()
+    return NextResponse.json({ success: true, data: wishes })
+  } catch {
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/api/career/wishes/route.ts
+++ b/src/app/api/career/wishes/route.ts
@@ -1,0 +1,76 @@
+/**
+ * Issue #39 / Task 12.1: キャリア希望 登録・取得 API (Req 5.2, 5.6, 5.7)
+ *
+ * - POST /api/career/wishes  — 希望登録（自分自身のみ）
+ * - GET  /api/career/wishes?userId=...  — 現在の希望取得（本人 or HR_MANAGER以上）
+ */
+import { type NextRequest, NextResponse } from 'next/server'
+import { careerWishInputSchema } from '@/lib/career/career-wish-types'
+import {
+  parseJsonBody,
+  requireAuthenticated,
+} from '@/lib/skill/skill-route-helpers'
+import { getCareerWishService } from '@/lib/career/career-wish-service-di'
+
+export {
+  setCareerWishServiceForTesting,
+  clearCareerWishServiceForTesting,
+} from '@/lib/career/career-wish-service-di'
+
+const HR_MANAGER_OR_ABOVE: readonly string[] = ['HR_MANAGER', 'ADMIN']
+
+function isHrManagerOrAbove(role: string): boolean {
+  return HR_MANAGER_OR_ABOVE.includes(role)
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const guard = await requireAuthenticated()
+  if (!guard.ok) return guard.response
+
+  const parsedBody = await parseJsonBody(request)
+  if (!parsedBody.ok) return parsedBody.response
+
+  const validated = careerWishInputSchema.safeParse(parsedBody.body)
+  if (!validated.success) {
+    return NextResponse.json({ error: validated.error.flatten() }, { status: 422 })
+  }
+
+  let svc: ReturnType<typeof getCareerWishService>
+  try {
+    svc = getCareerWishService()
+  } catch {
+    return NextResponse.json({ error: 'CareerWish service not initialized' }, { status: 503 })
+  }
+
+  try {
+    const wish = await svc.registerWish(guard.session.userId, validated.data)
+    return NextResponse.json({ success: true, data: wish }, { status: 201 })
+  } catch {
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const guard = await requireAuthenticated()
+  if (!guard.ok) return guard.response
+
+  const targetUserId = request.nextUrl.searchParams.get('userId') ?? guard.session.userId
+  const isSelf = targetUserId === guard.session.userId
+  if (!isSelf && !isHrManagerOrAbove(guard.session.role)) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  let svc: ReturnType<typeof getCareerWishService>
+  try {
+    svc = getCareerWishService()
+  } catch {
+    return NextResponse.json({ error: 'CareerWish service not initialized' }, { status: 503 })
+  }
+
+  try {
+    const wish = await svc.getCurrentWish(targetUserId)
+    return NextResponse.json({ success: true, data: wish })
+  } catch {
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/lib/career/career-wish-repository.ts
+++ b/src/lib/career/career-wish-repository.ts
@@ -1,0 +1,132 @@
+import { PrismaClient } from '@prisma/client'
+import { toCareerWishId, type CareerWish, type CareerWishId, type CareerWishInput } from './career-wish-types'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Prisma row shape
+// ─────────────────────────────────────────────────────────────────────────────
+
+type CareerWishRow = {
+  id: string
+  userId: string
+  desiredRoleId: string
+  desiredAt: Date
+  comment: string | null
+  supersededAt: Date | null
+  createdAt: Date
+  desiredRole: { name: string }
+}
+
+function mapRow(row: CareerWishRow): CareerWish {
+  return {
+    id: toCareerWishId(row.id),
+    userId: row.userId,
+    desiredRoleId: row.desiredRoleId,
+    desiredRoleName: row.desiredRole.name,
+    desiredAt: row.desiredAt,
+    comment: row.comment,
+    supersededAt: row.supersededAt,
+    createdAt: row.createdAt,
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Port
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface CareerWishRepository {
+  /** supersededAt が null の現在有効な希望を取得 */
+  findCurrentWish(userId: string): Promise<CareerWish | null>
+  /** 新しい希望を作成 */
+  createWish(userId: string, input: CareerWishInput): Promise<CareerWish>
+  /** 指定 wish の supersededAt をセット（履歴化） */
+  supersede(id: CareerWishId, supersededAt: Date): Promise<void>
+  /** ユーザーの全履歴（現在＋過去）を createdAt 降順で返す */
+  listAllByUser(userId: string): Promise<CareerWish[]>
+  /** 全社員の現在有効な希望一覧 */
+  listAllCurrent(): Promise<CareerWish[]>
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Prisma delegate shim
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface CareerWishDelegates {
+  careerWish: {
+    findFirst(args: unknown): Promise<CareerWishRow | null>
+    create(args: unknown): Promise<CareerWishRow>
+    update(args: unknown): Promise<CareerWishRow>
+    findMany(args: unknown): Promise<CareerWishRow[]>
+  }
+}
+
+function asDelegates(db: PrismaClient): CareerWishDelegates {
+  return db as unknown as CareerWishDelegates
+}
+
+const ROLE_INCLUDE = { desiredRole: { select: { name: true } } }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Prisma implementation
+// ─────────────────────────────────────────────────────────────────────────────
+
+class PrismaCareerWishRepository implements CareerWishRepository {
+  private readonly delegates: CareerWishDelegates
+
+  constructor(db: PrismaClient) {
+    this.delegates = asDelegates(db)
+  }
+
+  async findCurrentWish(userId: string): Promise<CareerWish | null> {
+    const row = await this.delegates.careerWish.findFirst({
+      where: { userId, supersededAt: null },
+      include: ROLE_INCLUDE,
+    })
+    return row ? mapRow(row) : null
+  }
+
+  async createWish(userId: string, input: CareerWishInput): Promise<CareerWish> {
+    const row = await this.delegates.careerWish.create({
+      data: {
+        userId,
+        desiredRoleId: input.desiredRoleId,
+        desiredAt: input.desiredAt,
+        comment: input.comment ?? null,
+      },
+      include: ROLE_INCLUDE,
+    })
+    return mapRow(row)
+  }
+
+  async supersede(id: CareerWishId, supersededAt: Date): Promise<void> {
+    await this.delegates.careerWish.update({
+      where: { id },
+      data: { supersededAt },
+    })
+  }
+
+  async listAllByUser(userId: string): Promise<CareerWish[]> {
+    const rows = await this.delegates.careerWish.findMany({
+      where: { userId },
+      include: ROLE_INCLUDE,
+      orderBy: { createdAt: 'desc' },
+    })
+    return rows.map(mapRow)
+  }
+
+  async listAllCurrent(): Promise<CareerWish[]> {
+    const rows = await this.delegates.careerWish.findMany({
+      where: { supersededAt: null },
+      include: ROLE_INCLUDE,
+      orderBy: { createdAt: 'desc' },
+    })
+    return rows.map(mapRow)
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Factory
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function createPrismaCareerWishRepository(db?: PrismaClient): CareerWishRepository {
+  return new PrismaCareerWishRepository(db ?? new PrismaClient())
+}

--- a/src/lib/career/career-wish-service-di.ts
+++ b/src/lib/career/career-wish-service-di.ts
@@ -1,0 +1,24 @@
+import type { CareerWishService } from './career-wish-service'
+
+let _careerWishService: CareerWishService | null = null
+
+export function setCareerWishServiceForTesting(svc: CareerWishService): void {
+  _careerWishService = svc
+}
+
+export function clearCareerWishServiceForTesting(): void {
+  _careerWishService = null
+}
+
+export function getCareerWishService(): CareerWishService {
+  if (_careerWishService) return _careerWishService
+  throw new Error(
+    'CareerWishService is not initialized. ' +
+      'テストでは setCareerWishServiceForTesting() を呼んでください。' +
+      'プロダクションではサーバー起動前に initCareerWishService() を呼んでください。',
+  )
+}
+
+export function initCareerWishService(svc: CareerWishService): void {
+  _careerWishService = svc
+}

--- a/src/lib/career/career-wish-service.ts
+++ b/src/lib/career/career-wish-service.ts
@@ -1,0 +1,62 @@
+import type { CareerWishRepository } from './career-wish-repository'
+import type { CareerWish, CareerWishInput } from './career-wish-types'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Service interface
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface CareerWishService {
+  /** 現在有効な希望を登録（既存の有効な希望は supersededAt をセット） */
+  registerWish(userId: string, input: CareerWishInput): Promise<CareerWish>
+  /** 現在有効な希望を取得 */
+  getCurrentWish(userId: string): Promise<CareerWish | null>
+  /** 全履歴を取得 */
+  getWishHistory(userId: string): Promise<CareerWish[]>
+  /** 全社員の現在の希望一覧 */
+  listAllCurrentWishes(): Promise<CareerWish[]>
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Implementation
+// ─────────────────────────────────────────────────────────────────────────────
+
+class CareerWishServiceImpl implements CareerWishService {
+  private readonly repo: CareerWishRepository
+  private readonly clock: () => Date
+
+  constructor(repo: CareerWishRepository, clock: () => Date) {
+    this.repo = repo
+    this.clock = clock
+  }
+
+  async registerWish(userId: string, input: CareerWishInput): Promise<CareerWish> {
+    const current = await this.repo.findCurrentWish(userId)
+    if (current) {
+      await this.repo.supersede(current.id, this.clock())
+    }
+    return this.repo.createWish(userId, input)
+  }
+
+  async getCurrentWish(userId: string): Promise<CareerWish | null> {
+    return this.repo.findCurrentWish(userId)
+  }
+
+  async getWishHistory(userId: string): Promise<CareerWish[]> {
+    return this.repo.listAllByUser(userId)
+  }
+
+  async listAllCurrentWishes(): Promise<CareerWish[]> {
+    return this.repo.listAllCurrent()
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Factory
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function createCareerWishService(
+  repo: CareerWishRepository,
+  clock: () => Date = () => new Date(),
+): CareerWishService {
+  return new CareerWishServiceImpl(repo, clock)
+}

--- a/src/lib/career/career-wish-types.ts
+++ b/src/lib/career/career-wish-types.ts
@@ -1,0 +1,56 @@
+import { z } from 'zod'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Branded ID
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type CareerWishId = string & { readonly __brand: 'CareerWishId' }
+
+export function toCareerWishId(value: string): CareerWishId {
+  return value as CareerWishId
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Input schema
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const careerWishInputSchema = z.object({
+  desiredRoleId: z.string().min(1),
+  desiredAt: z.coerce.date(),
+  comment: z.string().optional(),
+})
+
+export type CareerWishInput = z.infer<typeof careerWishInputSchema>
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Output type
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface CareerWish {
+  readonly id: CareerWishId
+  readonly userId: string
+  readonly desiredRoleId: string
+  readonly desiredRoleName: string
+  readonly desiredAt: Date
+  readonly comment: string | null
+  readonly supersededAt: Date | null
+  readonly createdAt: Date
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Domain exceptions
+// ─────────────────────────────────────────────────────────────────────────────
+
+export class CareerWishNotFoundError extends Error {
+  constructor(userId: string) {
+    super(`Career wish not found for userId=${userId}`)
+    this.name = 'CareerWishNotFoundError'
+  }
+}
+
+export class CareerWishAccessDeniedError extends Error {
+  constructor() {
+    super('Career wish access denied')
+    this.name = 'CareerWishAccessDeniedError'
+  }
+}

--- a/src/tests/career/career-wish-service.test.ts
+++ b/src/tests/career/career-wish-service.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Issue #39 / Task 12.1: CareerWishService の単体テスト (Req 5.2, 5.6, 5.7)
+ *
+ * - registerWish: 新規登録 / 既存希望の supersededAt セット
+ * - getCurrentWish: 現在有効な希望取得
+ * - getWishHistory: 全履歴取得
+ * - listAllCurrentWishes: 全社員の現在の希望一覧
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { createCareerWishService } from '@/lib/career/career-wish-service'
+import type { CareerWishRepository } from '@/lib/career/career-wish-repository'
+import {
+  toCareerWishId,
+  type CareerWish,
+  type CareerWishInput,
+} from '@/lib/career/career-wish-types'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fixtures
+// ─────────────────────────────────────────────────────────────────────────────
+
+const EMPLOYEE_ID = 'user-emp-1'
+const ROLE_ID = 'role-senior-1'
+
+function makeCareerWish(overrides: Partial<CareerWish> = {}): CareerWish {
+  return {
+    id: toCareerWishId('wish-1'),
+    userId: EMPLOYEE_ID,
+    desiredRoleId: ROLE_ID,
+    desiredRoleName: 'Senior Engineer',
+    desiredAt: new Date('2027-04-01T00:00:00.000Z'),
+    comment: null,
+    supersededAt: null,
+    createdAt: new Date('2026-04-19T09:00:00.000Z'),
+    ...overrides,
+  }
+}
+
+function makeInput(overrides: Partial<CareerWishInput> = {}): CareerWishInput {
+  return {
+    desiredRoleId: ROLE_ID,
+    desiredAt: new Date('2027-04-01T00:00:00.000Z'),
+    comment: undefined,
+    ...overrides,
+  }
+}
+
+function makeRepoMock(): CareerWishRepository {
+  return {
+    findCurrentWish: vi.fn().mockResolvedValue(null),
+    createWish: vi.fn().mockResolvedValue(makeCareerWish()),
+    supersede: vi.fn().mockResolvedValue(undefined),
+    listAllByUser: vi.fn().mockResolvedValue([]),
+    listAllCurrent: vi.fn().mockResolvedValue([]),
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('CareerWishService', () => {
+  let repo: CareerWishRepository
+  const FIXED_DATE = new Date('2026-04-19T12:00:00.000Z')
+
+  beforeEach(() => {
+    repo = makeRepoMock()
+  })
+
+  describe('registerWish', () => {
+    it('既存の有効な希望がない場合に新規希望を作成する', async () => {
+      const svc = createCareerWishService(repo, () => FIXED_DATE)
+      const input = makeInput()
+
+      await svc.registerWish(EMPLOYEE_ID, input)
+
+      expect(repo.findCurrentWish).toHaveBeenCalledWith(EMPLOYEE_ID)
+      expect(repo.supersede).not.toHaveBeenCalled()
+      expect(repo.createWish).toHaveBeenCalledWith(EMPLOYEE_ID, input)
+    })
+
+    it('既存の有効な希望がある場合に supersededAt をセットして新規作成する', async () => {
+      const existing = makeCareerWish({ supersededAt: null })
+      vi.mocked(repo.findCurrentWish).mockResolvedValue(existing)
+      const svc = createCareerWishService(repo, () => FIXED_DATE)
+      const input = makeInput({ comment: 'updated goal' })
+
+      await svc.registerWish(EMPLOYEE_ID, input)
+
+      expect(repo.supersede).toHaveBeenCalledWith(existing.id, FIXED_DATE)
+      expect(repo.createWish).toHaveBeenCalledWith(EMPLOYEE_ID, input)
+    })
+
+    it('新しく作成した希望を返す', async () => {
+      const expected = makeCareerWish({ comment: 'new' })
+      vi.mocked(repo.createWish).mockResolvedValue(expected)
+      const svc = createCareerWishService(repo, () => FIXED_DATE)
+
+      const result = await svc.registerWish(EMPLOYEE_ID, makeInput())
+
+      expect(result).toEqual(expected)
+    })
+  })
+
+  describe('getCurrentWish', () => {
+    it('supersededAt が null の希望を返す', async () => {
+      const wish = makeCareerWish({ supersededAt: null })
+      vi.mocked(repo.findCurrentWish).mockResolvedValue(wish)
+      const svc = createCareerWishService(repo)
+
+      const result = await svc.getCurrentWish(EMPLOYEE_ID)
+
+      expect(result).toEqual(wish)
+    })
+
+    it('有効な希望がない場合 null を返す', async () => {
+      vi.mocked(repo.findCurrentWish).mockResolvedValue(null)
+      const svc = createCareerWishService(repo)
+
+      const result = await svc.getCurrentWish(EMPLOYEE_ID)
+
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('getWishHistory', () => {
+    it('ユーザーの全履歴（現在＋過去）を返す', async () => {
+      const history = [
+        makeCareerWish({ id: toCareerWishId('wish-2'), supersededAt: new Date('2026-04-19T00:00:00.000Z') }),
+        makeCareerWish({ id: toCareerWishId('wish-1'), supersededAt: null }),
+      ]
+      vi.mocked(repo.listAllByUser).mockResolvedValue(history)
+      const svc = createCareerWishService(repo)
+
+      const result = await svc.getWishHistory(EMPLOYEE_ID)
+
+      expect(result).toEqual(history)
+      expect(repo.listAllByUser).toHaveBeenCalledWith(EMPLOYEE_ID)
+    })
+  })
+
+  describe('listAllCurrentWishes', () => {
+    it('全社員の現在有効な希望一覧を返す', async () => {
+      const wishes = [makeCareerWish(), makeCareerWish({ userId: 'user-emp-2' })]
+      vi.mocked(repo.listAllCurrent).mockResolvedValue(wishes)
+      const svc = createCareerWishService(repo)
+
+      const result = await svc.listAllCurrentWishes()
+
+      expect(result).toEqual(wishes)
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- EMPLOYEE が希望役職・希望時期・コメントを登録できる機能を実装（Req 5.2）
- 更新時に旧希望を `supersededAt` で履歴保持（Req 5.6）
- HR_MANAGER以上のみ全社員の希望・履歴を参照可能（Req 5.7）

## 追加ファイル
- `prisma/schema.prisma` — `CareerWish` モデル追加（User・RoleMaster にリレーション）
- `src/lib/career/career-wish-types.ts` — 型定義・Zodスキーマ・ドメインエラー
- `src/lib/career/career-wish-repository.ts` — Repository + Prisma実装
- `src/lib/career/career-wish-service.ts` — supersede ロジックを含むサービス
- `src/lib/career/career-wish-service-di.ts` — DIシングルトン
- `src/app/api/career/wishes/route.ts` — POST・GET エンドポイント
- `src/app/api/career/wishes/all/route.ts` — 全社員一覧（HR_MANAGER以上）
- `src/app/api/career/wishes/[userId]/history/route.ts` — 履歴取得
- `src/tests/career/career-wish-service.test.ts` — 7件テスト全通過

## Test plan
- [ ] `POST /api/career/wishes` — 希望登録・旧希望がsupersededAtにセットされる
- [ ] `GET /api/career/wishes?userId=...` — 本人 or HR_MANAGERのみ
- [ ] `GET /api/career/wishes/all` — HR_MANAGERのみ（一般ユーザー → 403）
- [ ] `GET /api/career/wishes/{userId}/history` — 全履歴取得

Closes #39