### PR TITLE
[#41] 組織全体のキャリア希望集計ダッシュボード

### DIFF
--- a/src/app/api/career/aggregate/dashboard/route.ts
+++ b/src/app/api/career/aggregate/dashboard/route.ts
@@ -1,0 +1,38 @@
+/**
+ * Issue #41 / Req 5.5: キャリア希望集計ダッシュボード API
+ *
+ * - GET /api/career/aggregate/dashboard — HR_MANAGER / ADMIN のみ
+ */
+import { type NextRequest, NextResponse } from 'next/server'
+import { requireAuthenticated } from '@/lib/skill/skill-route-helpers'
+import { getCareerAggregateService } from '@/lib/career/career-aggregate-service-di'
+
+export {
+  setCareerAggregateServiceForTesting,
+  clearCareerAggregateServiceForTesting,
+} from '@/lib/career/career-aggregate-service-di'
+
+const ALLOWED_ROLES: readonly string[] = ['HR_MANAGER', 'ADMIN']
+
+export async function GET(_request: NextRequest): Promise<NextResponse> {
+  const guard = await requireAuthenticated()
+  if (!guard.ok) return guard.response
+
+  if (!ALLOWED_ROLES.includes(guard.session.role)) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  let svc: ReturnType<typeof getCareerAggregateService>
+  try {
+    svc = getCareerAggregateService()
+  } catch {
+    return NextResponse.json({ error: 'CareerAggregate service not initialized' }, { status: 503 })
+  }
+
+  try {
+    const dashboard = await svc.getDashboard()
+    return NextResponse.json({ success: true, data: dashboard })
+  } catch {
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/lib/career/career-aggregate-service-di.ts
+++ b/src/lib/career/career-aggregate-service-di.ts
@@ -1,0 +1,27 @@
+/**
+ * Issue #41: CareerAggregateService のシングルトン DI モジュール。
+ */
+import type { CareerAggregateService } from './career-aggregate-service'
+
+let _service: CareerAggregateService | null = null
+
+export function setCareerAggregateServiceForTesting(svc: CareerAggregateService): void {
+  _service = svc
+}
+
+export function clearCareerAggregateServiceForTesting(): void {
+  _service = null
+}
+
+export function initCareerAggregateService(svc: CareerAggregateService): void {
+  _service = svc
+}
+
+export function getCareerAggregateService(): CareerAggregateService {
+  if (_service) return _service
+  throw new Error(
+    'CareerAggregateService is not initialized. ' +
+      'テストでは setCareerAggregateServiceForTesting() を呼んでください。' +
+      'プロダクションではサーバー起動前に initCareerAggregateService() を呼んでください。',
+  )
+}

--- a/src/lib/career/career-aggregate-service.ts
+++ b/src/lib/career/career-aggregate-service.ts
@@ -1,0 +1,141 @@
+/**
+ * Issue #41 / Req 5.5: キャリア希望集計サービス
+ *
+ * - getDashboard: HR_MANAGER 向けのキャリア希望分布・充足予測ダッシュボード
+ */
+import {
+  UNFULFILLED_TOP_ROLES_LIMIT,
+  type CareerAggregateDashboard,
+  type RoleWishDistribution,
+} from './career-aggregate-types'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Repository port
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface WishRow {
+  readonly userId: string
+  readonly desiredRoleId: string
+}
+
+export interface RoleMasterRow {
+  readonly id: string
+  readonly name: string
+}
+
+export interface PositionRow {
+  readonly roleId: string
+  readonly holderUserId: string | null
+}
+
+export interface CareerAggregateRepository {
+  listCurrentWishes(): Promise<WishRow[]>
+  listRoleMasters(): Promise<RoleMasterRow[]>
+  listPositions(): Promise<PositionRow[]>
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Service interface
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface CareerAggregateService {
+  getDashboard(): Promise<CareerAggregateDashboard>
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Pure computation helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+function buildWishCountByRole(wishes: readonly WishRow[]): Map<string, number> {
+  const counts = new Map<string, number>()
+  for (const wish of wishes) {
+    counts.set(wish.desiredRoleId, (counts.get(wish.desiredRoleId) ?? 0) + 1)
+  }
+  return counts
+}
+
+function buildHolderCountByRole(positions: readonly PositionRow[]): Map<string, number> {
+  const counts = new Map<string, number>()
+  for (const pos of positions) {
+    if (pos.holderUserId === null) continue
+    counts.set(pos.roleId, (counts.get(pos.roleId) ?? 0) + 1)
+  }
+  return counts
+}
+
+function buildRoleNameMap(roles: readonly RoleMasterRow[]): Map<string, string> {
+  const map = new Map<string, string>()
+  for (const role of roles) {
+    map.set(role.id, role.name)
+  }
+  return map
+}
+
+function computeFulfillmentRate(holderCount: number, wishCount: number): number {
+  if (wishCount === 0) return 0
+  return holderCount / wishCount
+}
+
+function buildDistribution(
+  wishCounts: Map<string, number>,
+  holderCounts: Map<string, number>,
+  roleNames: Map<string, string>,
+): RoleWishDistribution[] {
+  return Array.from(wishCounts.entries()).map(([roleId, wishCount]) => ({
+    roleId,
+    roleName: roleNames.get(roleId) ?? 'Unknown',
+    wishCount,
+    fulfillmentRate: computeFulfillmentRate(holderCounts.get(roleId) ?? 0, wishCount),
+  }))
+}
+
+function selectUnfulfilledTopRoles(
+  distribution: readonly RoleWishDistribution[],
+): readonly RoleWishDistribution[] {
+  return [...distribution]
+    .sort((a, b) => a.fulfillmentRate - b.fulfillmentRate)
+    .slice(0, UNFULFILLED_TOP_ROLES_LIMIT)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Implementation
+// ─────────────────────────────────────────────────────────────────────────────
+
+class CareerAggregateServiceImpl implements CareerAggregateService {
+  private readonly repo: CareerAggregateRepository
+
+  constructor(repo: CareerAggregateRepository) {
+    this.repo = repo
+  }
+
+  async getDashboard(): Promise<CareerAggregateDashboard> {
+    const [wishes, roles, positions] = await Promise.all([
+      this.repo.listCurrentWishes(),
+      this.repo.listRoleMasters(),
+      this.repo.listPositions(),
+    ])
+
+    const wishCounts = buildWishCountByRole(wishes)
+    const holderCounts = buildHolderCountByRole(positions)
+    const roleNames = buildRoleNameMap(roles)
+
+    const distribution = buildDistribution(wishCounts, holderCounts, roleNames)
+    const unfulfilledTopRoles = selectUnfulfilledTopRoles(distribution)
+
+    return {
+      totalWishes: wishes.length,
+      distribution,
+      unfulfilledTopRoles,
+    }
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Factory
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function createCareerAggregateService(
+  repo: CareerAggregateRepository,
+): CareerAggregateService {
+  return new CareerAggregateServiceImpl(repo)
+}

--- a/src/lib/career/career-aggregate-types.ts
+++ b/src/lib/career/career-aggregate-types.ts
@@ -1,0 +1,18 @@
+/**
+ * Issue #41 / Req 5.5: キャリア希望集計ダッシュボードの型定義
+ */
+
+export interface RoleWishDistribution {
+  readonly roleId: string
+  readonly roleName: string
+  readonly wishCount: number
+  readonly fulfillmentRate: number
+}
+
+export interface CareerAggregateDashboard {
+  readonly totalWishes: number
+  readonly distribution: readonly RoleWishDistribution[]
+  readonly unfulfilledTopRoles: readonly RoleWishDistribution[]
+}
+
+export const UNFULFILLED_TOP_ROLES_LIMIT = 5

--- a/src/tests/career/career-aggregate-service.test.ts
+++ b/src/tests/career/career-aggregate-service.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Issue #41 / Req 5.5: CareerAggregateService 単体テスト
+ *
+ * - getDashboard: 分布計算、充足予測計算、unfulfilledTopRoles ソート
+ */
+import { describe, it, expect } from 'vitest'
+import { createCareerAggregateService } from '@/lib/career/career-aggregate-service'
+import type { CareerAggregateRepository } from '@/lib/career/career-aggregate-service'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fixtures
+// ─────────────────────────────────────────────────────────────────────────────
+
+function makeRepo(overrides: Partial<CareerAggregateRepository> = {}): CareerAggregateRepository {
+  return {
+    listCurrentWishes: async () => [],
+    listRoleMasters: async () => [],
+    listPositions: async () => [],
+    ...overrides,
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('CareerAggregateService.getDashboard', () => {
+  describe('分布計算', () => {
+    it('希望がない場合は空のダッシュボードを返す', async () => {
+      const svc = createCareerAggregateService(makeRepo())
+
+      const result = await svc.getDashboard()
+
+      expect(result.totalWishes).toBe(0)
+      expect(result.distribution).toEqual([])
+      expect(result.unfulfilledTopRoles).toEqual([])
+    })
+
+    it('同じロールへの希望者を正しくカウントする', async () => {
+      const repo = makeRepo({
+        listCurrentWishes: async () => [
+          { userId: 'u1', desiredRoleId: 'role-a' },
+          { userId: 'u2', desiredRoleId: 'role-a' },
+          { userId: 'u3', desiredRoleId: 'role-b' },
+        ],
+        listRoleMasters: async () => [
+          { id: 'role-a', name: 'Senior Engineer' },
+          { id: 'role-b', name: 'Tech Lead' },
+        ],
+        listPositions: async () => [],
+      })
+      const svc = createCareerAggregateService(repo)
+
+      const result = await svc.getDashboard()
+
+      expect(result.totalWishes).toBe(3)
+      const roleA = result.distribution.find((d) => d.roleId === 'role-a')
+      const roleB = result.distribution.find((d) => d.roleId === 'role-b')
+      expect(roleA?.wishCount).toBe(2)
+      expect(roleA?.roleName).toBe('Senior Engineer')
+      expect(roleB?.wishCount).toBe(1)
+      expect(roleB?.roleName).toBe('Tech Lead')
+    })
+
+    it('ロール名が存在しない roleId は "Unknown" として扱う', async () => {
+      const repo = makeRepo({
+        listCurrentWishes: async () => [{ userId: 'u1', desiredRoleId: 'role-unknown' }],
+        listRoleMasters: async () => [],
+        listPositions: async () => [],
+      })
+      const svc = createCareerAggregateService(repo)
+
+      const result = await svc.getDashboard()
+
+      const entry = result.distribution.find((d) => d.roleId === 'role-unknown')
+      expect(entry?.roleName).toBe('Unknown')
+    })
+  })
+
+  describe('充足予測計算', () => {
+    it('そのロールに就いている人数 / 希望者数 で充足率を計算する', async () => {
+      const repo = makeRepo({
+        listCurrentWishes: async () => [
+          { userId: 'u1', desiredRoleId: 'role-a' },
+          { userId: 'u2', desiredRoleId: 'role-a' },
+          { userId: 'u3', desiredRoleId: 'role-a' },
+          { userId: 'u4', desiredRoleId: 'role-a' },
+        ],
+        listRoleMasters: async () => [{ id: 'role-a', name: 'Senior Engineer' }],
+        listPositions: async () => [
+          { roleId: 'role-a', holderUserId: 'u10' },
+          { roleId: 'role-a', holderUserId: 'u11' },
+        ],
+      })
+      const svc = createCareerAggregateService(repo)
+
+      const result = await svc.getDashboard()
+
+      const roleA = result.distribution.find((d) => d.roleId === 'role-a')
+      expect(roleA?.fulfillmentRate).toBeCloseTo(0.5)
+    })
+
+    it('希望者が 0 のロールは充足率 0 とする', async () => {
+      const repo = makeRepo({
+        listCurrentWishes: async () => [],
+        listRoleMasters: async () => [{ id: 'role-a', name: 'Senior Engineer' }],
+        listPositions: async () => [{ roleId: 'role-a', holderUserId: 'u1' }],
+      })
+      const svc = createCareerAggregateService(repo)
+
+      const result = await svc.getDashboard()
+
+      expect(result.distribution).toHaveLength(0)
+    })
+
+    it('そのロールに誰も就いていない場合は充足率 0 とする', async () => {
+      const repo = makeRepo({
+        listCurrentWishes: async () => [
+          { userId: 'u1', desiredRoleId: 'role-a' },
+          { userId: 'u2', desiredRoleId: 'role-a' },
+        ],
+        listRoleMasters: async () => [{ id: 'role-a', name: 'Senior Engineer' }],
+        listPositions: async () => [],
+      })
+      const svc = createCareerAggregateService(repo)
+
+      const result = await svc.getDashboard()
+
+      const roleA = result.distribution.find((d) => d.roleId === 'role-a')
+      expect(roleA?.fulfillmentRate).toBe(0)
+    })
+
+    it('ポジションの holder が null の場合は在籍カウントから除外する', async () => {
+      const repo = makeRepo({
+        listCurrentWishes: async () => [{ userId: 'u1', desiredRoleId: 'role-a' }],
+        listRoleMasters: async () => [{ id: 'role-a', name: 'Senior Engineer' }],
+        listPositions: async () => [
+          { roleId: 'role-a', holderUserId: null },
+          { roleId: 'role-a', holderUserId: 'u10' },
+        ],
+      })
+      const svc = createCareerAggregateService(repo)
+
+      const result = await svc.getDashboard()
+
+      const roleA = result.distribution.find((d) => d.roleId === 'role-a')
+      expect(roleA?.fulfillmentRate).toBeCloseTo(1.0)
+    })
+  })
+
+  describe('unfulfilledTopRoles ソート', () => {
+    it('充足率が低いロールを上位 5 件返す', async () => {
+      const repo = makeRepo({
+        listCurrentWishes: async () => [
+          { userId: 'u1', desiredRoleId: 'role-a' },
+          { userId: 'u2', desiredRoleId: 'role-b' },
+          { userId: 'u3', desiredRoleId: 'role-c' },
+          { userId: 'u4', desiredRoleId: 'role-d' },
+          { userId: 'u5', desiredRoleId: 'role-e' },
+          { userId: 'u6', desiredRoleId: 'role-f' },
+        ],
+        listRoleMasters: async () => [
+          { id: 'role-a', name: 'Role A' },
+          { id: 'role-b', name: 'Role B' },
+          { id: 'role-c', name: 'Role C' },
+          { id: 'role-d', name: 'Role D' },
+          { id: 'role-e', name: 'Role E' },
+          { id: 'role-f', name: 'Role F' },
+        ],
+        listPositions: async () => [
+          { roleId: 'role-a', holderUserId: 'h1' },
+        ],
+      })
+      const svc = createCareerAggregateService(repo)
+
+      const result = await svc.getDashboard()
+
+      expect(result.unfulfilledTopRoles).toHaveLength(5)
+      expect(result.unfulfilledTopRoles[0]?.fulfillmentRate).toBeLessThanOrEqual(
+        result.unfulfilledTopRoles[1]?.fulfillmentRate ?? 1,
+      )
+    })
+
+    it('充足率が低い順に並んでいる', async () => {
+      const repo = makeRepo({
+        listCurrentWishes: async () => [
+          { userId: 'u1', desiredRoleId: 'role-a' },
+          { userId: 'u2', desiredRoleId: 'role-a' },
+          { userId: 'u3', desiredRoleId: 'role-b' },
+          { userId: 'u4', desiredRoleId: 'role-b' },
+          { userId: 'u5', desiredRoleId: 'role-b' },
+        ],
+        listRoleMasters: async () => [
+          { id: 'role-a', name: 'Role A' },
+          { id: 'role-b', name: 'Role B' },
+        ],
+        listPositions: async () => [
+          { roleId: 'role-a', holderUserId: 'h1' },
+        ],
+      })
+      const svc = createCareerAggregateService(repo)
+
+      const result = await svc.getDashboard()
+
+      expect(result.unfulfilledTopRoles[0]?.roleId).toBe('role-b')
+      expect(result.unfulfilledTopRoles[1]?.roleId).toBe('role-a')
+    })
+
+    it('ロール数が 5 以下の場合は全件返す', async () => {
+      const repo = makeRepo({
+        listCurrentWishes: async () => [
+          { userId: 'u1', desiredRoleId: 'role-a' },
+          { userId: 'u2', desiredRoleId: 'role-b' },
+        ],
+        listRoleMasters: async () => [
+          { id: 'role-a', name: 'Role A' },
+          { id: 'role-b', name: 'Role B' },
+        ],
+        listPositions: async () => [],
+      })
+      const svc = createCareerAggregateService(repo)
+
+      const result = await svc.getDashboard()
+
+      expect(result.unfulfilledTopRoles).toHaveLength(2)
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- HR_MANAGER向け希望役職分布・充足予測ダッシュボードを実装（Req 5.5）
- 役職ごとの希望者数と現在就任者数から充足率を計算
- 充足率が低い役職トップ5を `unfulfilledTopRoles` として返す

## 追加ファイル
- `src/lib/career/career-aggregate-types.ts` — RoleWishDistribution・CareerAggregateDashboard型
- `src/lib/career/career-aggregate-service.ts` — CareerAggregateService実装
- `src/lib/career/career-aggregate-service-di.ts` — DI
- `src/app/api/career/aggregate/dashboard/route.ts` — GET エンドポイント（HR_MANAGER/ADMIN）
- `src/tests/career/career-aggregate-service.test.ts` — 10件テスト全通過

## Test plan
- [ ] `GET /api/career/aggregate/dashboard` — HR_MANAGER以上のみアクセス可
- [ ] 一般ユーザー → 403
- [ ] 分布計算・充足率・unfulfilledTopRolesのソート確認

Closes #41