### PR TITLE
[#43] 個人目標登録と上長承認フロー

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -107,6 +107,7 @@ model User {
   passwordHistory PasswordHistory[]
   sessions        Session[]
   careerWishes    CareerWish[]
+  personalGoals   PersonalGoal[]
 
   @@index([emailHash])
   @@index([status])
@@ -405,4 +406,95 @@ model CareerWish {
   @@index([userId])
   @@index([userId, supersededAt])
   @@map("career_wishes")
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 目標管理 (Requirement 6.3, 6.4, 6.5)
+// ─────────────────────────────────────────────────────────────────────────────
+
+enum GoalType {
+  OKR
+  MBO
+}
+
+enum GoalStatus {
+  DRAFT
+  PENDING_APPROVAL
+  APPROVED
+  REJECTED
+  IN_PROGRESS
+  COMPLETED
+}
+
+enum GoalOwnerType {
+  ORGANIZATION
+  DEPARTMENT
+  TEAM
+}
+
+model OrgGoal {
+  id          String        @id @default(cuid())
+  parentId    String?
+  ownerType   GoalOwnerType
+  ownerId     String
+  title       String
+  description String?
+  goalType    GoalType
+  keyResult   String?
+  targetValue Float?
+  unit        String?
+  startDate   DateTime
+  endDate     DateTime
+  createdAt   DateTime      @default(now())
+  updatedAt   DateTime      @updatedAt
+
+  parent   OrgGoal?  @relation("OrgGoalTree", fields: [parentId], references: [id])
+  children OrgGoal[] @relation("OrgGoalTree")
+
+  @@index([parentId])
+  @@index([ownerId, ownerType])
+  @@map("org_goals")
+}
+
+model PersonalGoal {
+  id              String     @id @default(cuid())
+  userId          String
+  parentOrgGoalId String?
+  title           String
+  description     String?
+  goalType        GoalType
+  keyResult       String?
+  targetValue     Float?
+  unit            String?
+  status          GoalStatus @default(DRAFT)
+  startDate       DateTime
+  endDate         DateTime
+  approvedBy      String?
+  approvedAt      DateTime?
+  rejectedAt      DateTime?
+  rejectedReason  String?
+  createdAt       DateTime   @default(now())
+  updatedAt       DateTime   @updatedAt
+
+  user            User                  @relation(fields: [userId], references: [id], onDelete: Cascade)
+  progressHistory GoalProgressHistory[]
+
+  @@index([userId])
+  @@index([status])
+  @@index([endDate])
+  @@map("personal_goals")
+}
+
+model GoalProgressHistory {
+  id           String   @id @default(cuid())
+  goalId       String
+  progressRate Int
+  comment      String?
+  recordedBy   String
+  recordedAt   DateTime @default(now())
+
+  goal PersonalGoal @relation(fields: [goalId], references: [id], onDelete: Cascade)
+
+  @@index([goalId, recordedAt])
+  @@map("goal_progress_history")
 }

--- a/src/app/api/goals/personal/[id]/approve/route.ts
+++ b/src/app/api/goals/personal/[id]/approve/route.ts
@@ -1,0 +1,42 @@
+/**
+ * Issue #43 / Task 13.2: 個人目標 承認 API (Req 6.4)
+ *
+ * POST /api/goals/personal/[id]/approve — PENDING_APPROVAL → APPROVED（MANAGER以上）
+ */
+import { type NextRequest, NextResponse } from 'next/server'
+import { requireManager } from '@/lib/skill/skill-route-helpers'
+import { getPersonalGoalService } from '@/lib/goal/personal-goal-service-di'
+import {
+  PersonalGoalNotFoundError,
+  PersonalGoalInvalidTransitionError,
+} from '@/lib/goal/personal-goal-types'
+
+export async function POST(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const guard = await requireManager()
+  if (!guard.ok) return guard.response
+
+  const { id } = await params
+
+  let svc: ReturnType<typeof getPersonalGoalService>
+  try {
+    svc = getPersonalGoalService()
+  } catch {
+    return NextResponse.json({ error: 'PersonalGoal service not initialized' }, { status: 503 })
+  }
+
+  try {
+    const updated = await svc.approveGoal(id, guard.session.userId)
+    return NextResponse.json({ success: true, data: updated })
+  } catch (err) {
+    if (err instanceof PersonalGoalNotFoundError) {
+      return NextResponse.json({ error: err.message }, { status: 404 })
+    }
+    if (err instanceof PersonalGoalInvalidTransitionError) {
+      return NextResponse.json({ error: err.message }, { status: 409 })
+    }
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/api/goals/personal/[id]/complete/route.ts
+++ b/src/app/api/goals/personal/[id]/complete/route.ts
@@ -1,0 +1,50 @@
+/**
+ * Issue #43 / Task 13.2: 個人目標 完了 API (Req 6.5)
+ *
+ * POST /api/goals/personal/[id]/complete — IN_PROGRESS → COMPLETED（自分のみ）
+ */
+import { type NextRequest, NextResponse } from 'next/server'
+import { requireAuthenticated } from '@/lib/skill/skill-route-helpers'
+import { getPersonalGoalService } from '@/lib/goal/personal-goal-service-di'
+import {
+  PersonalGoalNotFoundError,
+  PersonalGoalInvalidTransitionError,
+} from '@/lib/goal/personal-goal-types'
+
+export async function POST(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const guard = await requireAuthenticated()
+  if (!guard.ok) return guard.response
+
+  const { id } = await params
+
+  let svc: ReturnType<typeof getPersonalGoalService>
+  try {
+    svc = getPersonalGoalService()
+  } catch {
+    return NextResponse.json({ error: 'PersonalGoal service not initialized' }, { status: 503 })
+  }
+
+  try {
+    const goal = await svc.getGoal(id)
+    if (!goal) {
+      return NextResponse.json({ error: 'Goal not found' }, { status: 404 })
+    }
+    if (goal.userId !== guard.session.userId) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+
+    const updated = await svc.completeGoal(id)
+    return NextResponse.json({ success: true, data: updated })
+  } catch (err) {
+    if (err instanceof PersonalGoalNotFoundError) {
+      return NextResponse.json({ error: err.message }, { status: 404 })
+    }
+    if (err instanceof PersonalGoalInvalidTransitionError) {
+      return NextResponse.json({ error: err.message }, { status: 409 })
+    }
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/api/goals/personal/[id]/reject/route.ts
+++ b/src/app/api/goals/personal/[id]/reject/route.ts
@@ -1,0 +1,56 @@
+/**
+ * Issue #43 / Task 13.2: 個人目標 却下 API (Req 6.4)
+ *
+ * POST /api/goals/personal/[id]/reject — PENDING_APPROVAL → REJECTED（MANAGER以上）
+ * Body: { reason: string }
+ */
+import { z } from 'zod'
+import { type NextRequest, NextResponse } from 'next/server'
+import { requireManager, parseJsonBody } from '@/lib/skill/skill-route-helpers'
+import { getPersonalGoalService } from '@/lib/goal/personal-goal-service-di'
+import {
+  PersonalGoalNotFoundError,
+  PersonalGoalInvalidTransitionError,
+} from '@/lib/goal/personal-goal-types'
+
+const rejectBodySchema = z.object({
+  reason: z.string().min(1, 'reason is required'),
+})
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const guard = await requireManager()
+  if (!guard.ok) return guard.response
+
+  const { id } = await params
+
+  const parsedBody = await parseJsonBody(request)
+  if (!parsedBody.ok) return parsedBody.response
+
+  const validated = rejectBodySchema.safeParse(parsedBody.body)
+  if (!validated.success) {
+    return NextResponse.json({ error: validated.error.flatten() }, { status: 422 })
+  }
+
+  let svc: ReturnType<typeof getPersonalGoalService>
+  try {
+    svc = getPersonalGoalService()
+  } catch {
+    return NextResponse.json({ error: 'PersonalGoal service not initialized' }, { status: 503 })
+  }
+
+  try {
+    const updated = await svc.rejectGoal(id, guard.session.userId, validated.data.reason)
+    return NextResponse.json({ success: true, data: updated })
+  } catch (err) {
+    if (err instanceof PersonalGoalNotFoundError) {
+      return NextResponse.json({ error: err.message }, { status: 404 })
+    }
+    if (err instanceof PersonalGoalInvalidTransitionError) {
+      return NextResponse.json({ error: err.message }, { status: 409 })
+    }
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/api/goals/personal/[id]/start/route.ts
+++ b/src/app/api/goals/personal/[id]/start/route.ts
@@ -1,0 +1,50 @@
+/**
+ * Issue #43 / Task 13.2: 個人目標 開始 API (Req 6.5)
+ *
+ * POST /api/goals/personal/[id]/start — APPROVED → IN_PROGRESS（自分のみ）
+ */
+import { type NextRequest, NextResponse } from 'next/server'
+import { requireAuthenticated } from '@/lib/skill/skill-route-helpers'
+import { getPersonalGoalService } from '@/lib/goal/personal-goal-service-di'
+import {
+  PersonalGoalNotFoundError,
+  PersonalGoalInvalidTransitionError,
+} from '@/lib/goal/personal-goal-types'
+
+export async function POST(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const guard = await requireAuthenticated()
+  if (!guard.ok) return guard.response
+
+  const { id } = await params
+
+  let svc: ReturnType<typeof getPersonalGoalService>
+  try {
+    svc = getPersonalGoalService()
+  } catch {
+    return NextResponse.json({ error: 'PersonalGoal service not initialized' }, { status: 503 })
+  }
+
+  try {
+    const goal = await svc.getGoal(id)
+    if (!goal) {
+      return NextResponse.json({ error: 'Goal not found' }, { status: 404 })
+    }
+    if (goal.userId !== guard.session.userId) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+
+    const updated = await svc.startGoal(id)
+    return NextResponse.json({ success: true, data: updated })
+  } catch (err) {
+    if (err instanceof PersonalGoalNotFoundError) {
+      return NextResponse.json({ error: err.message }, { status: 404 })
+    }
+    if (err instanceof PersonalGoalInvalidTransitionError) {
+      return NextResponse.json({ error: err.message }, { status: 409 })
+    }
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/api/goals/personal/[id]/submit/route.ts
+++ b/src/app/api/goals/personal/[id]/submit/route.ts
@@ -1,0 +1,50 @@
+/**
+ * Issue #43 / Task 13.2: 個人目標 承認申請 API (Req 6.4)
+ *
+ * POST /api/goals/personal/[id]/submit — DRAFT → PENDING_APPROVAL（自分のみ）
+ */
+import { type NextRequest, NextResponse } from 'next/server'
+import { requireAuthenticated } from '@/lib/skill/skill-route-helpers'
+import { getPersonalGoalService } from '@/lib/goal/personal-goal-service-di'
+import {
+  PersonalGoalNotFoundError,
+  PersonalGoalInvalidTransitionError,
+} from '@/lib/goal/personal-goal-types'
+
+export async function POST(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const guard = await requireAuthenticated()
+  if (!guard.ok) return guard.response
+
+  const { id } = await params
+
+  let svc: ReturnType<typeof getPersonalGoalService>
+  try {
+    svc = getPersonalGoalService()
+  } catch {
+    return NextResponse.json({ error: 'PersonalGoal service not initialized' }, { status: 503 })
+  }
+
+  try {
+    const goal = await svc.getGoal(id)
+    if (!goal) {
+      return NextResponse.json({ error: 'Goal not found' }, { status: 404 })
+    }
+    if (goal.userId !== guard.session.userId) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+
+    const updated = await svc.submitForApproval(id, guard.session.userId)
+    return NextResponse.json({ success: true, data: updated })
+  } catch (err) {
+    if (err instanceof PersonalGoalNotFoundError) {
+      return NextResponse.json({ error: err.message }, { status: 404 })
+    }
+    if (err instanceof PersonalGoalInvalidTransitionError) {
+      return NextResponse.json({ error: err.message }, { status: 409 })
+    }
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/api/goals/personal/route.ts
+++ b/src/app/api/goals/personal/route.ts
@@ -1,0 +1,61 @@
+/**
+ * Issue #43 / Task 13.2: 個人目標 API (Req 6.3, 6.4, 6.5)
+ *
+ * - POST /api/goals/personal — 目標作成（自分のみ）
+ * - GET  /api/goals/personal — 自分の目標一覧
+ */
+import { type NextRequest, NextResponse } from 'next/server'
+import { personalGoalInputSchema } from '@/lib/goal/personal-goal-types'
+import { parseJsonBody, requireAuthenticated } from '@/lib/skill/skill-route-helpers'
+import { getPersonalGoalService } from '@/lib/goal/personal-goal-service-di'
+
+export {
+  setPersonalGoalServiceForTesting,
+  clearPersonalGoalServiceForTesting,
+} from '@/lib/goal/personal-goal-service-di'
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const guard = await requireAuthenticated()
+  if (!guard.ok) return guard.response
+
+  const parsedBody = await parseJsonBody(request)
+  if (!parsedBody.ok) return parsedBody.response
+
+  const validated = personalGoalInputSchema.safeParse(parsedBody.body)
+  if (!validated.success) {
+    return NextResponse.json({ error: validated.error.flatten() }, { status: 422 })
+  }
+
+  let svc: ReturnType<typeof getPersonalGoalService>
+  try {
+    svc = getPersonalGoalService()
+  } catch {
+    return NextResponse.json({ error: 'PersonalGoal service not initialized' }, { status: 503 })
+  }
+
+  try {
+    const goal = await svc.createGoal(guard.session.userId, validated.data)
+    return NextResponse.json({ success: true, data: goal }, { status: 201 })
+  } catch {
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}
+
+export async function GET(): Promise<NextResponse> {
+  const guard = await requireAuthenticated()
+  if (!guard.ok) return guard.response
+
+  let svc: ReturnType<typeof getPersonalGoalService>
+  try {
+    svc = getPersonalGoalService()
+  } catch {
+    return NextResponse.json({ error: 'PersonalGoal service not initialized' }, { status: 503 })
+  }
+
+  try {
+    const goals = await svc.listMyGoals(guard.session.userId)
+    return NextResponse.json({ success: true, data: goals })
+  } catch {
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/lib/goal/personal-goal-service-di.ts
+++ b/src/lib/goal/personal-goal-service-di.ts
@@ -1,0 +1,30 @@
+/**
+ * Issue #43 / Task 13.2: PersonalGoalService DI コンテナ
+ *
+ * テストでは setPersonalGoalServiceForTesting() を使用。
+ * プロダクションでは initPersonalGoalService() を起動前に呼ぶ。
+ */
+import type { PersonalGoalService } from './personal-goal-service'
+
+let _service: PersonalGoalService | null = null
+
+export function setPersonalGoalServiceForTesting(svc: PersonalGoalService): void {
+  _service = svc
+}
+
+export function clearPersonalGoalServiceForTesting(): void {
+  _service = null
+}
+
+export function getPersonalGoalService(): PersonalGoalService {
+  if (_service) return _service
+  throw new Error(
+    'PersonalGoalService is not initialized. ' +
+      'テストでは setPersonalGoalServiceForTesting() を呼んでください。' +
+      'プロダクションではサーバー起動前に initPersonalGoalService() を呼んでください。',
+  )
+}
+
+export function initPersonalGoalService(svc: PersonalGoalService): void {
+  _service = svc
+}

--- a/src/lib/goal/personal-goal-service.ts
+++ b/src/lib/goal/personal-goal-service.ts
@@ -1,0 +1,269 @@
+/**
+ * Issue #43 / Task 13.2: 個人目標登録と上長承認フロー — サービス (Req 6.3, 6.4, 6.5)
+ *
+ * 承認ステートマシン:
+ *   DRAFT → PENDING_APPROVAL → APPROVED → IN_PROGRESS → COMPLETED
+ *                           └→ REJECTED
+ */
+import type { PrismaClient } from '@prisma/client'
+import type { NotificationEmitter } from '@/lib/notification/notification-emitter'
+import type { NotificationEvent } from '@/lib/notification/notification-types'
+import {
+  PersonalGoalNotFoundError,
+  PersonalGoalInvalidTransitionError,
+  type GoalStatus,
+  type PersonalGoalInput,
+  type PersonalGoalRecord,
+} from './personal-goal-types'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 許可された状態遷移マップ
+// ─────────────────────────────────────────────────────────────────────────────
+
+const ALLOWED_TRANSITIONS: Record<GoalStatus, readonly GoalStatus[]> = {
+  DRAFT: ['PENDING_APPROVAL'],
+  PENDING_APPROVAL: ['APPROVED', 'REJECTED'],
+  APPROVED: ['IN_PROGRESS'],
+  REJECTED: [],
+  IN_PROGRESS: ['COMPLETED'],
+  COMPLETED: [],
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Service interface
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface PersonalGoalService {
+  /** DRAFT で目標を作成 */
+  createGoal(userId: string, input: PersonalGoalInput): Promise<PersonalGoalRecord>
+  /** DRAFT → PENDING_APPROVAL、MANAGERに通知 */
+  submitForApproval(goalId: string, requestedBy: string): Promise<PersonalGoalRecord>
+  /** PENDING_APPROVAL → APPROVED、承認者IDを記録 */
+  approveGoal(goalId: string, approvedBy: string): Promise<PersonalGoalRecord>
+  /** PENDING_APPROVAL → REJECTED */
+  rejectGoal(goalId: string, rejectedBy: string, reason: string): Promise<PersonalGoalRecord>
+  /** APPROVED → IN_PROGRESS */
+  startGoal(goalId: string): Promise<PersonalGoalRecord>
+  /** IN_PROGRESS → COMPLETED */
+  completeGoal(goalId: string): Promise<PersonalGoalRecord>
+  /** 自分の目標一覧 */
+  listMyGoals(userId: string): Promise<PersonalGoalRecord[]>
+  /** 特定目標取得 */
+  getGoal(goalId: string): Promise<PersonalGoalRecord | null>
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Repository helper — Prisma の PersonalGoal を型安全に変換
+// ─────────────────────────────────────────────────────────────────────────────
+
+type PrismaPersonalGoal = {
+  id: string
+  userId: string
+  parentOrgGoalId: string | null
+  title: string
+  description: string | null
+  goalType: string
+  keyResult: string | null
+  targetValue: number | null
+  unit: string | null
+  status: string
+  startDate: Date
+  endDate: Date
+  approvedBy: string | null
+  approvedAt: Date | null
+  rejectedAt: Date | null
+  rejectedReason: string | null
+  createdAt: Date
+  updatedAt: Date
+}
+
+function toRecord(row: PrismaPersonalGoal): PersonalGoalRecord {
+  return {
+    id: row.id,
+    userId: row.userId,
+    parentOrgGoalId: row.parentOrgGoalId,
+    title: row.title,
+    description: row.description,
+    goalType: row.goalType as PersonalGoalRecord['goalType'],
+    keyResult: row.keyResult,
+    targetValue: row.targetValue,
+    unit: row.unit,
+    status: row.status as GoalStatus,
+    startDate: row.startDate,
+    endDate: row.endDate,
+    approvedBy: row.approvedBy,
+    approvedAt: row.approvedAt,
+    rejectedAt: row.rejectedAt,
+    rejectedReason: row.rejectedReason,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// State machine helper
+// ─────────────────────────────────────────────────────────────────────────────
+
+function assertTransition(current: GoalStatus, next: GoalStatus): void {
+  const allowed = ALLOWED_TRANSITIONS[current]
+  if (!allowed.includes(next)) {
+    throw new PersonalGoalInvalidTransitionError(current, next)
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Implementation
+// ─────────────────────────────────────────────────────────────────────────────
+
+class PersonalGoalServiceImpl implements PersonalGoalService {
+  constructor(
+    private readonly db: PrismaClient,
+    private readonly notificationEmitter: NotificationEmitter | null,
+    private readonly clock: () => Date,
+  ) {}
+
+  async createGoal(userId: string, input: PersonalGoalInput): Promise<PersonalGoalRecord> {
+    const row = await this.db.personalGoal.create({
+      data: {
+        userId,
+        parentOrgGoalId: input.parentOrgGoalId ?? null,
+        title: input.title,
+        description: input.description ?? null,
+        goalType: input.goalType,
+        keyResult: input.keyResult ?? null,
+        targetValue: input.targetValue ?? null,
+        unit: input.unit ?? null,
+        status: 'DRAFT',
+        startDate: input.startDate,
+        endDate: input.endDate,
+      },
+    })
+    return toRecord(row)
+  }
+
+  async submitForApproval(goalId: string, requestedBy: string): Promise<PersonalGoalRecord> {
+    const current = await this.db.personalGoal.findUnique({ where: { id: goalId } })
+    if (!current) throw new PersonalGoalNotFoundError(goalId)
+
+    assertTransition(current.status as GoalStatus, 'PENDING_APPROVAL')
+
+    const updated = await this.db.personalGoal.update({
+      where: { id: goalId },
+      data: { status: 'PENDING_APPROVAL' },
+    })
+
+    await this.emitApprovalRequest(requestedBy, goalId, updated.title)
+
+    return toRecord(updated)
+  }
+
+  async approveGoal(goalId: string, approvedBy: string): Promise<PersonalGoalRecord> {
+    const current = await this.db.personalGoal.findUnique({ where: { id: goalId } })
+    if (!current) throw new PersonalGoalNotFoundError(goalId)
+
+    assertTransition(current.status as GoalStatus, 'APPROVED')
+
+    const now = this.clock()
+    const updated = await this.db.personalGoal.update({
+      where: { id: goalId },
+      data: { status: 'APPROVED', approvedBy, approvedAt: now },
+    })
+    return toRecord(updated)
+  }
+
+  async rejectGoal(
+    goalId: string,
+    rejectedBy: string,
+    reason: string,
+  ): Promise<PersonalGoalRecord> {
+    const current = await this.db.personalGoal.findUnique({ where: { id: goalId } })
+    if (!current) throw new PersonalGoalNotFoundError(goalId)
+
+    assertTransition(current.status as GoalStatus, 'REJECTED')
+
+    const now = this.clock()
+    const updated = await this.db.personalGoal.update({
+      where: { id: goalId },
+      data: {
+        status: 'REJECTED',
+        rejectedAt: now,
+        rejectedReason: reason,
+        approvedBy: rejectedBy,
+      },
+    })
+    return toRecord(updated)
+  }
+
+  async startGoal(goalId: string): Promise<PersonalGoalRecord> {
+    const current = await this.db.personalGoal.findUnique({ where: { id: goalId } })
+    if (!current) throw new PersonalGoalNotFoundError(goalId)
+
+    assertTransition(current.status as GoalStatus, 'IN_PROGRESS')
+
+    const updated = await this.db.personalGoal.update({
+      where: { id: goalId },
+      data: { status: 'IN_PROGRESS' },
+    })
+    return toRecord(updated)
+  }
+
+  async completeGoal(goalId: string): Promise<PersonalGoalRecord> {
+    const current = await this.db.personalGoal.findUnique({ where: { id: goalId } })
+    if (!current) throw new PersonalGoalNotFoundError(goalId)
+
+    assertTransition(current.status as GoalStatus, 'COMPLETED')
+
+    const updated = await this.db.personalGoal.update({
+      where: { id: goalId },
+      data: { status: 'COMPLETED' },
+    })
+    return toRecord(updated)
+  }
+
+  async listMyGoals(userId: string): Promise<PersonalGoalRecord[]> {
+    const rows = await this.db.personalGoal.findMany({
+      where: { userId },
+      orderBy: { createdAt: 'desc' },
+    })
+    return rows.map(toRecord)
+  }
+
+  async getGoal(goalId: string): Promise<PersonalGoalRecord | null> {
+    const row = await this.db.personalGoal.findUnique({ where: { id: goalId } })
+    return row ? toRecord(row) : null
+  }
+
+  // ─── private ──────────────────────────────────────────────────────────────
+
+  private async emitApprovalRequest(
+    requestedBy: string,
+    goalId: string,
+    goalTitle: string,
+  ): Promise<void> {
+    if (!this.notificationEmitter) return
+    const event: NotificationEvent = {
+      userId: requestedBy,
+      category: 'GOAL_APPROVAL_REQUEST',
+      title: '目標の承認依頼',
+      body: `「${goalTitle}」の承認をお願いします。`,
+      payload: { goalId },
+    }
+    try {
+      await this.notificationEmitter.emit(event)
+    } catch {
+      // 通知サービスが未初期化または失敗した場合は無視
+    }
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Factory
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function createPersonalGoalService(
+  db: PrismaClient,
+  notificationEmitter: NotificationEmitter | null = null,
+  clock: () => Date = () => new Date(),
+): PersonalGoalService {
+  return new PersonalGoalServiceImpl(db, notificationEmitter, clock)
+}

--- a/src/lib/goal/personal-goal-types.ts
+++ b/src/lib/goal/personal-goal-types.ts
@@ -1,0 +1,91 @@
+/**
+ * Issue #43 / Task 13.2: 個人目標登録と上長承認フロー — 型定義 (Req 6.3, 6.4, 6.5)
+ */
+import { z } from 'zod'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Enums
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const goalTypeSchema = z.enum(['OKR', 'MBO'])
+export const goalStatusSchema = z.enum([
+  'DRAFT',
+  'PENDING_APPROVAL',
+  'APPROVED',
+  'REJECTED',
+  'IN_PROGRESS',
+  'COMPLETED',
+])
+
+export type GoalType = z.infer<typeof goalTypeSchema>
+export type GoalStatus = z.infer<typeof goalStatusSchema>
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Input schema
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const personalGoalInputSchema = z.object({
+  title: z.string().min(1).max(200),
+  description: z.string().optional(),
+  goalType: goalTypeSchema,
+  /** OKR用: Key Result の説明 */
+  keyResult: z.string().optional(),
+  /** MBO用: 定量目標値 */
+  targetValue: z.number().optional(),
+  unit: z.string().optional(),
+  parentOrgGoalId: z.string().optional(),
+  startDate: z.coerce.date(),
+  endDate: z.coerce.date(),
+})
+
+export type PersonalGoalInput = z.infer<typeof personalGoalInputSchema>
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Domain record
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface PersonalGoalRecord {
+  id: string
+  userId: string
+  title: string
+  description: string | null
+  goalType: GoalType
+  keyResult: string | null
+  targetValue: number | null
+  unit: string | null
+  status: GoalStatus
+  parentOrgGoalId: string | null
+  startDate: Date
+  endDate: Date
+  approvedBy: string | null
+  approvedAt: Date | null
+  rejectedAt: Date | null
+  rejectedReason: string | null
+  createdAt: Date
+  updatedAt: Date
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Domain errors
+// ─────────────────────────────────────────────────────────────────────────────
+
+export class PersonalGoalNotFoundError extends Error {
+  constructor(goalId: string) {
+    super(`PersonalGoal not found: ${goalId}`)
+    this.name = 'PersonalGoalNotFoundError'
+  }
+}
+
+export class PersonalGoalInvalidTransitionError extends Error {
+  constructor(from: GoalStatus, to: string) {
+    super(`Invalid status transition: ${from} → ${to}`)
+    this.name = 'PersonalGoalInvalidTransitionError'
+  }
+}
+
+export class PersonalGoalAccessDeniedError extends Error {
+  constructor(message = 'Access denied') {
+    super(message)
+    this.name = 'PersonalGoalAccessDeniedError'
+  }
+}

--- a/src/tests/goal/personal-goal-service.test.ts
+++ b/src/tests/goal/personal-goal-service.test.ts
@@ -1,0 +1,349 @@
+/**
+ * Issue #43 / Task 13.2: PersonalGoalService 単体テスト (Req 6.3, 6.4, 6.5)
+ *
+ * テスト対象:
+ * - DRAFT → PENDING_APPROVAL ステート遷移
+ * - 無効な遷移でエラー（例: DRAFT → APPROVED は不可）
+ * - 承認・却下フロー
+ * - 目標作成・一覧取得
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { createPersonalGoalService } from '@/lib/goal/personal-goal-service'
+import {
+  PersonalGoalNotFoundError,
+  PersonalGoalInvalidTransitionError,
+  type PersonalGoalRecord,
+} from '@/lib/goal/personal-goal-types'
+import type { NotificationEmitter } from '@/lib/notification/notification-emitter'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fixtures
+// ─────────────────────────────────────────────────────────────────────────────
+
+const FIXED_NOW = new Date('2026-04-19T09:00:00.000Z')
+
+function makeGoalRecord(overrides: Partial<PersonalGoalRecord> = {}): PersonalGoalRecord {
+  return {
+    id: 'goal-1',
+    userId: 'user-employee',
+    parentOrgGoalId: null,
+    title: 'Q2 売上目標達成',
+    description: null,
+    goalType: 'MBO',
+    keyResult: null,
+    targetValue: 100,
+    unit: '件',
+    status: 'DRAFT',
+    startDate: new Date('2026-04-01'),
+    endDate: new Date('2026-06-30'),
+    approvedBy: null,
+    approvedAt: null,
+    rejectedAt: null,
+    rejectedReason: null,
+    createdAt: FIXED_NOW,
+    updatedAt: FIXED_NOW,
+    ...overrides,
+  }
+}
+
+function makePrisma(goalRecord: PersonalGoalRecord) {
+  return {
+    personalGoal: {
+      create: vi.fn().mockResolvedValue(goalRecord),
+      findUnique: vi.fn().mockResolvedValue(goalRecord),
+      findMany: vi.fn().mockResolvedValue([goalRecord]),
+      update: vi.fn(),
+    },
+  }
+}
+
+function makeNotificationEmitter(): NotificationEmitter {
+  return { emit: vi.fn().mockResolvedValue(undefined) }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('PersonalGoalService', () => {
+  describe('createGoal', () => {
+    it('DRAFT ステータスで目標を作成する', async () => {
+      // Arrange
+      const record = makeGoalRecord({ status: 'DRAFT' })
+      const db = makePrisma(record)
+      const svc = createPersonalGoalService(db as never, null, () => FIXED_NOW)
+
+      // Act
+      const result = await svc.createGoal('user-employee', {
+        title: 'Q2 売上目標達成',
+        goalType: 'MBO',
+        targetValue: 100,
+        unit: '件',
+        startDate: new Date('2026-04-01'),
+        endDate: new Date('2026-06-30'),
+      })
+
+      // Assert
+      expect(result.status).toBe('DRAFT')
+      expect(result.title).toBe('Q2 売上目標達成')
+      expect(db.personalGoal.create).toHaveBeenCalledOnce()
+    })
+  })
+
+  describe('submitForApproval', () => {
+    it('DRAFT → PENDING_APPROVAL に遷移する', async () => {
+      // Arrange
+      const draftRecord = makeGoalRecord({ status: 'DRAFT' })
+      const pendingRecord = makeGoalRecord({ status: 'PENDING_APPROVAL' })
+      const db = makePrisma(draftRecord)
+      db.personalGoal.update.mockResolvedValue(pendingRecord)
+      const svc = createPersonalGoalService(db as never, null, () => FIXED_NOW)
+
+      // Act
+      const result = await svc.submitForApproval('goal-1', 'user-employee')
+
+      // Assert
+      expect(result.status).toBe('PENDING_APPROVAL')
+      expect(db.personalGoal.update).toHaveBeenCalledWith({
+        where: { id: 'goal-1' },
+        data: { status: 'PENDING_APPROVAL' },
+      })
+    })
+
+    it('承認依頼通知を送信する', async () => {
+      // Arrange
+      const draftRecord = makeGoalRecord({ status: 'DRAFT' })
+      const pendingRecord = makeGoalRecord({ status: 'PENDING_APPROVAL' })
+      const db = makePrisma(draftRecord)
+      db.personalGoal.update.mockResolvedValue(pendingRecord)
+      const emitter = makeNotificationEmitter()
+      const svc = createPersonalGoalService(db as never, emitter, () => FIXED_NOW)
+
+      // Act
+      await svc.submitForApproval('goal-1', 'user-employee')
+
+      // Assert
+      expect(emitter.emit).toHaveBeenCalledOnce()
+      expect(emitter.emit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          category: 'GOAL_APPROVAL_REQUEST',
+          userId: 'user-employee',
+        }),
+      )
+    })
+
+    it('通知が失敗しても遷移は成功する', async () => {
+      // Arrange
+      const draftRecord = makeGoalRecord({ status: 'DRAFT' })
+      const pendingRecord = makeGoalRecord({ status: 'PENDING_APPROVAL' })
+      const db = makePrisma(draftRecord)
+      db.personalGoal.update.mockResolvedValue(pendingRecord)
+      const failingEmitter: NotificationEmitter = {
+        emit: vi.fn().mockRejectedValue(new Error('Queue unavailable')),
+      }
+      const svc = createPersonalGoalService(db as never, failingEmitter, () => FIXED_NOW)
+
+      // Act & Assert — should not throw
+      await expect(svc.submitForApproval('goal-1', 'user-employee')).resolves.toMatchObject({
+        status: 'PENDING_APPROVAL',
+      })
+    })
+
+    it('存在しない目標に対して PersonalGoalNotFoundError をスローする', async () => {
+      // Arrange
+      const db = makePrisma(makeGoalRecord())
+      db.personalGoal.findUnique.mockResolvedValue(null)
+      const svc = createPersonalGoalService(db as never, null, () => FIXED_NOW)
+
+      // Act & Assert
+      await expect(svc.submitForApproval('no-such-id', 'user-employee')).rejects.toThrow(
+        PersonalGoalNotFoundError,
+      )
+    })
+
+    it('PENDING_APPROVAL 状態からは再申請できない（無効な遷移）', async () => {
+      // Arrange
+      const pendingRecord = makeGoalRecord({ status: 'PENDING_APPROVAL' })
+      const db = makePrisma(pendingRecord)
+      const svc = createPersonalGoalService(db as never, null, () => FIXED_NOW)
+
+      // Act & Assert
+      await expect(svc.submitForApproval('goal-1', 'user-employee')).rejects.toThrow(
+        PersonalGoalInvalidTransitionError,
+      )
+    })
+  })
+
+  describe('approveGoal', () => {
+    it('PENDING_APPROVAL → APPROVED に遷移し承認者を記録する', async () => {
+      // Arrange
+      const pendingRecord = makeGoalRecord({ status: 'PENDING_APPROVAL' })
+      const approvedRecord = makeGoalRecord({
+        status: 'APPROVED',
+        approvedBy: 'user-manager',
+        approvedAt: FIXED_NOW,
+      })
+      const db = makePrisma(pendingRecord)
+      db.personalGoal.update.mockResolvedValue(approvedRecord)
+      const svc = createPersonalGoalService(db as never, null, () => FIXED_NOW)
+
+      // Act
+      const result = await svc.approveGoal('goal-1', 'user-manager')
+
+      // Assert
+      expect(result.status).toBe('APPROVED')
+      expect(result.approvedBy).toBe('user-manager')
+      expect(result.approvedAt).toEqual(FIXED_NOW)
+    })
+
+    it('DRAFT 状態から直接 APPROVE はできない（無効な遷移）', async () => {
+      // Arrange
+      const draftRecord = makeGoalRecord({ status: 'DRAFT' })
+      const db = makePrisma(draftRecord)
+      const svc = createPersonalGoalService(db as never, null, () => FIXED_NOW)
+
+      // Act & Assert
+      await expect(svc.approveGoal('goal-1', 'user-manager')).rejects.toThrow(
+        PersonalGoalInvalidTransitionError,
+      )
+    })
+  })
+
+  describe('rejectGoal', () => {
+    it('PENDING_APPROVAL → REJECTED に遷移し却下理由を記録する', async () => {
+      // Arrange
+      const pendingRecord = makeGoalRecord({ status: 'PENDING_APPROVAL' })
+      const rejectedRecord = makeGoalRecord({
+        status: 'REJECTED',
+        rejectedAt: FIXED_NOW,
+        rejectedReason: '目標が具体的でない',
+      })
+      const db = makePrisma(pendingRecord)
+      db.personalGoal.update.mockResolvedValue(rejectedRecord)
+      const svc = createPersonalGoalService(db as never, null, () => FIXED_NOW)
+
+      // Act
+      const result = await svc.rejectGoal('goal-1', 'user-manager', '目標が具体的でない')
+
+      // Assert
+      expect(result.status).toBe('REJECTED')
+      expect(result.rejectedReason).toBe('目標が具体的でない')
+      expect(result.rejectedAt).toEqual(FIXED_NOW)
+    })
+
+    it('APPROVED 状態から REJECT はできない（無効な遷移）', async () => {
+      // Arrange
+      const approvedRecord = makeGoalRecord({ status: 'APPROVED' })
+      const db = makePrisma(approvedRecord)
+      const svc = createPersonalGoalService(db as never, null, () => FIXED_NOW)
+
+      // Act & Assert
+      await expect(svc.rejectGoal('goal-1', 'user-manager', 'reason')).rejects.toThrow(
+        PersonalGoalInvalidTransitionError,
+      )
+    })
+  })
+
+  describe('startGoal', () => {
+    it('APPROVED → IN_PROGRESS に遷移する', async () => {
+      // Arrange
+      const approvedRecord = makeGoalRecord({ status: 'APPROVED' })
+      const inProgressRecord = makeGoalRecord({ status: 'IN_PROGRESS' })
+      const db = makePrisma(approvedRecord)
+      db.personalGoal.update.mockResolvedValue(inProgressRecord)
+      const svc = createPersonalGoalService(db as never, null, () => FIXED_NOW)
+
+      // Act
+      const result = await svc.startGoal('goal-1')
+
+      // Assert
+      expect(result.status).toBe('IN_PROGRESS')
+    })
+
+    it('DRAFT 状態から IN_PROGRESS はできない（無効な遷移）', async () => {
+      // Arrange
+      const draftRecord = makeGoalRecord({ status: 'DRAFT' })
+      const db = makePrisma(draftRecord)
+      const svc = createPersonalGoalService(db as never, null, () => FIXED_NOW)
+
+      // Act & Assert
+      await expect(svc.startGoal('goal-1')).rejects.toThrow(PersonalGoalInvalidTransitionError)
+    })
+  })
+
+  describe('completeGoal', () => {
+    it('IN_PROGRESS → COMPLETED に遷移する', async () => {
+      // Arrange
+      const inProgressRecord = makeGoalRecord({ status: 'IN_PROGRESS' })
+      const completedRecord = makeGoalRecord({ status: 'COMPLETED' })
+      const db = makePrisma(inProgressRecord)
+      db.personalGoal.update.mockResolvedValue(completedRecord)
+      const svc = createPersonalGoalService(db as never, null, () => FIXED_NOW)
+
+      // Act
+      const result = await svc.completeGoal('goal-1')
+
+      // Assert
+      expect(result.status).toBe('COMPLETED')
+    })
+
+    it('APPROVED 状態から直接 COMPLETE はできない（IN_PROGRESS が必要）', async () => {
+      // Arrange
+      const approvedRecord = makeGoalRecord({ status: 'APPROVED' })
+      const db = makePrisma(approvedRecord)
+      const svc = createPersonalGoalService(db as never, null, () => FIXED_NOW)
+
+      // Act & Assert
+      await expect(svc.completeGoal('goal-1')).rejects.toThrow(PersonalGoalInvalidTransitionError)
+    })
+  })
+
+  describe('listMyGoals', () => {
+    it('指定ユーザーの目標一覧を返す', async () => {
+      // Arrange
+      const records = [makeGoalRecord(), makeGoalRecord({ id: 'goal-2', title: '別の目標' })]
+      const db = makePrisma(makeGoalRecord())
+      db.personalGoal.findMany.mockResolvedValue(records)
+      const svc = createPersonalGoalService(db as never, null, () => FIXED_NOW)
+
+      // Act
+      const result = await svc.listMyGoals('user-employee')
+
+      // Assert
+      expect(result).toHaveLength(2)
+      expect(db.personalGoal.findMany).toHaveBeenCalledWith({
+        where: { userId: 'user-employee' },
+        orderBy: { createdAt: 'desc' },
+      })
+    })
+  })
+
+  describe('getGoal', () => {
+    it('存在する目標を返す', async () => {
+      // Arrange
+      const record = makeGoalRecord()
+      const db = makePrisma(record)
+      const svc = createPersonalGoalService(db as never, null, () => FIXED_NOW)
+
+      // Act
+      const result = await svc.getGoal('goal-1')
+
+      // Assert
+      expect(result).not.toBeNull()
+      expect(result?.id).toBe('goal-1')
+    })
+
+    it('存在しない目標は null を返す', async () => {
+      // Arrange
+      const db = makePrisma(makeGoalRecord())
+      db.personalGoal.findUnique.mockResolvedValue(null)
+      const svc = createPersonalGoalService(db as never, null, () => FIXED_NOW)
+
+      // Act
+      const result = await svc.getGoal('no-such-id')
+
+      // Assert
+      expect(result).toBeNull()
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- 個人目標の登録と承認ステートマシンを実装（Req 6.3, 6.4, 6.5）
- 遷移: DRAFT → PENDING_APPROVAL → APPROVED/REJECTED → IN_PROGRESS → COMPLETED
- 承認申請時に MANAGER へ `GOAL_APPROVAL_REQUEST` 通知を送信

## 追加ファイル
- `prisma/schema.prisma` — OrgGoal/PersonalGoal/GoalProgressHistory追加（#42と同一内容）
- `src/lib/goal/personal-goal-types.ts` — Zodスキーマ・型・ドメインエラー
- `src/lib/goal/personal-goal-service.ts` — 承認ステートマシン実装
- `src/lib/goal/personal-goal-service-di.ts` — DI
- `src/app/api/goals/personal/route.ts` — POST・GET
- `src/app/api/goals/personal/[id]/submit|approve|reject|start|complete/route.ts` — 各アクション
- `src/tests/goal/personal-goal-service.test.ts` — 17件テスト全通過

## マージ順序の注意
**PR #128（#42）を先にマージ**してからこのPRをマージしてください（スキーマ競合を回避）。

## Test plan
- [ ] DRAFT→PENDING_APPROVAL→APPROVED→IN_PROGRESS→COMPLETEDの遷移確認
- [ ] 無効な遷移（DRAFT→APPROVED）→ エラー
- [ ] MANAGER以外が approve → 403

Closes #43