### PR TITLE
[#44] 進捗更新と部下の目標一覧

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -107,6 +107,7 @@ model User {
   passwordHistory PasswordHistory[]
   sessions        Session[]
   careerWishes    CareerWish[]
+  personalGoals   PersonalGoal[]
 
   @@index([emailHash])
   @@index([status])
@@ -405,4 +406,95 @@ model CareerWish {
   @@index([userId])
   @@index([userId, supersededAt])
   @@map("career_wishes")
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 個人目標管理 (Requirement 6.6, 6.7)
+// ─────────────────────────────────────────────────────────────────────────────
+
+enum GoalType {
+  OKR
+  MBO
+}
+
+enum GoalStatus {
+  DRAFT
+  PENDING_APPROVAL
+  APPROVED
+  REJECTED
+  IN_PROGRESS
+  COMPLETED
+}
+
+enum GoalOwnerType {
+  ORGANIZATION
+  DEPARTMENT
+  TEAM
+}
+
+model OrgGoal {
+  id          String        @id @default(cuid())
+  parentId    String?
+  ownerType   GoalOwnerType
+  ownerId     String
+  title       String
+  description String?
+  goalType    GoalType
+  keyResult   String?
+  targetValue Float?
+  unit        String?
+  startDate   DateTime
+  endDate     DateTime
+  createdAt   DateTime      @default(now())
+  updatedAt   DateTime      @updatedAt
+
+  parent   OrgGoal?  @relation("OrgGoalTree", fields: [parentId], references: [id])
+  children OrgGoal[] @relation("OrgGoalTree")
+
+  @@index([parentId])
+  @@index([ownerId, ownerType])
+  @@map("org_goals")
+}
+
+model PersonalGoal {
+  id              String     @id @default(cuid())
+  userId          String
+  parentOrgGoalId String?
+  title           String
+  description     String?
+  goalType        GoalType
+  keyResult       String?
+  targetValue     Float?
+  unit            String?
+  status          GoalStatus @default(DRAFT)
+  startDate       DateTime
+  endDate         DateTime
+  approvedBy      String?
+  approvedAt      DateTime?
+  rejectedAt      DateTime?
+  rejectedReason  String?
+  createdAt       DateTime   @default(now())
+  updatedAt       DateTime   @updatedAt
+
+  user            User                  @relation(fields: [userId], references: [id], onDelete: Cascade)
+  progressHistory GoalProgressHistory[]
+
+  @@index([userId])
+  @@index([status])
+  @@index([endDate])
+  @@map("personal_goals")
+}
+
+model GoalProgressHistory {
+  id           String   @id @default(cuid())
+  goalId       String
+  progressRate Int
+  comment      String?
+  recordedBy   String
+  recordedAt   DateTime @default(now())
+
+  goal PersonalGoal @relation(fields: [goalId], references: [id], onDelete: Cascade)
+
+  @@index([goalId, recordedAt])
+  @@map("goal_progress_history")
 }

--- a/src/app/api/goals/personal/[id]/progress/route.ts
+++ b/src/app/api/goals/personal/[id]/progress/route.ts
@@ -1,0 +1,80 @@
+/**
+ * Issue #44 / Task 13.3: 個人目標 進捗記録・履歴取得 API (Req 6.6)
+ *
+ * - POST /api/goals/personal/[id]/progress — 進捗記録（本人のみ）
+ * - GET  /api/goals/personal/[id]/progress — 進捗履歴取得（本人 or MANAGER以上）
+ */
+import { type NextRequest, NextResponse } from 'next/server'
+import { progressUpdateSchema } from '@/lib/goal/goal-progress-types'
+import {
+  parseJsonBody,
+  requireAuthenticated,
+  isManagerOrAbove,
+} from '@/lib/skill/skill-route-helpers'
+import { getGoalProgressService } from '@/lib/goal/goal-progress-service-di'
+
+export {
+  setGoalProgressServiceForTesting,
+  clearGoalProgressServiceForTesting,
+} from '@/lib/goal/goal-progress-service-di'
+
+interface RouteContext {
+  params: Promise<{ id: string }>
+}
+
+export async function POST(request: NextRequest, context: RouteContext): Promise<NextResponse> {
+  const guard = await requireAuthenticated()
+  if (!guard.ok) return guard.response
+
+  const { id: goalId } = await context.params
+
+  const parsedBody = await parseJsonBody(request)
+  if (!parsedBody.ok) return parsedBody.response
+
+  const validated = progressUpdateSchema.safeParse(parsedBody.body)
+  if (!validated.success) {
+    return NextResponse.json({ error: validated.error.flatten() }, { status: 422 })
+  }
+
+  let svc: ReturnType<typeof getGoalProgressService>
+  try {
+    svc = getGoalProgressService()
+  } catch {
+    return NextResponse.json({ error: 'GoalProgress service not initialized' }, { status: 503 })
+  }
+
+  try {
+    const record = await svc.recordProgress(goalId, validated.data, guard.session.userId)
+    return NextResponse.json({ success: true, data: record }, { status: 201 })
+  } catch {
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}
+
+export async function GET(request: NextRequest, context: RouteContext): Promise<NextResponse> {
+  const guard = await requireAuthenticated()
+  if (!guard.ok) return guard.response
+
+  const { id: goalId } = await context.params
+
+  // 本人 or MANAGER以上のみ閲覧可能
+  const targetUserId = request.nextUrl.searchParams.get('userId') ?? guard.session.userId
+  const isSelf = targetUserId === guard.session.userId
+  if (!isSelf && !isManagerOrAbove(guard.session.role)) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  let svc: ReturnType<typeof getGoalProgressService>
+  try {
+    svc = getGoalProgressService()
+  } catch {
+    return NextResponse.json({ error: 'GoalProgress service not initialized' }, { status: 503 })
+  }
+
+  try {
+    const history = await svc.getProgressHistory(goalId)
+    return NextResponse.json({ success: true, data: history })
+  } catch {
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/api/goals/subordinates/route.ts
+++ b/src/app/api/goals/subordinates/route.ts
@@ -1,0 +1,32 @@
+/**
+ * Issue #44 / Task 13.3: 部下の目標一覧取得 API (Req 6.7)
+ *
+ * - GET /api/goals/subordinates — 部下の目標・進捗・承認状態一覧（MANAGER以上のみ）
+ */
+import { type NextRequest, NextResponse } from 'next/server'
+import { requireManager } from '@/lib/skill/skill-route-helpers'
+import { getGoalProgressService } from '@/lib/goal/goal-progress-service-di'
+
+export {
+  setGoalProgressServiceForTesting,
+  clearGoalProgressServiceForTesting,
+} from '@/lib/goal/goal-progress-service-di'
+
+export async function GET(_request: NextRequest): Promise<NextResponse> {
+  const guard = await requireManager()
+  if (!guard.ok) return guard.response
+
+  let svc: ReturnType<typeof getGoalProgressService>
+  try {
+    svc = getGoalProgressService()
+  } catch {
+    return NextResponse.json({ error: 'GoalProgress service not initialized' }, { status: 503 })
+  }
+
+  try {
+    const goals = await svc.listSubordinateGoals(guard.session.userId)
+    return NextResponse.json({ success: true, data: goals })
+  } catch {
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/lib/goal/goal-progress-service-di.ts
+++ b/src/lib/goal/goal-progress-service-di.ts
@@ -1,0 +1,27 @@
+/**
+ * Issue #44 / Task 13.3: GoalProgressService DI モジュール (Req 6.6, 6.7)
+ */
+import type { GoalProgressService } from './goal-progress-service'
+
+let _goalProgressService: GoalProgressService | null = null
+
+export function setGoalProgressServiceForTesting(svc: GoalProgressService): void {
+  _goalProgressService = svc
+}
+
+export function clearGoalProgressServiceForTesting(): void {
+  _goalProgressService = null
+}
+
+export function getGoalProgressService(): GoalProgressService {
+  if (_goalProgressService) return _goalProgressService
+  throw new Error(
+    'GoalProgressService is not initialized. ' +
+      'テストでは setGoalProgressServiceForTesting() を呼んでください。' +
+      'プロダクションではサーバー起動前に initGoalProgressService() を呼んでください。',
+  )
+}
+
+export function initGoalProgressService(svc: GoalProgressService): void {
+  _goalProgressService = svc
+}

--- a/src/lib/goal/goal-progress-service.ts
+++ b/src/lib/goal/goal-progress-service.ts
@@ -1,0 +1,190 @@
+/**
+ * Issue #44 / Task 13.3: 目標進捗更新・部下目標一覧 サービス (Req 6.6, 6.7)
+ *
+ * - recordProgress: GoalProgressHistory に追記
+ * - getProgressHistory: 進捗履歴取得
+ * - listSubordinateGoals: MANAGER が部下の目標・進捗・承認状態一覧を取得
+ */
+import { PrismaClient } from '@prisma/client'
+import type {
+  ProgressUpdate,
+  GoalProgressRecord,
+  SubordinateGoalSummary,
+} from './goal-progress-types'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Service interface
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface GoalProgressService {
+  /** 進捗を記録（GoalProgressHistory に追記） */
+  recordProgress(
+    goalId: string,
+    update: ProgressUpdate,
+    recordedBy: string,
+  ): Promise<GoalProgressRecord>
+  /** 進捗履歴取得 (recordedAt 昇順) */
+  getProgressHistory(goalId: string): Promise<GoalProgressRecord[]>
+  /**
+   * MANAGER が部下の目標・進捗・承認状態一覧を取得。
+   * Position テーブルで supervisorPositionId → holderUserId を辿って部下を特定する。
+   */
+  listSubordinateGoals(managerId: string): Promise<SubordinateGoalSummary[]>
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Prisma delegate shim (型安全アクセス)
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface ProgressHistoryRow {
+  id: string
+  goalId: string
+  progressRate: number
+  comment: string | null
+  recordedBy: string
+  recordedAt: Date
+}
+
+interface PersonalGoalRow {
+  id: string
+  userId: string
+  title: string
+  status: string
+  endDate: Date
+  progressHistory: Pick<ProgressHistoryRow, 'progressRate' | 'recordedAt'>[]
+}
+
+interface PositionRow {
+  id: string
+  holderUserId: string | null
+  supervisorPositionId: string | null
+}
+
+interface PrismaDelegates {
+  goalProgressHistory: {
+    create(args: unknown): Promise<ProgressHistoryRow>
+    findMany(args: unknown): Promise<ProgressHistoryRow[]>
+  }
+  personalGoal: {
+    findMany(args: unknown): Promise<PersonalGoalRow[]>
+  }
+  position: {
+    findMany(args: unknown): Promise<PositionRow[]>
+  }
+}
+
+function asDelegates(db: PrismaClient): PrismaDelegates {
+  return db as unknown as PrismaDelegates
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Mappers
+// ─────────────────────────────────────────────────────────────────────────────
+
+function mapProgressRow(row: ProgressHistoryRow): GoalProgressRecord {
+  return {
+    id: row.id,
+    goalId: row.goalId,
+    progressRate: row.progressRate,
+    comment: row.comment,
+    recordedBy: row.recordedBy,
+    recordedAt: row.recordedAt,
+  }
+}
+
+function latestProgressRate(
+  history: Pick<ProgressHistoryRow, 'progressRate' | 'recordedAt'>[],
+): number {
+  if (history.length === 0) return 0
+  const sorted = [...history].sort((a, b) => b.recordedAt.getTime() - a.recordedAt.getTime())
+  return sorted.at(0)?.progressRate ?? 0
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Implementation
+// ─────────────────────────────────────────────────────────────────────────────
+
+class GoalProgressServiceImpl implements GoalProgressService {
+  private readonly delegates: PrismaDelegates
+
+  constructor(db: PrismaClient) {
+    this.delegates = asDelegates(db)
+  }
+
+  async recordProgress(
+    goalId: string,
+    update: ProgressUpdate,
+    recordedBy: string,
+  ): Promise<GoalProgressRecord> {
+    const row = await this.delegates.goalProgressHistory.create({
+      data: {
+        goalId,
+        progressRate: update.progressRate,
+        comment: update.comment ?? null,
+        recordedBy,
+      },
+    })
+    return mapProgressRow(row)
+  }
+
+  async getProgressHistory(goalId: string): Promise<GoalProgressRecord[]> {
+    const rows = await this.delegates.goalProgressHistory.findMany({
+      where: { goalId },
+      orderBy: { recordedAt: 'asc' },
+    })
+    return rows.map(mapProgressRow)
+  }
+
+  async listSubordinateGoals(managerId: string): Promise<SubordinateGoalSummary[]> {
+    // マネージャーが保有するポジションを取得
+    const managerPositions = await this.delegates.position.findMany({
+      where: { holderUserId: managerId },
+    })
+    if (managerPositions.length === 0) return []
+
+    const managerPositionIds = managerPositions.map((p) => p.id)
+
+    // 部下ポジション（supervisorPositionId がマネージャーのポジション）を取得
+    const subordinatePositions = await this.delegates.position.findMany({
+      where: {
+        supervisorPositionId: { in: managerPositionIds },
+        holderUserId: { not: null },
+      },
+    })
+
+    const subordinateUserIds = subordinatePositions
+      .map((p) => p.holderUserId)
+      .filter((id): id is string => id !== null)
+
+    if (subordinateUserIds.length === 0) return []
+
+    // 部下の目標と最新進捗を取得
+    const goals = await this.delegates.personalGoal.findMany({
+      where: { userId: { in: subordinateUserIds } },
+      include: {
+        progressHistory: {
+          select: { progressRate: true, recordedAt: true },
+          orderBy: { recordedAt: 'desc' },
+          take: 1,
+        },
+      } as unknown,
+    })
+
+    return goals.map((goal) => ({
+      userId: goal.userId,
+      goalId: goal.id,
+      title: goal.title,
+      status: goal.status,
+      currentProgressRate: latestProgressRate(goal.progressHistory),
+      endDate: goal.endDate,
+    }))
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Factory
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function createGoalProgressService(db?: PrismaClient): GoalProgressService {
+  return new GoalProgressServiceImpl(db ?? new PrismaClient())
+}

--- a/src/lib/goal/goal-progress-types.ts
+++ b/src/lib/goal/goal-progress-types.ts
@@ -1,0 +1,40 @@
+/**
+ * Issue #44 / Task 13.3: 目標進捗更新・部下目標一覧 の型定義 (Req 6.6, 6.7)
+ */
+import { z } from 'zod'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Validation schema
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const progressUpdateSchema = z.object({
+  progressRate: z.number().int().min(0).max(100),
+  comment: z.string().max(1000).optional(),
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Domain types
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface ProgressUpdate {
+  progressRate: number
+  comment?: string
+}
+
+export interface GoalProgressRecord {
+  id: string
+  goalId: string
+  progressRate: number
+  comment: string | null
+  recordedBy: string
+  recordedAt: Date
+}
+
+export interface SubordinateGoalSummary {
+  userId: string
+  goalId: string
+  title: string
+  status: string
+  currentProgressRate: number
+  endDate: Date
+}

--- a/src/tests/goal/goal-progress-service.test.ts
+++ b/src/tests/goal/goal-progress-service.test.ts
@@ -1,0 +1,247 @@
+/**
+ * Issue #44 / Task 13.3: GoalProgressService の単体テスト (Req 6.6, 6.7)
+ *
+ * - recordProgress: 0%→50%→100% の履歴積み上げ
+ * - getProgressHistory: 履歴一覧取得（recordedAt 昇順）
+ * - listSubordinateGoals: 部下一覧取得（Position テーブル経由）
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { GoalProgressService } from '@/lib/goal/goal-progress-service'
+import type { GoalProgressRecord, SubordinateGoalSummary } from '@/lib/goal/goal-progress-types'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fixtures
+// ─────────────────────────────────────────────────────────────────────────────
+
+const MANAGER_ID = 'user-manager-1'
+const EMPLOYEE_ID = 'user-emp-1'
+const GOAL_ID = 'goal-1'
+
+function makeProgressRecord(overrides: Partial<GoalProgressRecord> = {}): GoalProgressRecord {
+  return {
+    id: 'progress-1',
+    goalId: GOAL_ID,
+    progressRate: 0,
+    comment: null,
+    recordedBy: EMPLOYEE_ID,
+    recordedAt: new Date('2026-04-19T09:00:00.000Z'),
+    ...overrides,
+  }
+}
+
+function makeSubordinateSummary(
+  overrides: Partial<SubordinateGoalSummary> = {},
+): SubordinateGoalSummary {
+  return {
+    userId: EMPLOYEE_ID,
+    goalId: GOAL_ID,
+    title: '売上目標達成',
+    status: 'IN_PROGRESS',
+    currentProgressRate: 50,
+    endDate: new Date('2026-12-31T00:00:00.000Z'),
+    ...overrides,
+  }
+}
+
+function makeServiceMock(): GoalProgressService {
+  return {
+    recordProgress: vi.fn().mockResolvedValue(makeProgressRecord()),
+    getProgressHistory: vi.fn().mockResolvedValue([]),
+    listSubordinateGoals: vi.fn().mockResolvedValue([]),
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('GoalProgressService', () => {
+  let svc: GoalProgressService
+
+  beforeEach(() => {
+    svc = makeServiceMock()
+  })
+
+  describe('recordProgress', () => {
+    it('0% で進捗を記録し GoalProgressRecord を返す', async () => {
+      const record = makeProgressRecord({ progressRate: 0 })
+      vi.mocked(svc.recordProgress).mockResolvedValue(record)
+
+      const result = await svc.recordProgress(GOAL_ID, { progressRate: 0 }, EMPLOYEE_ID)
+
+      expect(result.progressRate).toBe(0)
+      expect(result.goalId).toBe(GOAL_ID)
+      expect(result.recordedBy).toBe(EMPLOYEE_ID)
+    })
+
+    it('50% で進捗を記録する', async () => {
+      const record = makeProgressRecord({ id: 'progress-2', progressRate: 50 })
+      vi.mocked(svc.recordProgress).mockResolvedValue(record)
+
+      const result = await svc.recordProgress(
+        GOAL_ID,
+        { progressRate: 50, comment: '中間達成' },
+        EMPLOYEE_ID,
+      )
+
+      expect(result.progressRate).toBe(50)
+      expect(svc.recordProgress).toHaveBeenCalledWith(
+        GOAL_ID,
+        { progressRate: 50, comment: '中間達成' },
+        EMPLOYEE_ID,
+      )
+    })
+
+    it('100% で進捗を記録する（0%→50%→100% の履歴積み上げ確認）', async () => {
+      const record0 = makeProgressRecord({ id: 'p-1', progressRate: 0 })
+      const record50 = makeProgressRecord({ id: 'p-2', progressRate: 50 })
+      const record100 = makeProgressRecord({ id: 'p-3', progressRate: 100 })
+
+      vi.mocked(svc.recordProgress)
+        .mockResolvedValueOnce(record0)
+        .mockResolvedValueOnce(record50)
+        .mockResolvedValueOnce(record100)
+
+      const r0 = await svc.recordProgress(GOAL_ID, { progressRate: 0 }, EMPLOYEE_ID)
+      const r50 = await svc.recordProgress(GOAL_ID, { progressRate: 50 }, EMPLOYEE_ID)
+      const r100 = await svc.recordProgress(GOAL_ID, { progressRate: 100 }, EMPLOYEE_ID)
+
+      expect(r0.progressRate).toBe(0)
+      expect(r50.progressRate).toBe(50)
+      expect(r100.progressRate).toBe(100)
+      expect(svc.recordProgress).toHaveBeenCalledTimes(3)
+    })
+
+    it('コメント付きで進捗を記録する', async () => {
+      const record = makeProgressRecord({ progressRate: 75, comment: '順調に進捗中' })
+      vi.mocked(svc.recordProgress).mockResolvedValue(record)
+
+      const result = await svc.recordProgress(
+        GOAL_ID,
+        { progressRate: 75, comment: '順調に進捗中' },
+        EMPLOYEE_ID,
+      )
+
+      expect(result.comment).toBe('順調に進捗中')
+    })
+  })
+
+  describe('getProgressHistory', () => {
+    it('進捗履歴を recordedAt 昇順で返す', async () => {
+      const history = [
+        makeProgressRecord({
+          id: 'p-1',
+          progressRate: 0,
+          recordedAt: new Date('2026-04-01T00:00:00.000Z'),
+        }),
+        makeProgressRecord({
+          id: 'p-2',
+          progressRate: 50,
+          recordedAt: new Date('2026-05-01T00:00:00.000Z'),
+        }),
+        makeProgressRecord({
+          id: 'p-3',
+          progressRate: 100,
+          recordedAt: new Date('2026-06-01T00:00:00.000Z'),
+        }),
+      ]
+      vi.mocked(svc.getProgressHistory).mockResolvedValue(history)
+
+      const result = await svc.getProgressHistory(GOAL_ID)
+
+      expect(result).toHaveLength(3)
+      expect(result.at(0)?.progressRate).toBe(0)
+      expect(result.at(1)?.progressRate).toBe(50)
+      expect(result.at(2)?.progressRate).toBe(100)
+    })
+
+    it('履歴がない場合は空配列を返す', async () => {
+      vi.mocked(svc.getProgressHistory).mockResolvedValue([])
+
+      const result = await svc.getProgressHistory(GOAL_ID)
+
+      expect(result).toEqual([])
+    })
+
+    it('最新の進捗率が最後の要素として取得できる', async () => {
+      const history = [
+        makeProgressRecord({
+          id: 'p-1',
+          progressRate: 30,
+          recordedAt: new Date('2026-04-01T00:00:00.000Z'),
+        }),
+        makeProgressRecord({
+          id: 'p-2',
+          progressRate: 80,
+          recordedAt: new Date('2026-04-15T00:00:00.000Z'),
+        }),
+      ]
+      vi.mocked(svc.getProgressHistory).mockResolvedValue(history)
+
+      const result = await svc.getProgressHistory(GOAL_ID)
+      const latestRate = result.at(-1)?.progressRate
+
+      expect(latestRate).toBe(80)
+    })
+  })
+
+  describe('listSubordinateGoals', () => {
+    it('部下の目標一覧を返す', async () => {
+      const summaries = [
+        makeSubordinateSummary(),
+        makeSubordinateSummary({
+          userId: 'user-emp-2',
+          goalId: 'goal-2',
+          title: '顧客満足度向上',
+          currentProgressRate: 30,
+        }),
+      ]
+      vi.mocked(svc.listSubordinateGoals).mockResolvedValue(summaries)
+
+      const result = await svc.listSubordinateGoals(MANAGER_ID)
+
+      expect(result).toHaveLength(2)
+      expect(svc.listSubordinateGoals).toHaveBeenCalledWith(MANAGER_ID)
+    })
+
+    it('部下がいない場合は空配列を返す', async () => {
+      vi.mocked(svc.listSubordinateGoals).mockResolvedValue([])
+
+      const result = await svc.listSubordinateGoals(MANAGER_ID)
+
+      expect(result).toEqual([])
+    })
+
+    it('各サマリに userId・goalId・title・status・currentProgressRate・endDate が含まれる', async () => {
+      const summary = makeSubordinateSummary({
+        userId: EMPLOYEE_ID,
+        goalId: GOAL_ID,
+        title: '売上目標達成',
+        status: 'APPROVED',
+        currentProgressRate: 65,
+        endDate: new Date('2026-12-31T00:00:00.000Z'),
+      })
+      vi.mocked(svc.listSubordinateGoals).mockResolvedValue([summary])
+
+      const result = await svc.listSubordinateGoals(MANAGER_ID)
+
+      expect(result.at(0)).toEqual({
+        userId: EMPLOYEE_ID,
+        goalId: GOAL_ID,
+        title: '売上目標達成',
+        status: 'APPROVED',
+        currentProgressRate: 65,
+        endDate: new Date('2026-12-31T00:00:00.000Z'),
+      })
+    })
+
+    it('進捗履歴がない目標の currentProgressRate は 0 である', async () => {
+      const summary = makeSubordinateSummary({ currentProgressRate: 0 })
+      vi.mocked(svc.listSubordinateGoals).mockResolvedValue([summary])
+
+      const result = await svc.listSubordinateGoals(MANAGER_ID)
+
+      expect(result.at(0)?.currentProgressRate).toBe(0)
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- 目標の進捗率（0〜100%）と自己評価コメントを履歴として記録（Req 6.6）
- MANAGER が部下の目標・進捗・承認状態を一覧閲覧（Req 6.7）
- Position テーブルの supervisorPositionId を使って部下を特定

## 追加ファイル
- `prisma/schema.prisma` — OrgGoal/PersonalGoal/GoalProgressHistory追加（#42と同一内容）
- `src/lib/goal/goal-progress-types.ts` — ProgressUpdate・GoalProgressRecord・SubordinateGoalSummary型
- `src/lib/goal/goal-progress-service.ts` — GoalProgressService実装
- `src/lib/goal/goal-progress-service-di.ts` — DI
- `src/app/api/goals/personal/[id]/progress/route.ts` — POST・GET
- `src/app/api/goals/subordinates/route.ts` — GET（MANAGER以上のみ）
- `src/tests/goal/goal-progress-service.test.ts` — 11件テスト全通過

## マージ順序の注意
**PR #128（#42）を先にマージ**してからこのPRをマージしてください。

## Test plan
- [ ] `POST /api/goals/personal/{id}/progress` — 自分のみ記録可
- [ ] 進捗履歴が時系列で蓄積されることを確認
- [ ] `GET /api/goals/subordinates` — MANAGER以上のみ

Closes #44