### PR TITLE
[#40] キャリアマップとギャップ表示

### DIFF
--- a/src/app/api/career/map/gap/route.ts
+++ b/src/app/api/career/map/gap/route.ts
@@ -1,0 +1,46 @@
+/**
+ * Issue #40 / Req 5.3: スキルギャップ API
+ *
+ * GET /api/career/map/gap?desiredRoleId=<id>
+ *   - ログインユーザー本人のギャップのみ返す
+ */
+import { getServerSession } from 'next-auth'
+import { type NextRequest, NextResponse } from 'next/server'
+import { getCareerMapService } from '@/lib/career/career-map-service-di'
+
+export {
+  setCareerMapServiceForTesting,
+  clearCareerMapServiceForTesting,
+} from '@/lib/career/career-map-service-di'
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const serverSession = await getServerSession()
+  if (!serverSession?.user?.email) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const sess = serverSession as Record<string, unknown>
+  const userId = typeof sess.userId === 'string' ? sess.userId : undefined
+  if (!userId) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const desiredRoleId = req.nextUrl.searchParams.get('desiredRoleId')
+  if (!desiredRoleId) {
+    return NextResponse.json({ error: 'desiredRoleId is required' }, { status: 400 })
+  }
+
+  let svc: ReturnType<typeof getCareerMapService>
+  try {
+    svc = getCareerMapService()
+  } catch {
+    return NextResponse.json({ error: 'CareerMapService not initialized' }, { status: 503 })
+  }
+
+  try {
+    const result = await svc.calculateCareerGap(userId, desiredRoleId)
+    return NextResponse.json({ success: true, data: result })
+  } catch {
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/api/career/map/roles/route.ts
+++ b/src/app/api/career/map/roles/route.ts
@@ -1,0 +1,35 @@
+/**
+ * Issue #40 / Req 5.1: 役職一覧 API
+ *
+ * GET /api/career/map/roles
+ *   - 認証済みユーザーであれば全ロール参照可
+ */
+import { getServerSession } from 'next-auth'
+import { NextResponse } from 'next/server'
+import { getCareerMapService } from '@/lib/career/career-map-service-di'
+
+export {
+  setCareerMapServiceForTesting,
+  clearCareerMapServiceForTesting,
+} from '@/lib/career/career-map-service-di'
+
+export async function GET(): Promise<NextResponse> {
+  const session = await getServerSession()
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  let svc: ReturnType<typeof getCareerMapService>
+  try {
+    svc = getCareerMapService()
+  } catch {
+    return NextResponse.json({ error: 'CareerMapService not initialized' }, { status: 503 })
+  }
+
+  try {
+    const roles = await svc.listRoles()
+    return NextResponse.json({ success: true, data: roles })
+  } catch {
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/api/career/map/subordinates/wishes/route.ts
+++ b/src/app/api/career/map/subordinates/wishes/route.ts
@@ -1,0 +1,46 @@
+/**
+ * Issue #40 / Req 5.4: 部下キャリア希望一覧 API
+ *
+ * GET /api/career/map/subordinates/wishes
+ *   - MANAGER / HR_MANAGER / ADMIN のみアクセス可
+ *   - ログインユーザー配下の部下のキャリア希望一覧を返す
+ */
+import { getServerSession } from 'next-auth'
+import { NextResponse } from 'next/server'
+import { getCareerMapService } from '@/lib/career/career-map-service-di'
+
+export {
+  setCareerMapServiceForTesting,
+  clearCareerMapServiceForTesting,
+} from '@/lib/career/career-map-service-di'
+
+const ALLOWED_ROLES = new Set(['MANAGER', 'HR_MANAGER', 'ADMIN'])
+
+export async function GET(): Promise<NextResponse> {
+  const serverSession = await getServerSession()
+  if (!serverSession?.user?.email) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const sess = serverSession as Record<string, unknown>
+  const userId = typeof sess.userId === 'string' ? sess.userId : undefined
+  const role = typeof sess.role === 'string' ? sess.role : undefined
+
+  if (!userId || !role || !ALLOWED_ROLES.has(role)) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  let svc: ReturnType<typeof getCareerMapService>
+  try {
+    svc = getCareerMapService()
+  } catch {
+    return NextResponse.json({ error: 'CareerMapService not initialized' }, { status: 503 })
+  }
+
+  try {
+    const wishes = await svc.listSubordinateWishes(userId)
+    return NextResponse.json({ success: true, data: wishes })
+  } catch {
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/lib/career/career-map-service-di.ts
+++ b/src/lib/career/career-map-service-di.ts
@@ -1,0 +1,27 @@
+/**
+ * Issue #40: CareerMapService のシングルトン DI モジュール。
+ */
+import type { CareerMapService } from './career-map-service'
+
+let _service: CareerMapService | null = null
+
+export function setCareerMapServiceForTesting(svc: CareerMapService): void {
+  _service = svc
+}
+
+export function clearCareerMapServiceForTesting(): void {
+  _service = null
+}
+
+export function initCareerMapService(svc: CareerMapService): void {
+  _service = svc
+}
+
+export function getCareerMapService(): CareerMapService {
+  if (_service) return _service
+  throw new Error(
+    'CareerMapService is not initialized. ' +
+      'テストでは setCareerMapServiceForTesting() を呼んでください。' +
+      'プロダクションではサーバー起動前に initCareerMapService() を呼んでください。',
+  )
+}

--- a/src/lib/career/career-map-service.ts
+++ b/src/lib/career/career-map-service.ts
@@ -1,0 +1,396 @@
+/**
+ * Issue #40 / Req 5.1, 5.3, 5.4: キャリアマップとギャップ表示サービス
+ *
+ * - listRoles:              組織内の全役職一覧とスキル要件 (Req 5.1)
+ * - calculateCareerGap:    現役職 → 希望役職のスキルギャップ計算 (Req 5.3)
+ * - listSubordinateWishes: MANAGER が部下のキャリア希望一覧を取得 (Req 5.4)
+ */
+import type { PrismaClient } from '@prisma/client'
+import {
+  calculateFulfillmentRate,
+  calculateGap,
+  type EmployeeSkill,
+} from '@/lib/shared/skill-gap-calculator'
+import type { CareerGapResult, RoleNode, SkillGapItem, SubordinateWish } from './career-map-types'
+import type { CareerWish } from './career-wish-types'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Repository port
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface RoleMasterRow {
+  readonly id: string
+  readonly name: string
+}
+
+export interface RoleSkillRequirementRow {
+  readonly roleId: string
+  readonly skillId: string
+  readonly requiredLevel: number
+  readonly skillName: string
+}
+
+export interface EmployeeSkillRow {
+  readonly skillId: string
+  readonly level: number
+  readonly acquiredAt: Date
+  readonly approvedAt: Date | null
+}
+
+export interface UserPositionRow {
+  readonly userId: string
+  readonly positionId: string | null
+  readonly roleId: string | null
+  readonly name: string | null
+}
+
+export interface SubordinateRow {
+  readonly userId: string
+  readonly positionId: string | null
+  readonly roleId: string | null
+  readonly name: string | null
+}
+
+export interface CareerMapRepository {
+  listRoles(): Promise<RoleMasterRow[]>
+  listRoleSkillRequirements(): Promise<RoleSkillRequirementRow[]>
+  getEmployeeSkills(userId: string): Promise<EmployeeSkillRow[]>
+  getUserPosition(userId: string): Promise<UserPositionRow | null>
+  getActiveCareerWish(userId: string): Promise<CareerWish | null>
+  listSubordinates(managerPositionId: string): Promise<SubordinateRow[]>
+  getManagerPositionId(managerId: string): Promise<string | null>
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Service port
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface CareerMapService {
+  listRoles(): Promise<RoleNode[]>
+  calculateCareerGap(userId: string, desiredRoleId: string): Promise<CareerGapResult>
+  listSubordinateWishes(managerId: string): Promise<SubordinateWish[]>
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Service implementation
+// ─────────────────────────────────────────────────────────────────────────────
+
+class CareerMapServiceImpl implements CareerMapService {
+  constructor(private readonly repo: CareerMapRepository) {}
+
+  async listRoles(): Promise<RoleNode[]> {
+    const [roles, requirements] = await Promise.all([
+      this.repo.listRoles(),
+      this.repo.listRoleSkillRequirements(),
+    ])
+
+    const reqByRole = groupByRole(requirements)
+
+    return roles.map((role) => ({
+      id: role.id,
+      name: role.name,
+      skillRequirements: (reqByRole.get(role.id) ?? []).map((r) => ({
+        skillId: r.skillId,
+        skillName: r.skillName,
+        requiredLevel: r.requiredLevel,
+      })),
+    }))
+  }
+
+  async calculateCareerGap(userId: string, desiredRoleId: string): Promise<CareerGapResult> {
+    const [userPosition, employeeSkillRows, requirements] = await Promise.all([
+      this.repo.getUserPosition(userId),
+      this.repo.getEmployeeSkills(userId),
+      this.repo.listRoleSkillRequirements(),
+    ])
+
+    const currentRoleId = userPosition?.roleId ?? null
+    const roleReqs = requirements.filter((r) => r.roleId === desiredRoleId)
+
+    const holderSkills: EmployeeSkill[] = employeeSkillRows.map((s) => ({
+      id: `${userId}-${s.skillId}`,
+      userId,
+      skillId: s.skillId,
+      level: s.level,
+      acquiredAt: s.acquiredAt,
+      approvedByManagerId: null,
+      approvedAt: s.approvedAt,
+    }))
+
+    const requiredSkills = roleReqs.map((r) => ({
+      skillId: r.skillId,
+      requiredLevel: r.requiredLevel,
+      skillName: r.skillName,
+    }))
+
+    const calcInput = { holderSkills, requiredSkills }
+    const gapResults = calculateGap(calcInput)
+    const fulfillmentRate = calculateFulfillmentRate(calcInput)
+
+    const gaps: SkillGapItem[] = gapResults.map((g) => ({
+      skillId: g.skillId,
+      skillName: g.skillName,
+      requiredLevel: g.requiredLevel,
+      actualLevel: g.currentLevel,
+      gap: g.gap,
+    }))
+
+    const totalGap = gaps.reduce((sum, g) => sum + g.gap, 0)
+
+    return { currentRoleId, desiredRoleId, gaps, totalGap, fulfillmentRate }
+  }
+
+  async listSubordinateWishes(managerId: string): Promise<SubordinateWish[]> {
+    const managerPositionId = await this.repo.getManagerPositionId(managerId)
+    if (!managerPositionId) return []
+
+    const [subordinates, requirements] = await Promise.all([
+      this.repo.listSubordinates(managerPositionId),
+      this.repo.listRoleSkillRequirements(),
+    ])
+
+    const wishes = await Promise.all(
+      subordinates.map((sub) => this.buildSubordinateWish(sub, requirements)),
+    )
+
+    return wishes.filter((w): w is SubordinateWish => w !== null)
+  }
+
+  private async buildSubordinateWish(
+    sub: SubordinateRow,
+    requirements: RoleSkillRequirementRow[],
+  ): Promise<SubordinateWish | null> {
+    const wish = await this.repo.getActiveCareerWish(sub.userId)
+    if (!wish) return null
+
+    const employeeSkillRows = await this.repo.getEmployeeSkills(sub.userId)
+    const holderSkills: EmployeeSkill[] = employeeSkillRows.map((s) => ({
+      id: `${sub.userId}-${s.skillId}`,
+      userId: sub.userId,
+      skillId: s.skillId,
+      level: s.level,
+      acquiredAt: s.acquiredAt,
+      approvedByManagerId: null,
+      approvedAt: s.approvedAt,
+    }))
+
+    const roleReqs = requirements.filter((r) => r.roleId === wish.desiredRoleId)
+    const requiredSkills = roleReqs.map((r) => ({
+      skillId: r.skillId,
+      requiredLevel: r.requiredLevel,
+    }))
+
+    const fulfillmentRate = calculateFulfillmentRate({ holderSkills, requiredSkills })
+
+    return {
+      userId: sub.userId,
+      userName: sub.name ?? undefined,
+      currentRoleId: sub.roleId,
+      desiredRoleId: wish.desiredRoleId,
+      desiredRoleName: wish.desiredRoleName,
+      desiredAt: wish.desiredAt,
+      fulfillmentRate,
+    }
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Pure helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+function groupByRole(
+  requirements: readonly RoleSkillRequirementRow[],
+): Map<string, RoleSkillRequirementRow[]> {
+  const map = new Map<string, RoleSkillRequirementRow[]>()
+  for (const req of requirements) {
+    const list = map.get(req.roleId) ?? []
+    list.push(req)
+    map.set(req.roleId, list)
+  }
+  return map
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Prisma narrow types
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface PrismaRoleMaster {
+  id: string
+  name: string
+}
+
+interface PrismaRoleSkillRequirement {
+  roleId: string
+  skillId: string
+  requiredLevel: number
+  skill?: { name: string } | null
+}
+
+interface PrismaEmployeeSkill {
+  skillId: string
+  level: number
+  acquiredAt: Date
+  approvedAt: Date | null
+}
+
+interface PrismaPosition {
+  id: string
+  roleId: string
+  supervisorPositionId: string | null
+}
+
+interface PrismaUser {
+  id: string
+  positionId: string | null
+  name?: string | null
+  status?: string
+}
+
+interface PrismaCareerWish {
+  id: string
+  userId: string
+  desiredRoleId: string
+  desiredAt: Date
+  comment: string | null
+  supersededAt: Date | null
+  createdAt: Date
+  role?: { name: string } | null
+}
+
+interface CareerMapDelegates {
+  roleMaster: {
+    findMany(args?: unknown): Promise<PrismaRoleMaster[]>
+  }
+  roleSkillRequirement: {
+    findMany(args?: unknown): Promise<PrismaRoleSkillRequirement[]>
+  }
+  employeeSkill: {
+    findMany(args?: unknown): Promise<PrismaEmployeeSkill[]>
+  }
+  position: {
+    findUnique(args: unknown): Promise<PrismaPosition | null>
+    findMany(args?: unknown): Promise<PrismaPosition[]>
+  }
+  user: {
+    findUnique(args: unknown): Promise<PrismaUser | null>
+    findMany(args?: unknown): Promise<PrismaUser[]>
+  }
+  careerWish: {
+    findFirst(args?: unknown): Promise<PrismaCareerWish | null>
+  }
+}
+
+function asDelegates(db: PrismaClient): CareerMapDelegates {
+  return db as unknown as CareerMapDelegates
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Prisma repository implementation
+// ─────────────────────────────────────────────────────────────────────────────
+
+class PrismaCareerMapRepository implements CareerMapRepository {
+  private readonly d: CareerMapDelegates
+
+  constructor(db: PrismaClient) {
+    this.d = asDelegates(db)
+  }
+
+  async listRoles(): Promise<RoleMasterRow[]> {
+    const rows = await this.d.roleMaster.findMany({})
+    return rows.map((r) => ({ id: r.id, name: r.name }))
+  }
+
+  async listRoleSkillRequirements(): Promise<RoleSkillRequirementRow[]> {
+    const rows = await this.d.roleSkillRequirement.findMany({
+      include: { skill: { select: { name: true } } },
+    })
+    return rows.map((r) => ({
+      roleId: r.roleId,
+      skillId: r.skillId,
+      requiredLevel: r.requiredLevel,
+      skillName: r.skill?.name ?? '',
+    }))
+  }
+
+  async getEmployeeSkills(userId: string): Promise<EmployeeSkillRow[]> {
+    const rows = await this.d.employeeSkill.findMany({ where: { userId } })
+    return rows.map((r) => ({
+      skillId: r.skillId,
+      level: r.level,
+      acquiredAt: r.acquiredAt,
+      approvedAt: r.approvedAt,
+    }))
+  }
+
+  async getUserPosition(userId: string): Promise<UserPositionRow | null> {
+    const user = await this.d.user.findUnique({ where: { id: userId } })
+    if (!user) return null
+    if (!user.positionId) return { userId, positionId: null, roleId: null, name: null }
+
+    const position = await this.d.position.findUnique({ where: { id: user.positionId } })
+    return {
+      userId,
+      positionId: user.positionId,
+      roleId: position?.roleId ?? null,
+      name: null,
+    }
+  }
+
+  async getActiveCareerWish(userId: string): Promise<CareerWish | null> {
+    const row = await this.d.careerWish.findFirst({
+      where: { userId, supersededAt: null },
+      include: { role: { select: { name: true } } },
+      orderBy: { desiredAt: 'desc' },
+    })
+    if (!row) return null
+    return {
+      id: row.id,
+      userId: row.userId,
+      desiredRoleId: row.desiredRoleId,
+      desiredRoleName: row.role?.name ?? '',
+      desiredAt: row.desiredAt,
+      comment: row.comment,
+      supersededAt: row.supersededAt,
+      createdAt: row.createdAt,
+    }
+  }
+
+  async getManagerPositionId(managerId: string): Promise<string | null> {
+    const user = await this.d.user.findUnique({ where: { id: managerId } })
+    return user?.positionId ?? null
+  }
+
+  async listSubordinates(managerPositionId: string): Promise<SubordinateRow[]> {
+    const subPositions = await this.d.position.findMany({
+      where: { supervisorPositionId: managerPositionId },
+    })
+    if (subPositions.length === 0) return []
+
+    const positionIds = subPositions.map((p) => p.id)
+    const users = await this.d.user.findMany({
+      where: { positionId: { in: positionIds }, status: 'ACTIVE' } as unknown,
+    })
+
+    return users.map((u) => {
+      const pos = subPositions.find((p) => p.id === u.positionId)
+      return {
+        userId: u.id,
+        positionId: u.positionId ?? null,
+        roleId: pos?.roleId ?? null,
+        name: u.name ?? null,
+      }
+    })
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Factories
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function createPrismaCareerMapRepository(db: PrismaClient): CareerMapRepository {
+  return new PrismaCareerMapRepository(db)
+}
+
+export function createCareerMapService(repo: CareerMapRepository): CareerMapService {
+  return new CareerMapServiceImpl(repo)
+}

--- a/src/lib/career/career-map-types.ts
+++ b/src/lib/career/career-map-types.ts
@@ -1,0 +1,41 @@
+/**
+ * Issue #40 / Req 5.1, 5.3, 5.4: キャリアマップとギャップ表示の型定義
+ */
+
+export interface SkillRequirement {
+  skillId: string
+  skillName: string
+  requiredLevel: number
+}
+
+export interface RoleNode {
+  id: string
+  name: string
+  skillRequirements: SkillRequirement[]
+}
+
+export interface SkillGapItem {
+  skillId: string
+  skillName: string
+  requiredLevel: number
+  actualLevel: number
+  gap: number
+}
+
+export interface CareerGapResult {
+  currentRoleId: string | null
+  desiredRoleId: string
+  gaps: SkillGapItem[]
+  totalGap: number
+  fulfillmentRate: number
+}
+
+export interface SubordinateWish {
+  userId: string
+  userName?: string
+  currentRoleId: string | null
+  desiredRoleId: string
+  desiredRoleName: string
+  desiredAt: Date
+  fulfillmentRate: number
+}

--- a/src/lib/career/career-wish-types.ts
+++ b/src/lib/career/career-wish-types.ts
@@ -1,0 +1,17 @@
+/**
+ * TODO: merge後に #39のcareer-wish-types.tsからimportする
+ *
+ * Issue #39 が実装する CareerWish モデルの仮型定義。
+ * merge後はこのファイルを削除し、#39 のファイルからインポートする。
+ */
+
+export interface CareerWish {
+  id: string
+  userId: string
+  desiredRoleId: string
+  desiredRoleName: string
+  desiredAt: Date
+  comment: string | null
+  supersededAt: Date | null
+  createdAt: Date
+}

--- a/src/tests/career/career-map-service.test.ts
+++ b/src/tests/career/career-map-service.test.ts
@@ -1,0 +1,350 @@
+/**
+ * Issue #40 / Req 5.1, 5.3, 5.4: CareerMapService の単体テスト
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { createCareerMapService } from '@/lib/career/career-map-service'
+import type {
+  CareerMapRepository,
+  EmployeeSkillRow,
+  RoleMasterRow,
+  RoleSkillRequirementRow,
+  SubordinateRow,
+} from '@/lib/career/career-map-service'
+import type { CareerWish } from '@/lib/career/career-wish-types'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fixtures
+// ─────────────────────────────────────────────────────────────────────────────
+
+function makeRole(overrides: Partial<RoleMasterRow> = {}): RoleMasterRow {
+  return { id: 'role-1', name: 'Engineer', ...overrides }
+}
+
+function makeRequirement(
+  overrides: Partial<RoleSkillRequirementRow> = {},
+): RoleSkillRequirementRow {
+  return {
+    roleId: 'role-1',
+    skillId: 'skill-ts',
+    requiredLevel: 5,
+    skillName: 'TypeScript',
+    ...overrides,
+  }
+}
+
+function makeEmployeeSkill(overrides: Partial<EmployeeSkillRow> = {}): EmployeeSkillRow {
+  return {
+    skillId: 'skill-ts',
+    level: 3,
+    acquiredAt: new Date('2024-01-01'),
+    approvedAt: new Date('2024-01-15'),
+    ...overrides,
+  }
+}
+
+function makeSubordinate(overrides: Partial<SubordinateRow> = {}): SubordinateRow {
+  return {
+    userId: 'user-sub',
+    positionId: 'pos-sub',
+    roleId: 'role-1',
+    name: 'Taro Yamada',
+    ...overrides,
+  }
+}
+
+function makeCareerWish(overrides: Partial<CareerWish> = {}): CareerWish {
+  return {
+    id: 'wish-1',
+    userId: 'user-sub',
+    desiredRoleId: 'role-2',
+    desiredRoleName: 'Senior Engineer',
+    desiredAt: new Date('2026-01-01'),
+    comment: null,
+    supersededAt: null,
+    createdAt: new Date('2026-01-01'),
+    ...overrides,
+  }
+}
+
+function makeRepo(overrides: Partial<CareerMapRepository> = {}): CareerMapRepository {
+  return {
+    listRoles: vi.fn().mockResolvedValue([]),
+    listRoleSkillRequirements: vi.fn().mockResolvedValue([]),
+    getEmployeeSkills: vi.fn().mockResolvedValue([]),
+    getUserPosition: vi.fn().mockResolvedValue(null),
+    getActiveCareerWish: vi.fn().mockResolvedValue(null),
+    listSubordinates: vi.fn().mockResolvedValue([]),
+    getManagerPositionId: vi.fn().mockResolvedValue(null),
+    ...overrides,
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// listRoles
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('CareerMapService.listRoles', () => {
+  it('returns empty array when no roles exist', async () => {
+    const svc = createCareerMapService(makeRepo())
+    const result = await svc.listRoles()
+    expect(result).toEqual([])
+  })
+
+  it('returns roles with matching skill requirements', async () => {
+    const repo = makeRepo({
+      listRoles: vi.fn().mockResolvedValue([makeRole()]),
+      listRoleSkillRequirements: vi.fn().mockResolvedValue([makeRequirement()]),
+    })
+    const svc = createCareerMapService(repo)
+
+    const result = await svc.listRoles()
+
+    expect(result).toHaveLength(1)
+    const role = result[0]!
+    expect(role.id).toBe('role-1')
+    expect(role.name).toBe('Engineer')
+    expect(role.skillRequirements).toHaveLength(1)
+    expect(role.skillRequirements[0]).toEqual({
+      skillId: 'skill-ts',
+      skillName: 'TypeScript',
+      requiredLevel: 5,
+    })
+  })
+
+  it('returns role with empty requirements when no requirements match', async () => {
+    const repo = makeRepo({
+      listRoles: vi.fn().mockResolvedValue([makeRole({ id: 'role-99' })]),
+      listRoleSkillRequirements: vi.fn().mockResolvedValue([makeRequirement({ roleId: 'role-1' })]),
+    })
+    const svc = createCareerMapService(repo)
+
+    const result = await svc.listRoles()
+
+    expect(result[0]!.skillRequirements).toHaveLength(0)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// calculateCareerGap
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('CareerMapService.calculateCareerGap', () => {
+  it('calculates gap correctly when actual level 3 and required level 5 → gap = 2', async () => {
+    const repo = makeRepo({
+      getUserPosition: vi
+        .fn()
+        .mockResolvedValue({ userId: 'user-1', positionId: 'pos-1', roleId: 'role-1', name: null }),
+      getEmployeeSkills: vi.fn().mockResolvedValue([makeEmployeeSkill({ level: 3 })]),
+      listRoleSkillRequirements: vi
+        .fn()
+        .mockResolvedValue([makeRequirement({ roleId: 'role-2', requiredLevel: 5 })]),
+    })
+    const svc = createCareerMapService(repo)
+
+    const result = await svc.calculateCareerGap('user-1', 'role-2')
+
+    expect(result.desiredRoleId).toBe('role-2')
+    expect(result.currentRoleId).toBe('role-1')
+    expect(result.gaps).toHaveLength(1)
+    const gap0 = result.gaps[0]!
+    expect(gap0.gap).toBe(2)
+    expect(gap0.actualLevel).toBe(3)
+    expect(gap0.requiredLevel).toBe(5)
+    expect(result.totalGap).toBe(2)
+  })
+
+  it('returns zero gap and fulfillmentRate 1.0 when employee meets all requirements', async () => {
+    const repo = makeRepo({
+      getUserPosition: vi
+        .fn()
+        .mockResolvedValue({ userId: 'user-1', positionId: 'pos-1', roleId: 'role-1', name: null }),
+      getEmployeeSkills: vi.fn().mockResolvedValue([makeEmployeeSkill({ level: 5 })]),
+      listRoleSkillRequirements: vi
+        .fn()
+        .mockResolvedValue([makeRequirement({ roleId: 'role-2', requiredLevel: 5 })]),
+    })
+    const svc = createCareerMapService(repo)
+
+    const result = await svc.calculateCareerGap('user-1', 'role-2')
+
+    expect(result.gaps).toHaveLength(0)
+    expect(result.totalGap).toBe(0)
+    expect(result.fulfillmentRate).toBe(1)
+  })
+
+  it('calculates fulfillmentRate correctly for partial fulfillment (3/5 = 0.6)', async () => {
+    const repo = makeRepo({
+      getUserPosition: vi.fn().mockResolvedValue(null),
+      getEmployeeSkills: vi.fn().mockResolvedValue([makeEmployeeSkill({ level: 3 })]),
+      listRoleSkillRequirements: vi
+        .fn()
+        .mockResolvedValue([makeRequirement({ roleId: 'role-2', requiredLevel: 5 })]),
+    })
+    const svc = createCareerMapService(repo)
+
+    const result = await svc.calculateCareerGap('user-1', 'role-2')
+
+    expect(result.fulfillmentRate).toBeCloseTo(0.6)
+    expect(result.currentRoleId).toBeNull()
+  })
+
+  it('returns fulfillmentRate 1.0 when desired role has no requirements', async () => {
+    const repo = makeRepo({
+      getUserPosition: vi.fn().mockResolvedValue(null),
+      getEmployeeSkills: vi.fn().mockResolvedValue([makeEmployeeSkill()]),
+      listRoleSkillRequirements: vi.fn().mockResolvedValue([]),
+    })
+    const svc = createCareerMapService(repo)
+
+    const result = await svc.calculateCareerGap('user-1', 'role-empty')
+
+    expect(result.fulfillmentRate).toBe(1)
+    expect(result.gaps).toHaveLength(0)
+    expect(result.totalGap).toBe(0)
+  })
+
+  it('calculates totalGap as sum of all individual gaps', async () => {
+    const repo = makeRepo({
+      getUserPosition: vi.fn().mockResolvedValue(null),
+      getEmployeeSkills: vi
+        .fn()
+        .mockResolvedValue([
+          makeEmployeeSkill({ skillId: 'skill-a', level: 1 }),
+          makeEmployeeSkill({ skillId: 'skill-b', level: 2 }),
+        ]),
+      listRoleSkillRequirements: vi.fn().mockResolvedValue([
+        makeRequirement({
+          roleId: 'role-2',
+          skillId: 'skill-a',
+          requiredLevel: 4,
+          skillName: 'Skill A',
+        }),
+        makeRequirement({
+          roleId: 'role-2',
+          skillId: 'skill-b',
+          requiredLevel: 5,
+          skillName: 'Skill B',
+        }),
+      ]),
+    })
+    const svc = createCareerMapService(repo)
+
+    const result = await svc.calculateCareerGap('user-1', 'role-2')
+
+    expect(result.totalGap).toBe(6)
+    expect(result.gaps).toHaveLength(2)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// listSubordinateWishes
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('CareerMapService.listSubordinateWishes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns empty array when manager has no position', async () => {
+    const repo = makeRepo({
+      getManagerPositionId: vi.fn().mockResolvedValue(null),
+    })
+    const svc = createCareerMapService(repo)
+
+    const result = await svc.listSubordinateWishes('manager-1')
+
+    expect(result).toEqual([])
+  })
+
+  it('returns empty array when manager has no subordinates', async () => {
+    const repo = makeRepo({
+      getManagerPositionId: vi.fn().mockResolvedValue('pos-mgr'),
+      listSubordinates: vi.fn().mockResolvedValue([]),
+      listRoleSkillRequirements: vi.fn().mockResolvedValue([]),
+    })
+    const svc = createCareerMapService(repo)
+
+    const result = await svc.listSubordinateWishes('manager-1')
+
+    expect(result).toEqual([])
+  })
+
+  it('excludes subordinates without an active career wish', async () => {
+    const repo = makeRepo({
+      getManagerPositionId: vi.fn().mockResolvedValue('pos-mgr'),
+      listSubordinates: vi.fn().mockResolvedValue([makeSubordinate()]),
+      listRoleSkillRequirements: vi.fn().mockResolvedValue([]),
+      getActiveCareerWish: vi.fn().mockResolvedValue(null),
+      getEmployeeSkills: vi.fn().mockResolvedValue([]),
+    })
+    const svc = createCareerMapService(repo)
+
+    const result = await svc.listSubordinateWishes('manager-1')
+
+    expect(result).toHaveLength(0)
+  })
+
+  it('returns subordinate wish with fulfillmentRate 1.0 when skills are fully met', async () => {
+    const wish = makeCareerWish()
+    const repo = makeRepo({
+      getManagerPositionId: vi.fn().mockResolvedValue('pos-mgr'),
+      listSubordinates: vi.fn().mockResolvedValue([makeSubordinate()]),
+      listRoleSkillRequirements: vi
+        .fn()
+        .mockResolvedValue([makeRequirement({ roleId: 'role-2', requiredLevel: 4 })]),
+      getActiveCareerWish: vi.fn().mockResolvedValue(wish),
+      getEmployeeSkills: vi.fn().mockResolvedValue([makeEmployeeSkill({ level: 4 })]),
+    })
+    const svc = createCareerMapService(repo)
+
+    const result = await svc.listSubordinateWishes('manager-1')
+
+    expect(result).toHaveLength(1)
+    const wish0 = result[0]!
+    expect(wish0.userId).toBe('user-sub')
+    expect(wish0.userName).toBe('Taro Yamada')
+    expect(wish0.desiredRoleId).toBe('role-2')
+    expect(wish0.desiredRoleName).toBe('Senior Engineer')
+    expect(wish0.fulfillmentRate).toBe(1)
+  })
+
+  it('calculates fulfillmentRate for subordinate with partial skills (3/5 = 0.6)', async () => {
+    const wish = makeCareerWish()
+    const repo = makeRepo({
+      getManagerPositionId: vi.fn().mockResolvedValue('pos-mgr'),
+      listSubordinates: vi.fn().mockResolvedValue([makeSubordinate()]),
+      listRoleSkillRequirements: vi
+        .fn()
+        .mockResolvedValue([makeRequirement({ roleId: 'role-2', requiredLevel: 5 })]),
+      getActiveCareerWish: vi.fn().mockResolvedValue(wish),
+      getEmployeeSkills: vi.fn().mockResolvedValue([makeEmployeeSkill({ level: 3 })]),
+    })
+    const svc = createCareerMapService(repo)
+
+    const result = await svc.listSubordinateWishes('manager-1')
+
+    expect(result[0]!.fulfillmentRate).toBeCloseTo(0.6)
+  })
+
+  it('returns multiple subordinates who have active wishes', async () => {
+    const sub1 = makeSubordinate({ userId: 'user-a', name: 'Alice' })
+    const sub2 = makeSubordinate({ userId: 'user-b', name: 'Bob' })
+    const wish1 = makeCareerWish({ userId: 'user-a' })
+    const wish2 = makeCareerWish({ userId: 'user-b', desiredRoleName: 'Lead' })
+
+    const repo = makeRepo({
+      getManagerPositionId: vi.fn().mockResolvedValue('pos-mgr'),
+      listSubordinates: vi.fn().mockResolvedValue([sub1, sub2]),
+      listRoleSkillRequirements: vi.fn().mockResolvedValue([]),
+      getActiveCareerWish: vi.fn().mockResolvedValueOnce(wish1).mockResolvedValueOnce(wish2),
+      getEmployeeSkills: vi.fn().mockResolvedValue([]),
+    })
+    const svc = createCareerMapService(repo)
+
+    const result = await svc.listSubordinateWishes('manager-1')
+
+    expect(result).toHaveLength(2)
+    expect(result.map((r) => r.userId)).toContain('user-a')
+    expect(result.map((r) => r.userId)).toContain('user-b')
+  })
+})


### PR DESCRIPTION
## Summary
- 組織内の役職一覧とスキル要件を可視化（Req 5.1）
- 現役職と希望役職間のスキルギャップを計算・表示（Req 5.3）
- MANAGER向け部下のキャリア希望一覧（Req 5.4）

## 追加ファイル
- `src/lib/career/career-map-types.ts` — RoleNode・SkillGapItem・CareerGapResult等の型定義
- `src/lib/career/career-wish-types.ts` — CareerWish仮型定義（#39 merge後に統合予定）
- `src/lib/career/career-map-service.ts` — SkillGapCalculator活用のサービス
- `src/lib/career/career-map-service-di.ts` — DIシングルトン
- `src/app/api/career/map/roles/route.ts` — 全役職一覧
- `src/app/api/career/map/gap/route.ts` — スキルギャップ計算
- `src/app/api/career/map/subordinates/wishes/route.ts` — 部下キャリア希望
- `src/tests/career/career-map-service.test.ts` — 14件テスト全通過

## マージ時の注意
`src/lib/career/career-wish-types.ts` は #39（PR #125）とコンフリクトします。マージ時に #39 の型定義を使用して統合してください。

## Test plan
- [ ] `GET /api/career/map/roles` — 全ロールで閲覧可能
- [ ] `GET /api/career/map/gap?desiredRoleId=...` — 本人のギャップ表示
- [ ] `GET /api/career/map/subordinates/wishes` — MANAGER以上のみ（一般ユーザー → 403）
- [ ] ギャップ計算: 要件レベル5・実レベル3 → gap=2, fulfillmentRate=0.6

Closes #40