### PR TITLE
[#46] 評価サイクルとの目標達成率連携

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -103,11 +103,12 @@ model User {
   anonymizedAt     DateTime?
 
   // Relations
-  profile         Profile?
-  passwordHistory PasswordHistory[]
-  sessions        Session[]
-  careerWishes    CareerWish[]
-  personalGoals   PersonalGoal[]
+  profile            Profile?
+  passwordHistory    PasswordHistory[]
+  sessions           Session[]
+  careerWishes       CareerWish[]
+  personalGoals      PersonalGoal[]
+  goalAchievements   GoalAchievement[]
 
   @@index([emailHash])
   @@index([status])
@@ -506,4 +507,43 @@ model GoalProgressHistory {
 
   @@index([goalId, recordedAt])
   @@map("goal_progress_history")
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 評価サイクル・目標達成率連携 (Requirement 6.9)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// 評価サイクル (Requirement 6.9)
+model EvaluationCycle {
+  id          String   @id @default(cuid())
+  name        String
+  startDate   DateTime
+  endDate     DateTime
+  createdAt   DateTime @default(now())
+
+  achievements GoalAchievement[]
+
+  @@index([endDate])
+  @@map("evaluation_cycles")
+}
+
+/// 目標達成率連携レコード (Requirement 6.9)
+/// 評価期間終了時に PersonalGoal の達成状況をスナップショットとして保存
+model GoalAchievement {
+  id              String   @id @default(cuid())
+  cycleId         String
+  goalId          String
+  userId          String
+  finalProgress   Int      // 最終進捗率 0-100
+  isCompleted     Boolean  // status === COMPLETED
+  achievementNote String?  // 定性評価コメント
+  linkedAt        DateTime @default(now())
+
+  cycle EvaluationCycle @relation(fields: [cycleId], references: [id], onDelete: Cascade)
+  user  User            @relation(fields: [userId], references: [id])
+
+  @@unique([cycleId, goalId])
+  @@index([cycleId])
+  @@index([userId])
+  @@map("goal_achievements")
 }

--- a/src/app/api/goals/achievements/cycles/[cycleId]/link/route.ts
+++ b/src/app/api/goals/achievements/cycles/[cycleId]/link/route.ts
@@ -1,0 +1,77 @@
+/**
+ * Issue #46 / Task 13.5: 目標達成率連携 API (Req 6.9)
+ *
+ * - POST /api/goals/achievements/cycles/[cycleId]/link — 目標達成率を連携（HR_MANAGER/ADMIN）
+ */
+import { type NextRequest, NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { EvaluationCycleNotFoundError } from '@/lib/goal/goal-achievement-types'
+import { getGoalAchievementService } from '@/lib/goal/goal-achievement-service-di'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Auth helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+type UserRole = 'ADMIN' | 'HR_MANAGER' | 'MANAGER' | 'EMPLOYEE'
+
+function isUserRole(value: unknown): value is UserRole {
+  return value === 'ADMIN' || value === 'HR_MANAGER' || value === 'MANAGER' || value === 'EMPLOYEE'
+}
+
+async function requireAuthenticated(): Promise<
+  { ok: true; userId: string; role: UserRole } | { ok: false; response: NextResponse }
+> {
+  const serverSession = await getServerSession()
+  if (!serverSession?.user?.email) {
+    return { ok: false, response: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
+  }
+  const sess = serverSession as Record<string, unknown>
+  const userId = typeof sess.userId === 'string' ? sess.userId : undefined
+  const roleValue = sess.role
+  if (!userId || !isUserRole(roleValue)) {
+    return { ok: false, response: NextResponse.json({ error: 'Forbidden' }, { status: 403 }) }
+  }
+  return { ok: true, userId, role: roleValue }
+}
+
+function isHrManagerOrAbove(role: UserRole): boolean {
+  return role === 'HR_MANAGER' || role === 'ADMIN'
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// POST /api/goals/achievements/cycles/[cycleId]/link
+// ─────────────────────────────────────────────────────────────────────────────
+
+export async function POST(
+  _request: NextRequest,
+  { params }: { params: Promise<{ cycleId: string }> },
+): Promise<NextResponse> {
+  const guard = await requireAuthenticated()
+  if (!guard.ok) return guard.response
+
+  if (!isHrManagerOrAbove(guard.role)) {
+    return NextResponse.json({ error: 'Forbidden: HR_MANAGER or ADMIN required' }, { status: 403 })
+  }
+
+  const { cycleId } = await params
+
+  let svc: ReturnType<typeof getGoalAchievementService>
+  try {
+    svc = getGoalAchievementService()
+  } catch {
+    return NextResponse.json({ error: 'GoalAchievementService not initialized' }, { status: 503 })
+  }
+
+  try {
+    const result = await svc.linkGoalsToCycle(cycleId)
+    return NextResponse.json({ success: true, data: result })
+  } catch (err) {
+    if (err instanceof EvaluationCycleNotFoundError) {
+      return NextResponse.json(
+        { error: 'EvaluationCycle not found', cycleId: err.cycleId },
+        { status: 404 },
+      )
+    }
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/api/goals/achievements/cycles/[cycleId]/summary/route.ts
+++ b/src/app/api/goals/achievements/cycles/[cycleId]/summary/route.ts
@@ -1,0 +1,77 @@
+/**
+ * Issue #46 / Task 13.5: 評価サイクル全体サマリ API (Req 6.9)
+ *
+ * - GET /api/goals/achievements/cycles/[cycleId]/summary — サイクル全体サマリ（HR_MANAGER/ADMIN）
+ */
+import { type NextRequest, NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { EvaluationCycleNotFoundError } from '@/lib/goal/goal-achievement-types'
+import { getGoalAchievementService } from '@/lib/goal/goal-achievement-service-di'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Auth helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+type UserRole = 'ADMIN' | 'HR_MANAGER' | 'MANAGER' | 'EMPLOYEE'
+
+function isUserRole(value: unknown): value is UserRole {
+  return value === 'ADMIN' || value === 'HR_MANAGER' || value === 'MANAGER' || value === 'EMPLOYEE'
+}
+
+async function requireAuthenticated(): Promise<
+  { ok: true; userId: string; role: UserRole } | { ok: false; response: NextResponse }
+> {
+  const serverSession = await getServerSession()
+  if (!serverSession?.user?.email) {
+    return { ok: false, response: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
+  }
+  const sess = serverSession as Record<string, unknown>
+  const userId = typeof sess.userId === 'string' ? sess.userId : undefined
+  const roleValue = sess.role
+  if (!userId || !isUserRole(roleValue)) {
+    return { ok: false, response: NextResponse.json({ error: 'Forbidden' }, { status: 403 }) }
+  }
+  return { ok: true, userId, role: roleValue }
+}
+
+function isHrManagerOrAbove(role: UserRole): boolean {
+  return role === 'HR_MANAGER' || role === 'ADMIN'
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /api/goals/achievements/cycles/[cycleId]/summary
+// ─────────────────────────────────────────────────────────────────────────────
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ cycleId: string }> },
+): Promise<NextResponse> {
+  const guard = await requireAuthenticated()
+  if (!guard.ok) return guard.response
+
+  if (!isHrManagerOrAbove(guard.role)) {
+    return NextResponse.json({ error: 'Forbidden: HR_MANAGER or ADMIN required' }, { status: 403 })
+  }
+
+  const { cycleId } = await params
+
+  let svc: ReturnType<typeof getGoalAchievementService>
+  try {
+    svc = getGoalAchievementService()
+  } catch {
+    return NextResponse.json({ error: 'GoalAchievementService not initialized' }, { status: 503 })
+  }
+
+  try {
+    const summaries = await svc.listCycleAchievements(cycleId)
+    return NextResponse.json({ success: true, data: summaries })
+  } catch (err) {
+    if (err instanceof EvaluationCycleNotFoundError) {
+      return NextResponse.json(
+        { error: 'EvaluationCycle not found', cycleId: err.cycleId },
+        { status: 404 },
+      )
+    }
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/api/goals/achievements/cycles/[cycleId]/users/[userId]/route.ts
+++ b/src/app/api/goals/achievements/cycles/[cycleId]/users/[userId]/route.ts
@@ -1,0 +1,79 @@
+/**
+ * Issue #46 / Task 13.5: ユーザー個別達成率サマリ API (Req 6.9)
+ *
+ * - GET /api/goals/achievements/cycles/[cycleId]/users/[userId]
+ *   — ユーザー個別サマリ（本人 or HR_MANAGER/ADMIN）
+ */
+import { type NextRequest, NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { EvaluationCycleNotFoundError } from '@/lib/goal/goal-achievement-types'
+import { getGoalAchievementService } from '@/lib/goal/goal-achievement-service-di'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Auth helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+type UserRole = 'ADMIN' | 'HR_MANAGER' | 'MANAGER' | 'EMPLOYEE'
+
+function isUserRole(value: unknown): value is UserRole {
+  return value === 'ADMIN' || value === 'HR_MANAGER' || value === 'MANAGER' || value === 'EMPLOYEE'
+}
+
+async function requireAuthenticated(): Promise<
+  { ok: true; userId: string; role: UserRole } | { ok: false; response: NextResponse }
+> {
+  const serverSession = await getServerSession()
+  if (!serverSession?.user?.email) {
+    return { ok: false, response: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
+  }
+  const sess = serverSession as Record<string, unknown>
+  const userId = typeof sess.userId === 'string' ? sess.userId : undefined
+  const roleValue = sess.role
+  if (!userId || !isUserRole(roleValue)) {
+    return { ok: false, response: NextResponse.json({ error: 'Forbidden' }, { status: 403 }) }
+  }
+  return { ok: true, userId, role: roleValue }
+}
+
+function isHrManagerOrAbove(role: UserRole): boolean {
+  return role === 'HR_MANAGER' || role === 'ADMIN'
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /api/goals/achievements/cycles/[cycleId]/users/[userId]
+// ─────────────────────────────────────────────────────────────────────────────
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ cycleId: string; userId: string }> },
+): Promise<NextResponse> {
+  const guard = await requireAuthenticated()
+  if (!guard.ok) return guard.response
+
+  const { cycleId, userId } = await params
+
+  // 本人か HR_MANAGER/ADMIN のみアクセス可
+  if (guard.userId !== userId && !isHrManagerOrAbove(guard.role)) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  let svc: ReturnType<typeof getGoalAchievementService>
+  try {
+    svc = getGoalAchievementService()
+  } catch {
+    return NextResponse.json({ error: 'GoalAchievementService not initialized' }, { status: 503 })
+  }
+
+  try {
+    const summary = await svc.getAchievementSummary(cycleId, userId)
+    return NextResponse.json({ success: true, data: summary })
+  } catch (err) {
+    if (err instanceof EvaluationCycleNotFoundError) {
+      return NextResponse.json(
+        { error: 'EvaluationCycle not found', cycleId: err.cycleId },
+        { status: 404 },
+      )
+    }
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/api/goals/achievements/cycles/route.ts
+++ b/src/app/api/goals/achievements/cycles/route.ts
@@ -1,0 +1,83 @@
+/**
+ * Issue #46 / Task 13.5: 評価サイクル 作成 API (Req 6.9)
+ *
+ * - POST /api/goals/achievements/cycles — サイクル作成（HR_MANAGER/ADMIN）
+ */
+import { type NextRequest, NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { evaluationCycleInputSchema } from '@/lib/goal/goal-achievement-types'
+import { getGoalAchievementService } from '@/lib/goal/goal-achievement-service-di'
+
+export {
+  setGoalAchievementServiceForTesting,
+  clearGoalAchievementServiceForTesting,
+} from '@/lib/goal/goal-achievement-service-di'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Auth helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+type UserRole = 'ADMIN' | 'HR_MANAGER' | 'MANAGER' | 'EMPLOYEE'
+
+function isUserRole(value: unknown): value is UserRole {
+  return value === 'ADMIN' || value === 'HR_MANAGER' || value === 'MANAGER' || value === 'EMPLOYEE'
+}
+
+async function requireAuthenticated(): Promise<
+  { ok: true; userId: string; role: UserRole } | { ok: false; response: NextResponse }
+> {
+  const serverSession = await getServerSession()
+  if (!serverSession?.user?.email) {
+    return { ok: false, response: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
+  }
+  const sess = serverSession as Record<string, unknown>
+  const userId = typeof sess.userId === 'string' ? sess.userId : undefined
+  const roleValue = sess.role
+  if (!userId || !isUserRole(roleValue)) {
+    return { ok: false, response: NextResponse.json({ error: 'Forbidden' }, { status: 403 }) }
+  }
+  return { ok: true, userId, role: roleValue }
+}
+
+function isHrManagerOrAbove(role: UserRole): boolean {
+  return role === 'HR_MANAGER' || role === 'ADMIN'
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// POST /api/goals/achievements/cycles
+// ─────────────────────────────────────────────────────────────────────────────
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const guard = await requireAuthenticated()
+  if (!guard.ok) return guard.response
+
+  if (!isHrManagerOrAbove(guard.role)) {
+    return NextResponse.json({ error: 'Forbidden: HR_MANAGER or ADMIN required' }, { status: 403 })
+  }
+
+  let body: unknown
+  try {
+    body = (await request.json()) as unknown
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
+  }
+
+  const validated = evaluationCycleInputSchema.safeParse(body)
+  if (!validated.success) {
+    return NextResponse.json({ error: validated.error.flatten() }, { status: 422 })
+  }
+
+  let svc: ReturnType<typeof getGoalAchievementService>
+  try {
+    svc = getGoalAchievementService()
+  } catch {
+    return NextResponse.json({ error: 'GoalAchievementService not initialized' }, { status: 503 })
+  }
+
+  try {
+    const created = await svc.createCycle(validated.data)
+    return NextResponse.json({ success: true, data: created }, { status: 201 })
+  } catch {
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/lib/goal/goal-achievement-service-di.ts
+++ b/src/lib/goal/goal-achievement-service-di.ts
@@ -1,0 +1,30 @@
+/**
+ * Issue #46 / Task 13.5: GoalAchievementService DI コンテナ
+ *
+ * テストでは setGoalAchievementServiceForTesting() を使用。
+ * プロダクションではサーバー起動前に initGoalAchievementService() を呼ぶ。
+ */
+import type { GoalAchievementService } from './goal-achievement-service'
+
+let _service: GoalAchievementService | null = null
+
+export function setGoalAchievementServiceForTesting(svc: GoalAchievementService): void {
+  _service = svc
+}
+
+export function clearGoalAchievementServiceForTesting(): void {
+  _service = null
+}
+
+export function getGoalAchievementService(): GoalAchievementService {
+  if (_service) return _service
+  throw new Error(
+    'GoalAchievementService is not initialized. ' +
+      'テストでは setGoalAchievementServiceForTesting() を呼んでください。' +
+      'プロダクションではサーバー起動前に initGoalAchievementService() を呼んでください。',
+  )
+}
+
+export function initGoalAchievementService(svc: GoalAchievementService): void {
+  _service = svc
+}

--- a/src/lib/goal/goal-achievement-service.ts
+++ b/src/lib/goal/goal-achievement-service.ts
@@ -1,0 +1,238 @@
+/**
+ * Issue #46 / Task 13.5: 評価サイクルとの目標達成率連携 — サービス (Req 6.9)
+ *
+ * - createCycle: 評価サイクルを作成
+ * - linkGoalsToCycle: 評価期間内の PersonalGoal をスナップショット保存
+ * - getAchievementSummary: ユーザーごとの達成率サマリを取得
+ * - listCycleAchievements: サイクル全体のサマリ一覧（HR_MANAGER 向け）
+ */
+import type { PrismaClient } from '@prisma/client'
+import type {
+  EvaluationCycleInput,
+  EvaluationCycleRecord,
+  GoalAchievementRecord,
+  GoalAchievementSummary,
+} from './goal-achievement-types'
+import { EvaluationCycleNotFoundError } from './goal-achievement-types'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Service interface
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface GoalAchievementService {
+  /** 評価サイクルを作成 */
+  createCycle(input: EvaluationCycleInput): Promise<EvaluationCycleRecord>
+  /**
+   * 評価期間終了時に PersonalGoal の達成状況をスナップショット保存。
+   * cycleId の startDate〜endDate に endDate が含まれる PersonalGoal を対象とする。
+   */
+  linkGoalsToCycle(cycleId: string): Promise<{ linked: number }>
+  /** ユーザーごとの達成率サマリを取得 */
+  getAchievementSummary(cycleId: string, userId: string): Promise<GoalAchievementSummary>
+  /** 評価サイクル全体のサマリ一覧（HR_MANAGER 向け） */
+  listCycleAchievements(cycleId: string): Promise<GoalAchievementSummary[]>
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Prisma row types (型安全アクセス用)
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface EvaluationCycleRow {
+  id: string
+  name: string
+  startDate: Date
+  endDate: Date
+  createdAt: Date
+}
+
+interface GoalAchievementRow {
+  id: string
+  cycleId: string
+  goalId: string
+  userId: string
+  finalProgress: number
+  isCompleted: boolean
+  achievementNote: string | null
+  linkedAt: Date
+}
+
+interface PersonalGoalRow {
+  id: string
+  userId: string
+  status: string
+  endDate: Date
+  progressHistory: Array<{ progressRate: number; recordedAt: Date }>
+}
+
+interface PrismaDelegates {
+  evaluationCycle: {
+    create(args: unknown): Promise<EvaluationCycleRow>
+    findUnique(args: unknown): Promise<EvaluationCycleRow | null>
+  }
+  goalAchievement: {
+    upsert(args: unknown): Promise<GoalAchievementRow>
+    findMany(args: unknown): Promise<GoalAchievementRow[]>
+  }
+  personalGoal: {
+    findMany(args: unknown): Promise<PersonalGoalRow[]>
+  }
+}
+
+function asDelegates(db: PrismaClient): PrismaDelegates {
+  return db as unknown as PrismaDelegates
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Mappers
+// ─────────────────────────────────────────────────────────────────────────────
+
+function toCycleRecord(row: EvaluationCycleRow): EvaluationCycleRecord {
+  return {
+    id: row.id,
+    name: row.name,
+    startDate: row.startDate,
+    endDate: row.endDate,
+    createdAt: row.createdAt,
+  }
+}
+
+function toAchievementRecord(row: GoalAchievementRow): GoalAchievementRecord {
+  return {
+    id: row.id,
+    cycleId: row.cycleId,
+    goalId: row.goalId,
+    userId: row.userId,
+    finalProgress: row.finalProgress,
+    isCompleted: row.isCompleted,
+    achievementNote: row.achievementNote,
+    linkedAt: row.linkedAt,
+  }
+}
+
+function latestProgressRate(history: Array<{ progressRate: number; recordedAt: Date }>): number {
+  if (history.length === 0) return 0
+  const sorted = [...history].sort((a, b) => b.recordedAt.getTime() - a.recordedAt.getTime())
+  return sorted[0]?.progressRate ?? 0
+}
+
+function buildSummary(userId: string, records: GoalAchievementRecord[]): GoalAchievementSummary {
+  const totalGoals = records.length
+  const completedGoals = records.filter((r) => r.isCompleted).length
+  const averageProgress =
+    totalGoals === 0
+      ? 0
+      : Math.round(records.reduce((sum, r) => sum + r.finalProgress, 0) / totalGoals)
+  return { userId, totalGoals, completedGoals, averageProgress, achievements: records }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Implementation
+// ─────────────────────────────────────────────────────────────────────────────
+
+class GoalAchievementServiceImpl implements GoalAchievementService {
+  private readonly delegates: PrismaDelegates
+
+  constructor(db: PrismaClient) {
+    this.delegates = asDelegates(db)
+  }
+
+  async createCycle(input: EvaluationCycleInput): Promise<EvaluationCycleRecord> {
+    const row = await this.delegates.evaluationCycle.create({
+      data: {
+        name: input.name,
+        startDate: input.startDate,
+        endDate: input.endDate,
+      },
+    })
+    return toCycleRecord(row)
+  }
+
+  async linkGoalsToCycle(cycleId: string): Promise<{ linked: number }> {
+    const cycle = await this.delegates.evaluationCycle.findUnique({ where: { id: cycleId } })
+    if (!cycle) throw new EvaluationCycleNotFoundError(cycleId)
+
+    // 評価期間内に endDate が含まれる PersonalGoal を取得
+    const goals = await this.delegates.personalGoal.findMany({
+      where: {
+        endDate: {
+          gte: cycle.startDate,
+          lte: cycle.endDate,
+        },
+      },
+      include: {
+        progressHistory: {
+          select: { progressRate: true, recordedAt: true },
+          orderBy: { recordedAt: 'desc' },
+          take: 1,
+        },
+      } as unknown,
+    })
+
+    let linked = 0
+    for (const goal of goals) {
+      const finalProgress = latestProgressRate(goal.progressHistory)
+      const isCompleted = goal.status === 'COMPLETED'
+
+      await this.delegates.goalAchievement.upsert({
+        where: { cycleId_goalId: { cycleId, goalId: goal.id } },
+        create: {
+          cycleId,
+          goalId: goal.id,
+          userId: goal.userId,
+          finalProgress,
+          isCompleted,
+          achievementNote: null,
+        },
+        update: {
+          finalProgress,
+          isCompleted,
+        },
+      })
+      linked++
+    }
+
+    return { linked }
+  }
+
+  async getAchievementSummary(cycleId: string, userId: string): Promise<GoalAchievementSummary> {
+    const cycle = await this.delegates.evaluationCycle.findUnique({ where: { id: cycleId } })
+    if (!cycle) throw new EvaluationCycleNotFoundError(cycleId)
+
+    const rows = await this.delegates.goalAchievement.findMany({
+      where: { cycleId, userId },
+      orderBy: { linkedAt: 'asc' } as unknown,
+    })
+    const records = rows.map(toAchievementRecord)
+    return buildSummary(userId, records)
+  }
+
+  async listCycleAchievements(cycleId: string): Promise<GoalAchievementSummary[]> {
+    const cycle = await this.delegates.evaluationCycle.findUnique({ where: { id: cycleId } })
+    if (!cycle) throw new EvaluationCycleNotFoundError(cycleId)
+
+    const rows = await this.delegates.goalAchievement.findMany({
+      where: { cycleId },
+      orderBy: [{ userId: 'asc' }, { linkedAt: 'asc' }] as unknown,
+    })
+    const records = rows.map(toAchievementRecord)
+
+    // userId ごとにグループ化
+    const byUser = new Map<string, GoalAchievementRecord[]>()
+    for (const record of records) {
+      const existing = byUser.get(record.userId) ?? []
+      byUser.set(record.userId, [...existing, record])
+    }
+
+    return Array.from(byUser.entries()).map(([userId, userRecords]) =>
+      buildSummary(userId, userRecords),
+    )
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Factory
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function createGoalAchievementService(db: PrismaClient): GoalAchievementService {
+  return new GoalAchievementServiceImpl(db)
+}

--- a/src/lib/goal/goal-achievement-types.ts
+++ b/src/lib/goal/goal-achievement-types.ts
@@ -1,0 +1,61 @@
+/**
+ * Issue #46 / Task 13.5: 評価サイクルとの目標達成率連携 — 型定義 (Req 6.9)
+ */
+import { z } from 'zod'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Input validation schemas
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const evaluationCycleInputSchema = z.object({
+  name: z.string().min(1).max(200),
+  startDate: z.coerce.date(),
+  endDate: z.coerce.date(),
+})
+
+export type EvaluationCycleInput = z.infer<typeof evaluationCycleInputSchema>
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Domain records
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface EvaluationCycleRecord {
+  id: string
+  name: string
+  startDate: Date
+  endDate: Date
+  createdAt: Date
+}
+
+export interface GoalAchievementRecord {
+  id: string
+  cycleId: string
+  goalId: string
+  userId: string
+  finalProgress: number
+  isCompleted: boolean
+  achievementNote: string | null
+  linkedAt: Date
+}
+
+export interface GoalAchievementSummary {
+  userId: string
+  totalGoals: number
+  completedGoals: number
+  /** 平均進捗率 0-100 */
+  averageProgress: number
+  achievements: GoalAchievementRecord[]
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Domain errors
+// ─────────────────────────────────────────────────────────────────────────────
+
+export class EvaluationCycleNotFoundError extends Error {
+  readonly cycleId: string
+  constructor(cycleId: string) {
+    super(`EvaluationCycle not found: ${cycleId}`)
+    this.name = 'EvaluationCycleNotFoundError'
+    this.cycleId = cycleId
+  }
+}

--- a/src/tests/goal/goal-achievement-service.test.ts
+++ b/src/tests/goal/goal-achievement-service.test.ts
@@ -1,0 +1,320 @@
+/**
+ * Issue #46 / Task 13.5: GoalAchievementService 単体テスト (Req 6.9)
+ *
+ * テスト対象:
+ * - createCycle: サイクル作成
+ * - linkGoalsToCycle: 期間内の目標がスナップショット保存される
+ * - getAchievementSummary: 平均進捗率・完了数計算
+ * - listCycleAchievements: 複数ユーザーのサマリ一覧
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { createGoalAchievementService } from '@/lib/goal/goal-achievement-service'
+import {
+  EvaluationCycleNotFoundError,
+  type EvaluationCycleRecord,
+  type GoalAchievementRecord,
+} from '@/lib/goal/goal-achievement-types'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fixtures
+// ─────────────────────────────────────────────────────────────────────────────
+
+const FIXED_NOW = new Date('2026-04-19T09:00:00.000Z')
+
+function makeCycleRecord(overrides: Partial<EvaluationCycleRecord> = {}): EvaluationCycleRecord {
+  return {
+    id: 'cycle-1',
+    name: '2026 Q1 評価',
+    startDate: new Date('2026-01-01'),
+    endDate: new Date('2026-03-31'),
+    createdAt: FIXED_NOW,
+    ...overrides,
+  }
+}
+
+function makeAchievementRecord(
+  overrides: Partial<GoalAchievementRecord> = {},
+): GoalAchievementRecord {
+  return {
+    id: 'ach-1',
+    cycleId: 'cycle-1',
+    goalId: 'goal-1',
+    userId: 'user-1',
+    finalProgress: 80,
+    isCompleted: false,
+    achievementNote: null,
+    linkedAt: FIXED_NOW,
+    ...overrides,
+  }
+}
+
+type PersonalGoalRow = {
+  id: string
+  userId: string
+  status: string
+  endDate: Date
+  progressHistory: Array<{ progressRate: number; recordedAt: Date }>
+}
+
+function makePrisma({
+  cycleRow = makeCycleRecord() as EvaluationCycleRecord | null,
+  achievementRows = [] as GoalAchievementRecord[],
+  personalGoalRows = [] as PersonalGoalRow[],
+  upsertResult = makeAchievementRecord(),
+} = {}) {
+  return {
+    evaluationCycle: {
+      create: vi.fn().mockResolvedValue(cycleRow),
+      findUnique: vi.fn().mockResolvedValue(cycleRow),
+    },
+    goalAchievement: {
+      upsert: vi.fn().mockResolvedValue(upsertResult),
+      findMany: vi.fn().mockResolvedValue(achievementRows),
+    },
+    personalGoal: {
+      findMany: vi.fn().mockResolvedValue(personalGoalRows),
+    },
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('GoalAchievementService', () => {
+  // ── createCycle ────────────────────────────────────────────────────────────
+
+  describe('createCycle', () => {
+    it('評価サイクルを作成して返す', async () => {
+      // Arrange
+      const cycle = makeCycleRecord()
+      const db = makePrisma({ cycleRow: cycle })
+      const svc = createGoalAchievementService(db as never)
+
+      // Act
+      const result = await svc.createCycle({
+        name: '2026 Q1 評価',
+        startDate: new Date('2026-01-01'),
+        endDate: new Date('2026-03-31'),
+      })
+
+      // Assert
+      expect(result.id).toBe('cycle-1')
+      expect(result.name).toBe('2026 Q1 評価')
+      expect(db.evaluationCycle.create).toHaveBeenCalledOnce()
+    })
+  })
+
+  // ── linkGoalsToCycle ───────────────────────────────────────────────────────
+
+  describe('linkGoalsToCycle', () => {
+    it('期間内の目標をスナップショット保存して linked 件数を返す', async () => {
+      // Arrange
+      const goalRows: PersonalGoalRow[] = [
+        {
+          id: 'goal-1',
+          userId: 'user-1',
+          status: 'IN_PROGRESS',
+          endDate: new Date('2026-02-28'),
+          progressHistory: [{ progressRate: 75, recordedAt: new Date('2026-02-01') }],
+        },
+        {
+          id: 'goal-2',
+          userId: 'user-2',
+          status: 'COMPLETED',
+          endDate: new Date('2026-03-15'),
+          progressHistory: [{ progressRate: 100, recordedAt: new Date('2026-03-15') }],
+        },
+      ]
+      const db = makePrisma({ personalGoalRows: goalRows })
+      const svc = createGoalAchievementService(db as never)
+
+      // Act
+      const result = await svc.linkGoalsToCycle('cycle-1')
+
+      // Assert
+      expect(result.linked).toBe(2)
+      expect(db.goalAchievement.upsert).toHaveBeenCalledTimes(2)
+    })
+
+    it('COMPLETED ステータスの目標は isCompleted=true でスナップショット保存される', async () => {
+      // Arrange
+      const goalRows: PersonalGoalRow[] = [
+        {
+          id: 'goal-1',
+          userId: 'user-1',
+          status: 'COMPLETED',
+          endDate: new Date('2026-02-28'),
+          progressHistory: [{ progressRate: 100, recordedAt: new Date('2026-02-28') }],
+        },
+      ]
+      const db = makePrisma({ personalGoalRows: goalRows })
+      const svc = createGoalAchievementService(db as never)
+
+      // Act
+      await svc.linkGoalsToCycle('cycle-1')
+
+      // Assert
+      const upsertCall = db.goalAchievement.upsert.mock.calls[0]![0] as {
+        create: { isCompleted: boolean; finalProgress: number }
+      }
+      expect(upsertCall.create.isCompleted).toBe(true)
+      expect(upsertCall.create.finalProgress).toBe(100)
+    })
+
+    it('進捗履歴がない目標は finalProgress=0 になる', async () => {
+      // Arrange
+      const goalRows: PersonalGoalRow[] = [
+        {
+          id: 'goal-1',
+          userId: 'user-1',
+          status: 'DRAFT',
+          endDate: new Date('2026-02-28'),
+          progressHistory: [],
+        },
+      ]
+      const db = makePrisma({ personalGoalRows: goalRows })
+      const svc = createGoalAchievementService(db as never)
+
+      // Act
+      await svc.linkGoalsToCycle('cycle-1')
+
+      // Assert
+      const upsertCall = db.goalAchievement.upsert.mock.calls[0]![0] as {
+        create: { finalProgress: number }
+      }
+      expect(upsertCall.create.finalProgress).toBe(0)
+    })
+
+    it('サイクルが存在しない場合 EvaluationCycleNotFoundError をスローする', async () => {
+      // Arrange
+      const db = makePrisma({ cycleRow: null })
+      const svc = createGoalAchievementService(db as never)
+
+      // Act & Assert
+      await expect(svc.linkGoalsToCycle('nonexistent')).rejects.toThrow(
+        EvaluationCycleNotFoundError,
+      )
+    })
+  })
+
+  // ── getAchievementSummary ──────────────────────────────────────────────────
+
+  describe('getAchievementSummary', () => {
+    it('ユーザーの平均進捗率・完了数を正しく計算する', async () => {
+      // Arrange
+      const achievementRows = [
+        makeAchievementRecord({ goalId: 'goal-1', finalProgress: 80, isCompleted: false }),
+        makeAchievementRecord({
+          id: 'ach-2',
+          goalId: 'goal-2',
+          finalProgress: 100,
+          isCompleted: true,
+        }),
+        makeAchievementRecord({
+          id: 'ach-3',
+          goalId: 'goal-3',
+          finalProgress: 60,
+          isCompleted: false,
+        }),
+      ]
+      const db = makePrisma({ achievementRows })
+      const svc = createGoalAchievementService(db as never)
+
+      // Act
+      const summary = await svc.getAchievementSummary('cycle-1', 'user-1')
+
+      // Assert
+      expect(summary.userId).toBe('user-1')
+      expect(summary.totalGoals).toBe(3)
+      expect(summary.completedGoals).toBe(1)
+      expect(summary.averageProgress).toBe(80) // (80+100+60)/3 = 80
+      expect(summary.achievements).toHaveLength(3)
+    })
+
+    it('達成記録が0件の場合 averageProgress=0 を返す', async () => {
+      // Arrange
+      const db = makePrisma({ achievementRows: [] })
+      const svc = createGoalAchievementService(db as never)
+
+      // Act
+      const summary = await svc.getAchievementSummary('cycle-1', 'user-1')
+
+      // Assert
+      expect(summary.totalGoals).toBe(0)
+      expect(summary.completedGoals).toBe(0)
+      expect(summary.averageProgress).toBe(0)
+    })
+
+    it('サイクルが存在しない場合 EvaluationCycleNotFoundError をスローする', async () => {
+      // Arrange
+      const db = makePrisma({ cycleRow: null })
+      const svc = createGoalAchievementService(db as never)
+
+      // Act & Assert
+      await expect(svc.getAchievementSummary('nonexistent', 'user-1')).rejects.toThrow(
+        EvaluationCycleNotFoundError,
+      )
+    })
+  })
+
+  // ── listCycleAchievements ──────────────────────────────────────────────────
+
+  describe('listCycleAchievements', () => {
+    it('複数ユーザーの達成率サマリ一覧をユーザーごとにグループ化して返す', async () => {
+      // Arrange
+      const achievementRows = [
+        makeAchievementRecord({
+          id: 'ach-1',
+          goalId: 'goal-1',
+          userId: 'user-1',
+          finalProgress: 90,
+          isCompleted: true,
+        }),
+        makeAchievementRecord({
+          id: 'ach-2',
+          goalId: 'goal-2',
+          userId: 'user-1',
+          finalProgress: 70,
+          isCompleted: false,
+        }),
+        makeAchievementRecord({
+          id: 'ach-3',
+          goalId: 'goal-3',
+          userId: 'user-2',
+          finalProgress: 50,
+          isCompleted: false,
+        }),
+      ]
+      const db = makePrisma({ achievementRows })
+      const svc = createGoalAchievementService(db as never)
+
+      // Act
+      const summaries = await svc.listCycleAchievements('cycle-1')
+
+      // Assert
+      expect(summaries).toHaveLength(2)
+
+      const user1Summary = summaries.find((s) => s.userId === 'user-1')
+      expect(user1Summary?.totalGoals).toBe(2)
+      expect(user1Summary?.completedGoals).toBe(1)
+      expect(user1Summary?.averageProgress).toBe(80) // (90+70)/2 = 80
+
+      const user2Summary = summaries.find((s) => s.userId === 'user-2')
+      expect(user2Summary?.totalGoals).toBe(1)
+      expect(user2Summary?.completedGoals).toBe(0)
+      expect(user2Summary?.averageProgress).toBe(50)
+    })
+
+    it('サイクルが存在しない場合 EvaluationCycleNotFoundError をスローする', async () => {
+      // Arrange
+      const db = makePrisma({ cycleRow: null })
+      const svc = createGoalAchievementService(db as never)
+
+      // Act & Assert
+      await expect(svc.listCycleAchievements('nonexistent')).rejects.toThrow(
+        EvaluationCycleNotFoundError,
+      )
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- 評価期間終了時に PersonalGoal の達成状況をスナップショットとして評価データへ連携（Req 6.9）
- 定量（finalProgress 0-100%）・定性（isCompleted）の両形式をサポート
- HR_MANAGER が全社員の達成率サマリを閲覧可能

## Prismaスキーマ追加
- `EvaluationCycle` モデル（評価サイクル管理）
- `GoalAchievement` モデル（cycleId + goalId のユニーク制約でスナップショット保存）

## 追加ファイル
- `src/lib/goal/goal-achievement-types.ts` — 型定義・Zodスキーマ
- `src/lib/goal/goal-achievement-service.ts` — createCycle / linkGoalsToCycle / getAchievementSummary / listCycleAchievements
- `src/lib/goal/goal-achievement-service-di.ts` — DI
- `src/app/api/goals/achievements/cycles/` — 4エンドポイント
- `src/tests/goal/goal-achievement-service.test.ts` — 10件テスト全通過

## Test plan
- [ ] `POST /api/goals/achievements/cycles` — HR_MANAGER/ADMIN のみ
- [ ] `POST .../link` — 期間内の PersonalGoal が正しくスナップショット保存される
- [ ] `GET .../summary` — 平均進捗率・完了数が正確
- [ ] 一般ユーザー → 403

Closes #46