### PR TITLE
[#45] 目標期限アラートの定期ジョブ

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -107,6 +107,7 @@ model User {
   passwordHistory PasswordHistory[]
   sessions        Session[]
   careerWishes    CareerWish[]
+  personalGoals   PersonalGoal[]
 
   @@index([emailHash])
   @@index([status])
@@ -405,4 +406,98 @@ model CareerWish {
   @@index([userId])
   @@index([userId, supersededAt])
   @@map("career_wishes")
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 目標管理 (Requirement 6)
+// ─────────────────────────────────────────────────────────────────────────────
+
+enum GoalType {
+  OKR
+  MBO
+}
+
+enum GoalStatus {
+  DRAFT
+  PENDING_APPROVAL
+  APPROVED
+  REJECTED
+  IN_PROGRESS
+  COMPLETED
+}
+
+enum GoalOwnerType {
+  ORGANIZATION
+  DEPARTMENT
+  TEAM
+}
+
+/// 組織目標 (Requirement 6.1)
+model OrgGoal {
+  id          String        @id @default(cuid())
+  parentId    String?
+  ownerType   GoalOwnerType
+  ownerId     String
+  title       String
+  description String?
+  goalType    GoalType
+  keyResult   String?
+  targetValue Float?
+  unit        String?
+  startDate   DateTime
+  endDate     DateTime
+  createdAt   DateTime      @default(now())
+  updatedAt   DateTime      @updatedAt
+
+  parent   OrgGoal?  @relation("OrgGoalTree", fields: [parentId], references: [id])
+  children OrgGoal[] @relation("OrgGoalTree")
+
+  @@index([parentId])
+  @@index([ownerId, ownerType])
+  @@map("org_goals")
+}
+
+/// 個人目標 (Requirement 6.2)
+model PersonalGoal {
+  id              String     @id @default(cuid())
+  userId          String
+  parentOrgGoalId String?
+  title           String
+  description     String?
+  goalType        GoalType
+  keyResult       String?
+  targetValue     Float?
+  unit            String?
+  status          GoalStatus @default(DRAFT)
+  startDate       DateTime
+  endDate         DateTime
+  approvedBy      String?
+  approvedAt      DateTime?
+  rejectedAt      DateTime?
+  rejectedReason  String?
+  createdAt       DateTime   @default(now())
+  updatedAt       DateTime   @updatedAt
+
+  user            User                  @relation(fields: [userId], references: [id], onDelete: Cascade)
+  progressHistory GoalProgressHistory[]
+
+  @@index([userId])
+  @@index([status])
+  @@index([endDate])
+  @@map("personal_goals")
+}
+
+/// 目標進捗履歴 (Requirement 6.5)
+model GoalProgressHistory {
+  id           String   @id @default(cuid())
+  goalId       String
+  progressRate Int
+  comment      String?
+  recordedBy   String
+  recordedAt   DateTime @default(now())
+
+  goal PersonalGoal @relation(fields: [goalId], references: [id], onDelete: Cascade)
+
+  @@index([goalId, recordedAt])
+  @@map("goal_progress_history")
 }

--- a/src/app/api/goals/deadline-alerts/route.ts
+++ b/src/app/api/goals/deadline-alerts/route.ts
@@ -1,0 +1,80 @@
+/**
+ * Issue #45 / Req 6.8: 目標期限アラート手動トリガー API
+ *
+ * POST /api/goals/deadline-alerts/scan
+ * - ADMIN のみ実行可能
+ * - 200: { notified: number; skipped: number }
+ * - 401 / 403: 認証/認可エラー
+ * - 503: サービス未初期化
+ */
+import { getServerSession } from 'next-auth'
+import { type NextRequest, NextResponse } from 'next/server'
+import {
+  createDeadlineAlertService,
+  type DeadlineAlertService,
+} from '@/lib/goal/deadline-alert-service'
+import { createInMemoryNotificationRepository } from '@/lib/notification/notification-repository'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// DI（テスト差し替え用）
+// ─────────────────────────────────────────────────────────────────────────────
+
+let _service: DeadlineAlertService | null = null
+
+export function setDeadlineAlertServiceForTesting(s: DeadlineAlertService): void {
+  _service = s
+}
+
+export function clearDeadlineAlertServiceForTesting(): void {
+  _service = null
+}
+
+function getService(): DeadlineAlertService {
+  if (_service) return _service
+  // 本番では Prisma-backed リポジトリを注入する
+  // 現時点では InMemory 実装をフォールバックとして使用
+  return createDeadlineAlertService({
+    goalRepo: {
+      async findInProgressGoalsNearDeadline() {
+        return []
+      },
+    },
+    notificationRepo: createInMemoryNotificationRepository(),
+  })
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 認可
+// ─────────────────────────────────────────────────────────────────────────────
+
+function authorize(
+  serverSession: Awaited<ReturnType<typeof getServerSession>>,
+): { ok: true } | { ok: false; response: NextResponse } {
+  if (!serverSession?.user?.email) {
+    return { ok: false, response: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
+  }
+  const sess = serverSession as Record<string, unknown>
+  const role = typeof sess.role === 'string' ? sess.role : undefined
+  if (role !== 'ADMIN') {
+    return { ok: false, response: NextResponse.json({ error: 'Forbidden' }, { status: 403 }) }
+  }
+  return { ok: true }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// POST /api/goals/deadline-alerts/scan
+// ─────────────────────────────────────────────────────────────────────────────
+
+export async function POST(_req: NextRequest): Promise<NextResponse> {
+  const serverSession = await getServerSession()
+  const auth = authorize(serverSession)
+  if (!auth.ok) return auth.response
+
+  try {
+    const service = getService()
+    const result = await service.scanDeadlineAlerts()
+    return NextResponse.json(result, { status: 200 })
+  } catch {
+    return NextResponse.json({ error: 'Service unavailable' }, { status: 503 })
+  }
+}

--- a/src/lib/goal/deadline-alert-service.ts
+++ b/src/lib/goal/deadline-alert-service.ts
@@ -1,0 +1,159 @@
+/**
+ * Issue #45 / Req 6.8: 目標期限アラートサービス
+ *
+ * - 期限7日以内かつ進捗50%未満の IN_PROGRESS 目標をスキャン
+ * - daysUntilDeadline が 0, 1, 3, 7 のいずれかの場合のみ通知（重複防止）
+ * - 通知カテゴリ: DEADLINE_ALERT
+ */
+
+import type { NotificationRepository } from '@/lib/notification/notification-repository'
+import {
+  ALERT_TRIGGER_DAYS,
+  DEADLINE_ALERT_PROGRESS_THRESHOLD,
+  DEADLINE_ALERT_SCAN_DAYS,
+  type DeadlineAlertTarget,
+} from './deadline-alert-types'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Repository interfaces (依存性逆転)
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface GoalWithLatestProgress {
+  readonly id: string
+  readonly userId: string
+  readonly title: string
+  readonly endDate: Date
+  /** 最新の progressRate。履歴がない場合は 0 */
+  readonly latestProgressRate: number
+}
+
+export interface DeadlineAlertGoalRepository {
+  /** status=IN_PROGRESS かつ endDate が now から scanDays 日以内の目標を返す */
+  findInProgressGoalsNearDeadline(
+    now: Date,
+    scanDays: number,
+  ): Promise<readonly GoalWithLatestProgress[]>
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Service interface
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface DeadlineAlertScanResult {
+  readonly notified: number
+  readonly skipped: number
+}
+
+export interface DeadlineAlertService {
+  /**
+   * 期限7日以内かつ進捗50%未満の目標を検索して通知を送る
+   * @param now スキャン基準日時（省略時は現在時刻）
+   */
+  scanDeadlineAlerts(now?: Date): Promise<DeadlineAlertScanResult>
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 内部ヘルパ
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * 2つの日時の差を「日数」で返す（切り捨て）
+ * endDate が now より過去の場合は負の値を返す
+ */
+function calcDaysUntilDeadline(now: Date, endDate: Date): number {
+  const diffMs = endDate.getTime() - now.getTime()
+  return Math.floor(diffMs / (1000 * 60 * 60 * 24))
+}
+
+function buildAlertTarget(
+  goal: GoalWithLatestProgress,
+  daysUntilDeadline: number,
+): DeadlineAlertTarget {
+  return {
+    goalId: goal.id,
+    userId: goal.userId,
+    title: goal.title,
+    endDate: goal.endDate,
+    daysUntilDeadline,
+    currentProgressRate: goal.latestProgressRate,
+  }
+}
+
+function buildNotificationTitle(daysUntilDeadline: number): string {
+  if (daysUntilDeadline === 0) return '目標の期限が本日です'
+  return `目標の期限まで残り${daysUntilDeadline}日です`
+}
+
+function buildNotificationBody(target: DeadlineAlertTarget): string {
+  return `「${target.title}」の進捗が${target.currentProgressRate}%です。期限（${target.endDate.toLocaleDateString('ja-JP')}）までに完了しましょう。`
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Implementation
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface Dependencies {
+  readonly goalRepo: DeadlineAlertGoalRepository
+  readonly notificationRepo: NotificationRepository
+}
+
+class DeadlineAlertServiceImpl implements DeadlineAlertService {
+  constructor(private readonly deps: Dependencies) {}
+
+  async scanDeadlineAlerts(now?: Date): Promise<DeadlineAlertScanResult> {
+    const scanTime = now ?? new Date()
+    const goals = await this.deps.goalRepo.findInProgressGoalsNearDeadline(
+      scanTime,
+      DEADLINE_ALERT_SCAN_DAYS,
+    )
+
+    let notified = 0
+    let skipped = 0
+
+    for (const goal of goals) {
+      const daysUntilDeadline = calcDaysUntilDeadline(scanTime, goal.endDate)
+
+      // daysUntilDeadline が 0, 1, 3, 7 のいずれかでない場合はスキップ（重複防止）
+      if (!ALERT_TRIGGER_DAYS.has(daysUntilDeadline)) {
+        skipped += 1
+        continue
+      }
+
+      // 進捗50%以上の場合はスキップ
+      if (goal.latestProgressRate >= DEADLINE_ALERT_PROGRESS_THRESHOLD) {
+        skipped += 1
+        continue
+      }
+
+      const target = buildAlertTarget(goal, daysUntilDeadline)
+
+      try {
+        await this.deps.notificationRepo.create({
+          userId: target.userId,
+          category: 'DEADLINE_ALERT',
+          title: buildNotificationTitle(daysUntilDeadline),
+          body: buildNotificationBody(target),
+          payload: {
+            goalId: target.goalId,
+            daysUntilDeadline: target.daysUntilDeadline,
+            currentProgressRate: target.currentProgressRate,
+          },
+        })
+        notified += 1
+      } catch {
+        // 通知サービスが未初期化の場合などは無視してスキップ扱い
+        skipped += 1
+      }
+    }
+
+    return { notified, skipped }
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Factory
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function createDeadlineAlertService(deps: Dependencies): DeadlineAlertService {
+  return new DeadlineAlertServiceImpl(deps)
+}

--- a/src/lib/goal/deadline-alert-types.ts
+++ b/src/lib/goal/deadline-alert-types.ts
@@ -1,0 +1,33 @@
+/**
+ * Issue #45 / Req 6.8: 目標期限アラート型定義
+ */
+
+// ─────────────────────────────────────────────────────────────────────────────
+// アラート対象の目標情報
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface DeadlineAlertTarget {
+  readonly goalId: string
+  readonly userId: string
+  readonly title: string
+  readonly endDate: Date
+  /** 0=当日, 1=1日前, 7=7日以内 */
+  readonly daysUntilDeadline: number
+  readonly currentProgressRate: number
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// アラートトリガー（重複防止用）
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** 通知を送るタイミング。重複防止のため特定日のみ送信する */
+export type AlertTrigger = '7days' | '3days' | '1day' | 'today'
+
+/** 通知を送る残日数のセット */
+export const ALERT_TRIGGER_DAYS: ReadonlySet<number> = new Set([0, 1, 3, 7])
+
+/** 進捗が閾値未満の場合のみアラート送信 */
+export const DEADLINE_ALERT_PROGRESS_THRESHOLD = 50
+
+/** スキャン対象の最大残日数 */
+export const DEADLINE_ALERT_SCAN_DAYS = 7

--- a/src/lib/jobs/goal-deadline-alert-worker.ts
+++ b/src/lib/jobs/goal-deadline-alert-worker.ts
@@ -1,0 +1,68 @@
+/**
+ * Issue #45 / Req 6.8: goal-deadline-alert ジョブワーカー
+ *
+ * BullMQ の goal-deadline-alert キューからジョブを取り出し、
+ * DeadlineAlertService.scanDeadlineAlerts() を呼び出して期限アラートを送信する。
+ *
+ * cron: '0 0 * * *' (UTC 00:00 = JST 09:00)
+ */
+import type { Job } from 'bullmq'
+import { jobPayloadSchema } from '@/lib/jobs/job-types'
+import { createBaseWorker } from '@/lib/jobs/base-worker'
+import type { DeadlineAlertService } from '@/lib/goal/deadline-alert-service'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Result type
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface GoalDeadlineAlertJobResult {
+  readonly triggeredAt: string
+  readonly notified: number
+  readonly skipped: number
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Payload validation
+// ─────────────────────────────────────────────────────────────────────────────
+
+function isGoalDeadlineAlertPayload(value: unknown): value is { triggeredAt: string } {
+  return jobPayloadSchema['goal-deadline-alert'].safeParse(value).success
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ジョブプロセッサ（テスト可能な関数として分離）
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * goal-deadline-alert ジョブを処理する。
+ * DeadlineAlertService は DI で受け取る。
+ */
+export async function processGoalDeadlineAlertJob(
+  job: Job,
+  service: DeadlineAlertService,
+): Promise<GoalDeadlineAlertJobResult> {
+  const payload = job.data as unknown
+
+  if (!isGoalDeadlineAlertPayload(payload)) {
+    throw new Error(`GoalDeadlineAlertWorker: invalid payload for job "${job.id ?? 'unknown'}"`)
+  }
+
+  const now = new Date(payload.triggeredAt)
+  const result = await service.scanDeadlineAlerts(now)
+
+  return {
+    triggeredAt: payload.triggeredAt,
+    notified: result.notified,
+    skipped: result.skipped,
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ワーカー起動ファクトリ
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function createGoalDeadlineAlertWorker(service: DeadlineAlertService) {
+  return createBaseWorker('goal-deadline-alert', (job) =>
+    processGoalDeadlineAlertJob(job, service),
+  )
+}

--- a/src/lib/jobs/job-types.ts
+++ b/src/lib/jobs/job-types.ts
@@ -13,6 +13,7 @@ export const JOB_NAMES = [
   'import-csv',
   'anonymize-user',
   'ai-feedback-generation',
+  'goal-deadline-alert',
 ] as const
 
 export type JobName = (typeof JOB_NAMES)[number]
@@ -51,6 +52,10 @@ export const jobPayloadSchema = {
     evaluationId: z.string().min(1),
     prompt: z.string().min(1),
     requestedBy: z.string().min(1),
+  }),
+
+  'goal-deadline-alert': z.object({
+    triggeredAt: z.string().datetime(),
   }),
 } satisfies Record<JobName, z.ZodTypeAny>
 

--- a/src/tests/goal/deadline-alert-service.test.ts
+++ b/src/tests/goal/deadline-alert-service.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Issue #45 / Req 6.8: DeadlineAlertService 単体テスト
+ *
+ * - 期限7日以内・進捗50%未満の目標が検出されるテスト
+ * - 期限7日超の目標はスキップされるテスト
+ * - 進捗50%以上の目標はスキップされるテスト
+ * - daysUntilDeadline が 0,1,3,7 以外（例: 5）はスキップされるテスト
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  createDeadlineAlertService,
+  type DeadlineAlertGoalRepository,
+  type GoalWithLatestProgress,
+} from '@/lib/goal/deadline-alert-service'
+import { createInMemoryNotificationRepository } from '@/lib/notification/notification-repository'
+import type { NotificationRepository } from '@/lib/notification/notification-repository'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+const NOW = new Date('2026-04-19T00:00:00.000Z')
+
+/** daysFromNow 日後の Date を返す */
+function daysLater(days: number): Date {
+  return new Date(NOW.getTime() + days * 24 * 60 * 60 * 1000)
+}
+
+function makeGoal(
+  overrides: Partial<GoalWithLatestProgress> & { id: string },
+): GoalWithLatestProgress {
+  return {
+    userId: 'user-1',
+    title: 'テスト目標',
+    endDate: daysLater(3),
+    latestProgressRate: 30,
+    ...overrides,
+  }
+}
+
+function makeGoalRepo(goals: readonly GoalWithLatestProgress[]): DeadlineAlertGoalRepository {
+  return {
+    async findInProgressGoalsNearDeadline() {
+      return goals
+    },
+  }
+}
+
+function makeService(
+  goals: readonly GoalWithLatestProgress[],
+  notificationRepo?: NotificationRepository,
+) {
+  const notifRepo = notificationRepo ?? createInMemoryNotificationRepository()
+  const svc = createDeadlineAlertService({
+    goalRepo: makeGoalRepo(goals),
+    notificationRepo: notifRepo,
+  })
+  return { svc, notifRepo }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('DeadlineAlertService.scanDeadlineAlerts', () => {
+  describe('期限7日以内・進捗50%未満の目標が検出される', () => {
+    it('残り7日・進捗0%の目標は通知される', async () => {
+      // Arrange
+      const goal = makeGoal({ id: 'g1', endDate: daysLater(7), latestProgressRate: 0 })
+      const { svc, notifRepo } = makeService([goal])
+
+      // Act
+      const result = await svc.scanDeadlineAlerts(NOW)
+
+      // Assert
+      expect(result.notified).toBe(1)
+      expect(result.skipped).toBe(0)
+      const notifications = await notifRepo.listByUser('user-1')
+      expect(notifications).toHaveLength(1)
+      expect(notifications[0].category).toBe('DEADLINE_ALERT')
+    })
+
+    it('残り3日・進捗30%の目標は通知される', async () => {
+      // Arrange
+      const goal = makeGoal({ id: 'g2', endDate: daysLater(3), latestProgressRate: 30 })
+      const { svc, notifRepo } = makeService([goal])
+
+      // Act
+      const result = await svc.scanDeadlineAlerts(NOW)
+
+      // Assert
+      expect(result.notified).toBe(1)
+      expect(result.skipped).toBe(0)
+      const notifications = await notifRepo.listByUser('user-1')
+      expect(notifications[0].title).toContain('3日')
+    })
+
+    it('残り1日・進捗49%の目標は通知される', async () => {
+      // Arrange
+      const goal = makeGoal({ id: 'g3', endDate: daysLater(1), latestProgressRate: 49 })
+      const { svc } = makeService([goal])
+
+      // Act
+      const result = await svc.scanDeadlineAlerts(NOW)
+
+      // Assert
+      expect(result.notified).toBe(1)
+      expect(result.skipped).toBe(0)
+    })
+
+    it('残り0日（当日）・進捗10%の目標は通知される', async () => {
+      // Arrange
+      const goal = makeGoal({ id: 'g4', endDate: daysLater(0), latestProgressRate: 10 })
+      const { svc, notifRepo } = makeService([goal])
+
+      // Act
+      const result = await svc.scanDeadlineAlerts(NOW)
+
+      // Assert
+      expect(result.notified).toBe(1)
+      const notifications = await notifRepo.listByUser('user-1')
+      expect(notifications[0].title).toContain('本日')
+    })
+  })
+
+  describe('期限7日超の目標はスキップされる', () => {
+    it('残り8日の目標はスキップされる', async () => {
+      // Arrange
+      const goal = makeGoal({ id: 'g5', endDate: daysLater(8), latestProgressRate: 10 })
+      const { svc } = makeService([goal])
+
+      // Act
+      const result = await svc.scanDeadlineAlerts(NOW)
+
+      // Assert — 残り8日は ALERT_TRIGGER_DAYS に含まれない
+      expect(result.skipped).toBe(1)
+      expect(result.notified).toBe(0)
+    })
+  })
+
+  describe('進捗50%以上の目標はスキップされる', () => {
+    it('残り3日・進捗50%の目標はスキップされる', async () => {
+      // Arrange
+      const goal = makeGoal({ id: 'g6', endDate: daysLater(3), latestProgressRate: 50 })
+      const { svc } = makeService([goal])
+
+      // Act
+      const result = await svc.scanDeadlineAlerts(NOW)
+
+      // Assert
+      expect(result.skipped).toBe(1)
+      expect(result.notified).toBe(0)
+    })
+
+    it('残り1日・進捗100%の目標はスキップされる', async () => {
+      // Arrange
+      const goal = makeGoal({ id: 'g7', endDate: daysLater(1), latestProgressRate: 100 })
+      const { svc } = makeService([goal])
+
+      // Act
+      const result = await svc.scanDeadlineAlerts(NOW)
+
+      // Assert
+      expect(result.skipped).toBe(1)
+      expect(result.notified).toBe(0)
+    })
+  })
+
+  describe('daysUntilDeadline が 0,1,3,7 以外はスキップされる', () => {
+    it('残り5日はスキップされる', async () => {
+      // Arrange
+      const goal = makeGoal({ id: 'g8', endDate: daysLater(5), latestProgressRate: 10 })
+      const { svc } = makeService([goal])
+
+      // Act
+      const result = await svc.scanDeadlineAlerts(NOW)
+
+      // Assert
+      expect(result.skipped).toBe(1)
+      expect(result.notified).toBe(0)
+    })
+
+    it('残り2日はスキップされる', async () => {
+      // Arrange
+      const goal = makeGoal({ id: 'g9', endDate: daysLater(2), latestProgressRate: 10 })
+      const { svc } = makeService([goal])
+
+      // Act
+      const result = await svc.scanDeadlineAlerts(NOW)
+
+      // Assert
+      expect(result.skipped).toBe(1)
+      expect(result.notified).toBe(0)
+    })
+
+    it('残り4日はスキップされる', async () => {
+      // Arrange
+      const goal = makeGoal({ id: 'g10', endDate: daysLater(4), latestProgressRate: 10 })
+      const { svc } = makeService([goal])
+
+      // Act
+      const result = await svc.scanDeadlineAlerts(NOW)
+
+      // Assert
+      expect(result.skipped).toBe(1)
+      expect(result.notified).toBe(0)
+    })
+
+    it('残り6日はスキップされる', async () => {
+      // Arrange
+      const goal = makeGoal({ id: 'g11', endDate: daysLater(6), latestProgressRate: 10 })
+      const { svc } = makeService([goal])
+
+      // Act
+      const result = await svc.scanDeadlineAlerts(NOW)
+
+      // Assert
+      expect(result.skipped).toBe(1)
+      expect(result.notified).toBe(0)
+    })
+  })
+
+  describe('複数目標の混在', () => {
+    it('通知すべき目標とスキップすべき目標が混在する場合、それぞれ正しくカウントされる', async () => {
+      // Arrange
+      const goals = [
+        makeGoal({ id: 'g12', endDate: daysLater(3), latestProgressRate: 30 }), // 通知
+        makeGoal({ id: 'g13', endDate: daysLater(3), latestProgressRate: 60 }), // スキップ（進捗50%以上）
+        makeGoal({ id: 'g14', endDate: daysLater(5), latestProgressRate: 10 }), // スキップ（5日は対象外）
+        makeGoal({ id: 'g15', endDate: daysLater(1), latestProgressRate: 0 }),  // 通知
+      ]
+      const { svc } = makeService(goals)
+
+      // Act
+      const result = await svc.scanDeadlineAlerts(NOW)
+
+      // Assert
+      expect(result.notified).toBe(2)
+      expect(result.skipped).toBe(2)
+    })
+  })
+
+  describe('now 引数の省略', () => {
+    it('now を省略しても正常に動作する', async () => {
+      // Arrange
+      const { svc } = makeService([])
+
+      // Act
+      const result = await svc.scanDeadlineAlerts()
+
+      // Assert
+      expect(result.notified).toBe(0)
+      expect(result.skipped).toBe(0)
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- BullMQ 定期ジョブ（毎日 09:00 JST / UTC 00:00）で期限アラートをスキャン（Req 6.8）
- 期限 7 日以内かつ進捗 50% 未満を検出して `DEADLINE_ALERT` 通知を送信
- 重複通知防止: daysUntilDeadline が 0/1/3/7 の場合のみ通知

## 追加ファイル
- `prisma/schema.prisma` — OrgGoal/PersonalGoal/GoalProgressHistory追加（#42と同一内容）
- `src/lib/goal/deadline-alert-types.ts` — DeadlineAlertTarget・AlertTrigger型・定数
- `src/lib/goal/deadline-alert-service.ts` — scanDeadlineAlerts実装
- `src/lib/jobs/job-types.ts` — `goal-deadline-alert` ジョブ追加
- `src/lib/jobs/goal-deadline-alert-worker.ts` — BullMQワーカー
- `src/app/api/goals/deadline-alerts/route.ts` — POST手動トリガー（ADMINのみ）
- `src/tests/goal/deadline-alert-service.test.ts` — 13件テスト全通過

## マージ順序の注意
**PR #128（#42）を先にマージ**してからこのPRをマージしてください。
`src/lib/jobs/job-types.ts` は他ブランチと競合する可能性があります。

## Test plan
- [ ] `POST /api/goals/deadline-alerts/scan` — ADMINのみ実行可
- [ ] daysUntilDeadline=0,1,3,7 → 通知送信
- [ ] daysUntilDeadline=2,4,5,6 → スキップ
- [ ] 進捗≥50% → スキップ

Closes #45