### PR TITLE
[#42] 多階層目標ツリーの実装

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -107,6 +107,7 @@ model User {
   passwordHistory PasswordHistory[]
   sessions        Session[]
   careerWishes    CareerWish[]
+  personalGoals   PersonalGoal[]
 
   @@index([emailHash])
   @@index([status])
@@ -405,4 +406,98 @@ model CareerWish {
   @@index([userId])
   @@index([userId, supersededAt])
   @@map("career_wishes")
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 目標管理 (Requirement 6.1, 6.2, 6.3, 6.4, 6.5, 6.6, 6.7, 6.8, 6.10)
+// ─────────────────────────────────────────────────────────────────────────────
+
+enum GoalType {
+  OKR
+  MBO
+}
+
+enum GoalStatus {
+  DRAFT
+  PENDING_APPROVAL
+  APPROVED
+  REJECTED
+  IN_PROGRESS
+  COMPLETED
+}
+
+enum GoalOwnerType {
+  ORGANIZATION
+  DEPARTMENT
+  TEAM
+}
+
+/// 組織/部門/チーム階層目標 (Requirement 6.1, 6.2)
+model OrgGoal {
+  id          String        @id @default(cuid())
+  parentId    String?
+  ownerType   GoalOwnerType
+  ownerId     String
+  title       String
+  description String?
+  goalType    GoalType
+  keyResult   String?
+  targetValue Float?
+  unit        String?
+  startDate   DateTime
+  endDate     DateTime
+  createdAt   DateTime      @default(now())
+  updatedAt   DateTime      @updatedAt
+
+  parent   OrgGoal?  @relation("OrgGoalTree", fields: [parentId], references: [id])
+  children OrgGoal[] @relation("OrgGoalTree")
+
+  @@index([parentId])
+  @@index([ownerId, ownerType])
+  @@map("org_goals")
+}
+
+/// 個人目標 (Requirement 6.3, 6.4, 6.5)
+model PersonalGoal {
+  id              String     @id @default(cuid())
+  userId          String
+  parentOrgGoalId String?
+  title           String
+  description     String?
+  goalType        GoalType
+  keyResult       String?
+  targetValue     Float?
+  unit            String?
+  status          GoalStatus @default(DRAFT)
+  startDate       DateTime
+  endDate         DateTime
+  approvedBy      String?
+  approvedAt      DateTime?
+  rejectedAt      DateTime?
+  rejectedReason  String?
+  createdAt       DateTime   @default(now())
+  updatedAt       DateTime   @updatedAt
+
+  user            User                  @relation(fields: [userId], references: [id], onDelete: Cascade)
+  progressHistory GoalProgressHistory[]
+
+  @@index([userId])
+  @@index([status])
+  @@index([endDate])
+  @@map("personal_goals")
+}
+
+/// 目標進捗履歴 (Requirement 6.6)
+model GoalProgressHistory {
+  id           String   @id @default(cuid())
+  goalId       String
+  progressRate Int
+  comment      String?
+  recordedBy   String
+  recordedAt   DateTime @default(now())
+
+  goal PersonalGoal @relation(fields: [goalId], references: [id], onDelete: Cascade)
+
+  @@index([goalId, recordedAt])
+  @@map("goal_progress_history")
 }

--- a/src/app/api/goals/org/[id]/route.ts
+++ b/src/app/api/goals/org/[id]/route.ts
@@ -1,0 +1,61 @@
+/**
+ * Issue #42 / Task 13.1: 組織目標 個別取得 API (Req 6.1, 6.2)
+ *
+ * - GET /api/goals/org/[id] — 個別取得（認証済みユーザー全員）
+ */
+import { type NextRequest, NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { GoalNotFoundError } from '@/lib/goal/goal-types'
+import { getOrgGoalService } from '@/lib/goal/org-goal-service-di'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Auth helper
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function requireAuthenticated(): Promise<
+  { ok: true } | { ok: false; response: NextResponse }
+> {
+  const serverSession = await getServerSession()
+  if (!serverSession?.user?.email) {
+    return { ok: false, response: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
+  }
+  const sess = serverSession as Record<string, unknown>
+  if (typeof sess.userId !== 'string') {
+    return { ok: false, response: NextResponse.json({ error: 'Forbidden' }, { status: 403 }) }
+  }
+  return { ok: true }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /api/goals/org/[id]
+// ─────────────────────────────────────────────────────────────────────────────
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const guard = await requireAuthenticated()
+  if (!guard.ok) return guard.response
+
+  const { id } = await params
+
+  let svc: ReturnType<typeof getOrgGoalService>
+  try {
+    svc = getOrgGoalService()
+  } catch {
+    return NextResponse.json({ error: 'OrgGoalService not initialized' }, { status: 503 })
+  }
+
+  try {
+    const goal = await svc.getGoalById(id)
+    return NextResponse.json({ success: true, data: goal })
+  } catch (err) {
+    if (err instanceof GoalNotFoundError) {
+      return NextResponse.json(
+        { error: 'Goal not found', kind: err.kind, id: err.resourceId },
+        { status: 404 },
+      )
+    }
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/api/goals/org/route.ts
+++ b/src/app/api/goals/org/route.ts
@@ -1,0 +1,140 @@
+/**
+ * Issue #42 / Task 13.1: 組織目標 一覧・作成 API (Req 6.1, 6.2, 6.10)
+ *
+ * - GET  /api/goals/org            — 一覧取得（認証済みユーザー全員）
+ *   * ?ownerType=ORGANIZATION|DEPARTMENT|TEAM でフィルタ可
+ *   * ?ownerId=<id> でフィルタ可
+ *   * ?tree=1&rootId=<id> でツリー構造を返す
+ * - POST /api/goals/org            — 組織目標作成（HR_MANAGER / ADMIN のみ）
+ */
+import { type NextRequest, NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { GoalNotFoundError, orgGoalInputSchema, type GoalOwnerType } from '@/lib/goal/goal-types'
+import { getOrgGoalService } from '@/lib/goal/org-goal-service-di'
+
+export {
+  setOrgGoalServiceForTesting,
+  clearOrgGoalServiceForTesting,
+} from '@/lib/goal/org-goal-service-di'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Auth helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+type UserRole = 'ADMIN' | 'HR_MANAGER' | 'MANAGER' | 'EMPLOYEE'
+
+function isUserRole(value: unknown): value is UserRole {
+  return value === 'ADMIN' || value === 'HR_MANAGER' || value === 'MANAGER' || value === 'EMPLOYEE'
+}
+
+async function requireAuthenticated(): Promise<
+  { ok: true; userId: string; role: UserRole } | { ok: false; response: NextResponse }
+> {
+  const serverSession = await getServerSession()
+  if (!serverSession?.user?.email) {
+    return { ok: false, response: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
+  }
+  const sess = serverSession as Record<string, unknown>
+  const userId = typeof sess.userId === 'string' ? sess.userId : undefined
+  const roleValue = sess.role
+  if (!userId || !isUserRole(roleValue)) {
+    return { ok: false, response: NextResponse.json({ error: 'Forbidden' }, { status: 403 }) }
+  }
+  return { ok: true, userId, role: roleValue }
+}
+
+function isHrManagerOrAbove(role: UserRole): boolean {
+  return role === 'HR_MANAGER' || role === 'ADMIN'
+}
+
+const VALID_OWNER_TYPES: readonly GoalOwnerType[] = ['ORGANIZATION', 'DEPARTMENT', 'TEAM']
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /api/goals/org
+// ─────────────────────────────────────────────────────────────────────────────
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const guard = await requireAuthenticated()
+  if (!guard.ok) return guard.response
+
+  let svc: ReturnType<typeof getOrgGoalService>
+  try {
+    svc = getOrgGoalService()
+  } catch {
+    return NextResponse.json({ error: 'OrgGoalService not initialized' }, { status: 503 })
+  }
+
+  const params = request.nextUrl.searchParams
+  const treeMode = params.get('tree') === '1'
+  const rootId = params.get('rootId') ?? undefined
+  const ownerTypeParam = params.get('ownerType')
+  const ownerIdParam = params.get('ownerId') ?? undefined
+
+  const ownerType =
+    ownerTypeParam !== null && (VALID_OWNER_TYPES as readonly string[]).includes(ownerTypeParam)
+      ? (ownerTypeParam as GoalOwnerType)
+      : undefined
+
+  try {
+    if (treeMode) {
+      const tree = await svc.getGoalTree(rootId)
+      return NextResponse.json({ success: true, data: tree })
+    }
+
+    const goals = await svc.listGoals({ ownerType, ownerId: ownerIdParam })
+    return NextResponse.json({ success: true, data: goals })
+  } catch (err) {
+    if (err instanceof GoalNotFoundError) {
+      return NextResponse.json(
+        { error: 'Goal not found', kind: err.kind, id: err.resourceId },
+        { status: 404 },
+      )
+    }
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// POST /api/goals/org
+// ─────────────────────────────────────────────────────────────────────────────
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const guard = await requireAuthenticated()
+  if (!guard.ok) return guard.response
+
+  if (!isHrManagerOrAbove(guard.role)) {
+    return NextResponse.json({ error: 'Forbidden: HR_MANAGER or ADMIN required' }, { status: 403 })
+  }
+
+  let body: unknown
+  try {
+    body = (await request.json()) as unknown
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
+  }
+
+  const validated = orgGoalInputSchema.safeParse(body)
+  if (!validated.success) {
+    return NextResponse.json({ error: validated.error.flatten() }, { status: 422 })
+  }
+
+  let svc: ReturnType<typeof getOrgGoalService>
+  try {
+    svc = getOrgGoalService()
+  } catch {
+    return NextResponse.json({ error: 'OrgGoalService not initialized' }, { status: 503 })
+  }
+
+  try {
+    const created = await svc.createGoal(validated.data)
+    return NextResponse.json({ success: true, data: created }, { status: 201 })
+  } catch (err) {
+    if (err instanceof GoalNotFoundError) {
+      return NextResponse.json(
+        { error: 'Goal not found', kind: err.kind, id: err.resourceId },
+        { status: 404 },
+      )
+    }
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/lib/goal/goal-types.ts
+++ b/src/lib/goal/goal-types.ts
@@ -1,0 +1,159 @@
+/**
+ * Issue #42 / Task 13.1: 多階層目標ツリーの型定義 (Req 6.1, 6.2, 6.10)
+ *
+ * - Zod スキーマ: orgGoalInputSchema, personalGoalInputSchema
+ * - ブランド型: OrgGoalId, PersonalGoalId
+ * - ドメインエラー: GoalNotFoundError, GoalAccessDeniedError
+ * - 出力型: OrgGoalRecord, PersonalGoalRecord, OrgGoalTree
+ */
+import { z } from 'zod'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Enum re-exports (mirroring Prisma enums)
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type GoalType = 'OKR' | 'MBO'
+export type GoalStatus =
+  | 'DRAFT'
+  | 'PENDING_APPROVAL'
+  | 'APPROVED'
+  | 'REJECTED'
+  | 'IN_PROGRESS'
+  | 'COMPLETED'
+export type GoalOwnerType = 'ORGANIZATION' | 'DEPARTMENT' | 'TEAM'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Branded ID types
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type OrgGoalId = string & { readonly __brand: 'OrgGoalId' }
+export type PersonalGoalId = string & { readonly __brand: 'PersonalGoalId' }
+
+export function toOrgGoalId(value: string): OrgGoalId {
+  return value as OrgGoalId
+}
+
+export function toPersonalGoalId(value: string): PersonalGoalId {
+  return value as PersonalGoalId
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Input schemas
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** 組織目標作成・更新入力 (Req 6.1, 6.2) */
+export const orgGoalInputSchema = z.object({
+  parentId: z.string().optional(),
+  ownerType: z.enum(['ORGANIZATION', 'DEPARTMENT', 'TEAM']),
+  ownerId: z.string().min(1),
+  title: z.string().min(1).max(200),
+  description: z.string().optional(),
+  goalType: z.enum(['OKR', 'MBO']),
+  keyResult: z.string().optional(),
+  targetValue: z.number().optional(),
+  unit: z.string().optional(),
+  startDate: z.coerce.date(),
+  endDate: z.coerce.date(),
+})
+
+export type OrgGoalInput = z.infer<typeof orgGoalInputSchema>
+
+/** 個人目標作成・更新入力 (Req 6.3, 6.4) */
+export const personalGoalInputSchema = z.object({
+  parentOrgGoalId: z.string().optional(),
+  title: z.string().min(1).max(200),
+  description: z.string().optional(),
+  goalType: z.enum(['OKR', 'MBO']),
+  keyResult: z.string().optional(),
+  targetValue: z.number().optional(),
+  unit: z.string().optional(),
+  startDate: z.coerce.date(),
+  endDate: z.coerce.date(),
+})
+
+export type PersonalGoalInput = z.infer<typeof personalGoalInputSchema>
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Output types
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** 組織目標レコード (Req 6.1, 6.2) */
+export interface OrgGoalRecord {
+  readonly id: OrgGoalId
+  readonly parentId: string | null
+  readonly ownerType: GoalOwnerType
+  readonly ownerId: string
+  readonly title: string
+  readonly description: string | null
+  readonly goalType: GoalType
+  readonly keyResult: string | null
+  readonly targetValue: number | null
+  readonly unit: string | null
+  readonly startDate: Date
+  readonly endDate: Date
+  readonly createdAt: Date
+  readonly updatedAt: Date
+}
+
+/** 組織目標ツリーノード（親子関係を含む）(Req 6.1, 6.2) */
+export interface OrgGoalTree extends OrgGoalRecord {
+  readonly children: OrgGoalTree[]
+}
+
+/** 個人目標レコード (Req 6.3, 6.4, 6.5) */
+export interface PersonalGoalRecord {
+  readonly id: PersonalGoalId
+  readonly userId: string
+  readonly parentOrgGoalId: string | null
+  readonly title: string
+  readonly description: string | null
+  readonly goalType: GoalType
+  readonly keyResult: string | null
+  readonly targetValue: number | null
+  readonly unit: string | null
+  readonly status: GoalStatus
+  readonly startDate: Date
+  readonly endDate: Date
+  readonly approvedBy: string | null
+  readonly approvedAt: Date | null
+  readonly rejectedAt: Date | null
+  readonly rejectedReason: string | null
+  readonly createdAt: Date
+  readonly updatedAt: Date
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// List filters
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface OrgGoalFilters {
+  readonly ownerType?: GoalOwnerType
+  readonly ownerId?: string
+  readonly goalType?: GoalType
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Domain exceptions
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** 指定された目標が存在しない */
+export class GoalNotFoundError extends Error {
+  public readonly resourceId: string
+  public readonly kind: 'org-goal' | 'personal-goal'
+  constructor(kind: 'org-goal' | 'personal-goal', resourceId: string) {
+    super(`Goal not found: ${kind} id=${resourceId}`)
+    this.name = 'GoalNotFoundError'
+    this.kind = kind
+    this.resourceId = resourceId
+  }
+}
+
+/** 目標操作の権限がない */
+export class GoalAccessDeniedError extends Error {
+  public readonly reason: 'not-owner' | 'requires-hr-manager-or-above'
+  constructor(reason: 'not-owner' | 'requires-hr-manager-or-above') {
+    super(`Goal access denied: ${reason}`)
+    this.name = 'GoalAccessDeniedError'
+    this.reason = reason
+  }
+}

--- a/src/lib/goal/org-goal-service-di.ts
+++ b/src/lib/goal/org-goal-service-di.ts
@@ -1,0 +1,28 @@
+/**
+ * Issue #42 / Task 13.1: OrgGoalService のシングルトン DI モジュール。
+ * skill-service-di.ts と同一パターン。
+ */
+import type { OrgGoalService } from './org-goal-service'
+
+let _orgGoalService: OrgGoalService | null = null
+
+export function setOrgGoalServiceForTesting(svc: OrgGoalService): void {
+  _orgGoalService = svc
+}
+
+export function clearOrgGoalServiceForTesting(): void {
+  _orgGoalService = null
+}
+
+export function getOrgGoalService(): OrgGoalService {
+  if (_orgGoalService) return _orgGoalService
+  throw new Error(
+    'OrgGoalService is not initialized. ' +
+      'テストでは setOrgGoalServiceForTesting() を呼んでください。' +
+      'プロダクションではサーバー起動前に initOrgGoalService() を呼んでください。',
+  )
+}
+
+export function initOrgGoalService(svc: OrgGoalService): void {
+  _orgGoalService = svc
+}

--- a/src/lib/goal/org-goal-service.ts
+++ b/src/lib/goal/org-goal-service.ts
@@ -1,0 +1,210 @@
+/**
+ * Issue #42 / Task 13.1: 組織目標サービス (Req 6.1, 6.2, 6.10)
+ *
+ * - 責務:
+ *   1. OrgGoal の作成・更新・一覧・ツリー取得
+ *   2. 親子ツリー構造の構築 (organization→department→team 階層)
+ *   3. OKR / MBO 両形式サポート
+ *
+ * - design.md の契約:
+ *   - createGoal(input): Promise<OrgGoalRecord>
+ *   - listGoals(filters?): Promise<OrgGoalRecord[]>
+ *   - getGoalTree(rootId?): Promise<OrgGoalTree>
+ *   - updateGoal(id, input): Promise<OrgGoalRecord>
+ *   - getGoalById(id): Promise<OrgGoalRecord>
+ */
+import { PrismaClient } from '@prisma/client'
+import {
+  GoalNotFoundError,
+  toOrgGoalId,
+  type OrgGoalFilters,
+  type OrgGoalInput,
+  type OrgGoalRecord,
+  type OrgGoalTree,
+} from './goal-types'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Service interface
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface OrgGoalService {
+  /** 組織目標を作成する (Req 6.1) */
+  createGoal(input: OrgGoalInput): Promise<OrgGoalRecord>
+
+  /** 組織目標の一覧を取得する。フィルタ指定可 (Req 6.2) */
+  listGoals(filters?: OrgGoalFilters): Promise<OrgGoalRecord[]>
+
+  /**
+   * 親子ツリー構造を返す (Req 6.2, 6.10)。
+   * rootId 省略時は parentId=null の最初のルートゴールから構築する。
+   * rootId 指定時は指定ゴールをルートとするサブツリーを返す。
+   */
+  getGoalTree(rootId?: string): Promise<OrgGoalTree>
+
+  /** 組織目標を部分更新する */
+  updateGoal(id: string, input: Partial<OrgGoalInput>): Promise<OrgGoalRecord>
+
+  /** 指定 ID の組織目標を取得する */
+  getGoalById(id: string): Promise<OrgGoalRecord>
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Dependencies
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface OrgGoalServiceDeps {
+  readonly prisma: PrismaClient
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Internal helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+type PrismaOrgGoal = {
+  id: string
+  parentId: string | null
+  ownerType: 'ORGANIZATION' | 'DEPARTMENT' | 'TEAM'
+  ownerId: string
+  title: string
+  description: string | null
+  goalType: 'OKR' | 'MBO'
+  keyResult: string | null
+  targetValue: number | null
+  unit: string | null
+  startDate: Date
+  endDate: Date
+  createdAt: Date
+  updatedAt: Date
+}
+
+function toRecord(row: PrismaOrgGoal): OrgGoalRecord {
+  return {
+    id: toOrgGoalId(row.id),
+    parentId: row.parentId,
+    ownerType: row.ownerType,
+    ownerId: row.ownerId,
+    title: row.title,
+    description: row.description,
+    goalType: row.goalType,
+    keyResult: row.keyResult,
+    targetValue: row.targetValue,
+    unit: row.unit,
+    startDate: row.startDate,
+    endDate: row.endDate,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  }
+}
+
+/**
+ * フラットなレコード配列から指定ルート ID のツリーを再帰構築する。
+ * 目標数は数百件規模を想定しているため O(n²) は許容範囲。
+ */
+function buildTree(records: OrgGoalRecord[], rootId: string): OrgGoalTree {
+  const root = records.find((r) => r.id === rootId)
+  if (!root) {
+    throw new GoalNotFoundError('org-goal', rootId)
+  }
+  const children = records
+    .filter((r) => r.parentId === rootId)
+    .map((child) => buildTree(records, child.id))
+  return { ...root, children }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Implementation
+// ─────────────────────────────────────────────────────────────────────────────
+
+class OrgGoalServiceImpl implements OrgGoalService {
+  private readonly prisma: PrismaClient
+
+  constructor(deps: OrgGoalServiceDeps) {
+    this.prisma = deps.prisma
+  }
+
+  async createGoal(input: OrgGoalInput): Promise<OrgGoalRecord> {
+    const row = await this.prisma.orgGoal.create({
+      data: {
+        parentId: input.parentId ?? null,
+        ownerType: input.ownerType,
+        ownerId: input.ownerId,
+        title: input.title,
+        description: input.description ?? null,
+        goalType: input.goalType,
+        keyResult: input.keyResult ?? null,
+        targetValue: input.targetValue ?? null,
+        unit: input.unit ?? null,
+        startDate: input.startDate,
+        endDate: input.endDate,
+      },
+    })
+    return toRecord(row)
+  }
+
+  async listGoals(filters?: OrgGoalFilters): Promise<OrgGoalRecord[]> {
+    const rows = await this.prisma.orgGoal.findMany({
+      where: {
+        ...(filters?.ownerType !== undefined ? { ownerType: filters.ownerType } : {}),
+        ...(filters?.ownerId !== undefined ? { ownerId: filters.ownerId } : {}),
+        ...(filters?.goalType !== undefined ? { goalType: filters.goalType } : {}),
+      },
+      orderBy: [{ ownerType: 'asc' }, { createdAt: 'asc' }],
+    })
+    return rows.map(toRecord)
+  }
+
+  async getGoalTree(rootId?: string): Promise<OrgGoalTree> {
+    const allRecords = await this.listGoals()
+
+    if (rootId !== undefined) {
+      return buildTree(allRecords, rootId)
+    }
+
+    // rootId 省略時: parentId=null の最初のルートから構築
+    const firstRoot = allRecords.find((r) => r.parentId === null)
+    if (!firstRoot) {
+      throw new GoalNotFoundError('org-goal', '(root)')
+    }
+    return buildTree(allRecords, firstRoot.id)
+  }
+
+  async updateGoal(id: string, input: Partial<OrgGoalInput>): Promise<OrgGoalRecord> {
+    const existing = await this.prisma.orgGoal.findUnique({ where: { id } })
+    if (!existing) {
+      throw new GoalNotFoundError('org-goal', id)
+    }
+    const row = await this.prisma.orgGoal.update({
+      where: { id },
+      data: {
+        ...(input.parentId !== undefined ? { parentId: input.parentId } : {}),
+        ...(input.ownerType !== undefined ? { ownerType: input.ownerType } : {}),
+        ...(input.ownerId !== undefined ? { ownerId: input.ownerId } : {}),
+        ...(input.title !== undefined ? { title: input.title } : {}),
+        ...(input.description !== undefined ? { description: input.description } : {}),
+        ...(input.goalType !== undefined ? { goalType: input.goalType } : {}),
+        ...(input.keyResult !== undefined ? { keyResult: input.keyResult } : {}),
+        ...(input.targetValue !== undefined ? { targetValue: input.targetValue } : {}),
+        ...(input.unit !== undefined ? { unit: input.unit } : {}),
+        ...(input.startDate !== undefined ? { startDate: input.startDate } : {}),
+        ...(input.endDate !== undefined ? { endDate: input.endDate } : {}),
+      },
+    })
+    return toRecord(row)
+  }
+
+  async getGoalById(id: string): Promise<OrgGoalRecord> {
+    const row = await this.prisma.orgGoal.findUnique({ where: { id } })
+    if (!row) {
+      throw new GoalNotFoundError('org-goal', id)
+    }
+    return toRecord(row)
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Factory
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function createOrgGoalService(deps: OrgGoalServiceDeps): OrgGoalService {
+  return new OrgGoalServiceImpl(deps)
+}

--- a/src/tests/goal/org-goal-service.test.ts
+++ b/src/tests/goal/org-goal-service.test.ts
@@ -1,0 +1,345 @@
+/**
+ * Issue #42 / Task 13.1: OrgGoalService の単体テスト (Req 6.1, 6.2, 6.10)
+ *
+ * - createGoal: OKR/MBO 両形式での作成
+ * - listGoals: フィルタリング（ownerType / ownerId）
+ * - getGoalTree: 親子ツリー構造（organization→department→team 階層）
+ * - updateGoal: 部分更新 / 存在しない場合の GoalNotFoundError
+ * - getGoalById: 存在する / しない場合
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { createOrgGoalService } from '@/lib/goal/org-goal-service'
+import {
+  GoalNotFoundError,
+  toOrgGoalId,
+  type OrgGoalInput,
+  type OrgGoalRecord,
+} from '@/lib/goal/goal-types'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fixtures
+// ─────────────────────────────────────────────────────────────────────────────
+
+const NOW = new Date('2026-04-19T00:00:00.000Z')
+const START = new Date('2026-01-01T00:00:00.000Z')
+const END = new Date('2026-03-31T00:00:00.000Z')
+
+function makeOkrInput(overrides: Partial<OrgGoalInput> = {}): OrgGoalInput {
+  return {
+    ownerType: 'ORGANIZATION',
+    ownerId: 'org-001',
+    title: '全社売上目標',
+    goalType: 'OKR',
+    keyResult: '売上 +20%',
+    targetValue: 120,
+    unit: '%',
+    startDate: START,
+    endDate: END,
+    ...overrides,
+  }
+}
+
+function makeMboInput(overrides: Partial<OrgGoalInput> = {}): OrgGoalInput {
+  return {
+    ownerType: 'DEPARTMENT',
+    ownerId: 'dept-001',
+    title: '営業部門目標',
+    goalType: 'MBO',
+    startDate: START,
+    endDate: END,
+    ...overrides,
+  }
+}
+
+function makeRecord(overrides: Partial<OrgGoalRecord> = {}): OrgGoalRecord {
+  return {
+    id: toOrgGoalId('goal-org-1'),
+    parentId: null,
+    ownerType: 'ORGANIZATION',
+    ownerId: 'org-001',
+    title: '全社売上目標',
+    description: null,
+    goalType: 'OKR',
+    keyResult: '売上 +20%',
+    targetValue: 120,
+    unit: '%',
+    startDate: START,
+    endDate: END,
+    createdAt: NOW,
+    updatedAt: NOW,
+    ...overrides,
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Prisma mock factory
+// ─────────────────────────────────────────────────────────────────────────────
+
+function makePrisma(overrides: Record<string, unknown> = {}) {
+  return {
+    orgGoal: {
+      create: vi.fn(),
+      findMany: vi.fn().mockResolvedValue([]),
+      findUnique: vi.fn().mockResolvedValue(null),
+      update: vi.fn(),
+      ...overrides,
+    },
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// createGoal
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('OrgGoalService - createGoal', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('OKR 形式で目標を作成できる', async () => {
+    const expected = makeRecord()
+    const prisma = makePrisma({ create: vi.fn().mockResolvedValue(expected) })
+    const svc = createOrgGoalService({ prisma: prisma as never })
+
+    const result = await svc.createGoal(makeOkrInput())
+
+    expect(result.goalType).toBe('OKR')
+    expect(result.keyResult).toBe('売上 +20%')
+    expect(result.targetValue).toBe(120)
+    expect(prisma.orgGoal.create).toHaveBeenCalledOnce()
+  })
+
+  it('MBO 形式で目標を作成できる', async () => {
+    const expected = makeRecord({
+      id: toOrgGoalId('goal-dept-1'),
+      ownerType: 'DEPARTMENT',
+      ownerId: 'dept-001',
+      title: '営業部門目標',
+      goalType: 'MBO',
+      keyResult: null,
+      targetValue: null,
+      unit: null,
+    })
+    const prisma = makePrisma({ create: vi.fn().mockResolvedValue(expected) })
+    const svc = createOrgGoalService({ prisma: prisma as never })
+
+    const result = await svc.createGoal(makeMboInput())
+
+    expect(result.goalType).toBe('MBO')
+    expect(result.keyResult).toBeNull()
+    expect(result.ownerType).toBe('DEPARTMENT')
+  })
+
+  it('parentId を指定して子ゴールを作成できる', async () => {
+    const expected = makeRecord({
+      id: toOrgGoalId('goal-dept-1'),
+      parentId: 'goal-org-1',
+      ownerType: 'DEPARTMENT',
+      ownerId: 'dept-001',
+    })
+    const prisma = makePrisma({ create: vi.fn().mockResolvedValue(expected) })
+    const svc = createOrgGoalService({ prisma: prisma as never })
+
+    const result = await svc.createGoal(
+      makeMboInput({ parentId: 'goal-org-1', ownerType: 'DEPARTMENT' }),
+    )
+
+    expect(result.parentId).toBe('goal-org-1')
+    const callArg = (prisma.orgGoal.create as ReturnType<typeof vi.fn>).mock.calls[0]?.[0]
+    expect(callArg.data.parentId).toBe('goal-org-1')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// listGoals
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('OrgGoalService - listGoals', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('フィルタなしで全件返す', async () => {
+    const records = [makeRecord(), makeRecord({ id: toOrgGoalId('goal-2') })]
+    const prisma = makePrisma({ findMany: vi.fn().mockResolvedValue(records) })
+    const svc = createOrgGoalService({ prisma: prisma as never })
+
+    const result = await svc.listGoals()
+
+    expect(result).toHaveLength(2)
+    expect(prisma.orgGoal.findMany).toHaveBeenCalledWith(expect.objectContaining({ where: {} }))
+  })
+
+  it('ownerType フィルタを where 句に渡す', async () => {
+    const prisma = makePrisma({ findMany: vi.fn().mockResolvedValue([]) })
+    const svc = createOrgGoalService({ prisma: prisma as never })
+
+    await svc.listGoals({ ownerType: 'DEPARTMENT' })
+
+    const callArg = (prisma.orgGoal.findMany as ReturnType<typeof vi.fn>).mock.calls[0]?.[0]
+    expect(callArg.where.ownerType).toBe('DEPARTMENT')
+  })
+
+  it('ownerId フィルタを where 句に渡す', async () => {
+    const prisma = makePrisma({ findMany: vi.fn().mockResolvedValue([]) })
+    const svc = createOrgGoalService({ prisma: prisma as never })
+
+    await svc.listGoals({ ownerId: 'dept-001' })
+
+    const callArg = (prisma.orgGoal.findMany as ReturnType<typeof vi.fn>).mock.calls[0]?.[0]
+    expect(callArg.where.ownerId).toBe('dept-001')
+  })
+
+  it('goalType フィルタを where 句に渡す', async () => {
+    const prisma = makePrisma({ findMany: vi.fn().mockResolvedValue([]) })
+    const svc = createOrgGoalService({ prisma: prisma as never })
+
+    await svc.listGoals({ goalType: 'OKR' })
+
+    const callArg = (prisma.orgGoal.findMany as ReturnType<typeof vi.fn>).mock.calls[0]?.[0]
+    expect(callArg.where.goalType).toBe('OKR')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// getGoalTree
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('OrgGoalService - getGoalTree', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('organization→department の 2 階層ツリーを構築できる', async () => {
+    const orgGoal = makeRecord({
+      id: toOrgGoalId('goal-org-1'),
+      parentId: null,
+      ownerType: 'ORGANIZATION',
+    })
+    const deptGoal = makeRecord({
+      id: toOrgGoalId('goal-dept-1'),
+      parentId: 'goal-org-1',
+      ownerType: 'DEPARTMENT',
+      ownerId: 'dept-001',
+    })
+    const prisma = makePrisma({
+      findMany: vi.fn().mockResolvedValue([orgGoal, deptGoal]),
+    })
+    const svc = createOrgGoalService({ prisma: prisma as never })
+
+    const tree = await svc.getGoalTree('goal-org-1')
+
+    expect(tree.id).toBe('goal-org-1')
+    expect(tree.ownerType).toBe('ORGANIZATION')
+    expect(tree.children).toHaveLength(1)
+    expect(tree.children[0]?.id).toBe('goal-dept-1')
+    expect(tree.children[0]?.ownerType).toBe('DEPARTMENT')
+    expect(tree.children[0]?.children).toHaveLength(0)
+  })
+
+  it('organization→department→team の 3 階層ツリーを構築できる', async () => {
+    const orgGoal = makeRecord({
+      id: toOrgGoalId('goal-org-1'),
+      parentId: null,
+      ownerType: 'ORGANIZATION',
+    })
+    const deptGoal = makeRecord({
+      id: toOrgGoalId('goal-dept-1'),
+      parentId: 'goal-org-1',
+      ownerType: 'DEPARTMENT',
+    })
+    const teamGoal = makeRecord({
+      id: toOrgGoalId('goal-team-1'),
+      parentId: 'goal-dept-1',
+      ownerType: 'TEAM',
+    })
+    const prisma = makePrisma({
+      findMany: vi.fn().mockResolvedValue([orgGoal, deptGoal, teamGoal]),
+    })
+    const svc = createOrgGoalService({ prisma: prisma as never })
+
+    const tree = await svc.getGoalTree('goal-org-1')
+
+    expect(tree.children[0]?.children[0]?.id).toBe('goal-team-1')
+    expect(tree.children[0]?.children[0]?.ownerType).toBe('TEAM')
+  })
+
+  it('存在しない rootId は GoalNotFoundError を投げる', async () => {
+    const orgGoal = makeRecord({ id: toOrgGoalId('goal-org-1'), parentId: null })
+    const prisma = makePrisma({ findMany: vi.fn().mockResolvedValue([orgGoal]) })
+    const svc = createOrgGoalService({ prisma: prisma as never })
+
+    await expect(svc.getGoalTree('nonexistent-id')).rejects.toBeInstanceOf(GoalNotFoundError)
+  })
+
+  it('rootId 省略時はデータが空なら GoalNotFoundError を投げる', async () => {
+    const prisma = makePrisma({ findMany: vi.fn().mockResolvedValue([]) })
+    const svc = createOrgGoalService({ prisma: prisma as never })
+
+    await expect(svc.getGoalTree()).rejects.toBeInstanceOf(GoalNotFoundError)
+  })
+
+  it('rootId 省略時は parentId=null の最初のゴールをルートにする', async () => {
+    const orgGoal = makeRecord({ id: toOrgGoalId('goal-org-1'), parentId: null })
+    const prisma = makePrisma({ findMany: vi.fn().mockResolvedValue([orgGoal]) })
+    const svc = createOrgGoalService({ prisma: prisma as never })
+
+    const tree = await svc.getGoalTree()
+
+    expect(tree.id).toBe('goal-org-1')
+    expect(tree.children).toHaveLength(0)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// updateGoal
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('OrgGoalService - updateGoal', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('存在する目標を部分更新できる', async () => {
+    const existing = makeRecord()
+    const updated = makeRecord({ title: '更新後タイトル' })
+    const prisma = makePrisma({
+      findUnique: vi.fn().mockResolvedValue(existing),
+      update: vi.fn().mockResolvedValue(updated),
+    })
+    const svc = createOrgGoalService({ prisma: prisma as never })
+
+    const result = await svc.updateGoal('goal-org-1', { title: '更新後タイトル' })
+
+    expect(result.title).toBe('更新後タイトル')
+    expect(prisma.orgGoal.update).toHaveBeenCalledOnce()
+  })
+
+  it('存在しない目標の更新は GoalNotFoundError を投げる', async () => {
+    const prisma = makePrisma({ findUnique: vi.fn().mockResolvedValue(null) })
+    const svc = createOrgGoalService({ prisma: prisma as never })
+
+    await expect(svc.updateGoal('nonexistent', { title: '更新' })).rejects.toBeInstanceOf(
+      GoalNotFoundError,
+    )
+    expect(prisma.orgGoal.update).not.toHaveBeenCalled()
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// getGoalById
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('OrgGoalService - getGoalById', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('存在する ID のレコードを返す', async () => {
+    const record = makeRecord()
+    const prisma = makePrisma({ findUnique: vi.fn().mockResolvedValue(record) })
+    const svc = createOrgGoalService({ prisma: prisma as never })
+
+    const result = await svc.getGoalById('goal-org-1')
+
+    expect(result.id).toBe('goal-org-1')
+    expect(prisma.orgGoal.findUnique).toHaveBeenCalledWith({ where: { id: 'goal-org-1' } })
+  })
+
+  it('存在しない ID は GoalNotFoundError を投げる', async () => {
+    const prisma = makePrisma({ findUnique: vi.fn().mockResolvedValue(null) })
+    const svc = createOrgGoalService({ prisma: prisma as never })
+
+    await expect(svc.getGoalById('nonexistent')).rejects.toBeInstanceOf(GoalNotFoundError)
+  })
+})


### PR DESCRIPTION
## Summary
- 組織→部門→チーム階層の目標管理モデルを実装（Req 6.1, 6.2, 6.10）
- OKR / MBO の両形式をサポート
- 自己参照による再帰ツリー構造（`parentId`）

## Prismaスキーマ追加
- `GoalType` / `GoalStatus` / `GoalOwnerType` enum
- `OrgGoal`（自己参照ツリー）/ `PersonalGoal` / `GoalProgressHistory` モデル

## 追加ファイル
- `prisma/schema.prisma` — 3 enum + 3 model追加、Userにリレーション追加
- `src/lib/goal/goal-types.ts` — 型定義・Zodスキーマ・ドメインエラー
- `src/lib/goal/org-goal-service.ts` — OrgGoalService（ツリー構築含む）
- `src/lib/goal/org-goal-service-di.ts` — DI
- `src/app/api/goals/org/route.ts` — POST・GET（`?tree=1`対応）
- `src/app/api/goals/org/[id]/route.ts` — 個別取得
- `src/tests/goal/org-goal-service.test.ts` — 16件テスト全通過

## マージ順序の注意
このPRが #43, #44, #45 のスキーマ変更の基盤となります。**このPRを最初にマージ**してください。

## Test plan
- [ ] `POST /api/goals/org` — HR_MANAGER/ADMINのみ作成可
- [ ] `GET /api/goals/org?tree=1` — ツリー構造で返却
- [ ] OKR/MBO両形式での作成確認

Closes #42