### PR TITLE
[#47] 1on1予定登録と通知

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -103,11 +103,14 @@ model User {
   anonymizedAt     DateTime?
 
   // Relations
-  profile         Profile?
-  passwordHistory PasswordHistory[]
-  sessions        Session[]
-  careerWishes    CareerWish[]
-  personalGoals   PersonalGoal[]
+  profile          Profile?
+  passwordHistory  PasswordHistory[]
+  sessions         Session[]
+  careerWishes     CareerWish[]
+  personalGoals    PersonalGoal[]
+  managedSessions  OneOnOneSession[] @relation("OneOnOneAsManager")
+  employeeSessions OneOnOneSession[] @relation("OneOnOneAsEmployee")
+  oneOnOneLogs     OneOnOneLog[]     @relation("OneOnOneLogRecorder")
 
   @@index([emailHash])
   @@index([status])
@@ -506,4 +509,53 @@ model GoalProgressHistory {
 
   @@index([goalId, recordedAt])
   @@map("goal_progress_history")
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 1on1 管理 (Requirement 7.1, 7.2, 7.3, 7.4, 7.5, 7.6, 7.7, 7.8)
+// ─────────────────────────────────────────────────────────────────────────────
+
+enum OneOnOneVisibility {
+  MANAGER_ONLY
+  BOTH
+}
+
+/// 1on1 セッション (Requirement 7.1, 7.2)
+model OneOnOneSession {
+  id          String   @id @default(cuid())
+  managerId   String
+  employeeId  String
+  scheduledAt DateTime
+  durationMin Int
+  agenda      String?
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  manager  User          @relation("OneOnOneAsManager",  fields: [managerId],  references: [id])
+  employee User          @relation("OneOnOneAsEmployee", fields: [employeeId], references: [id])
+  logs     OneOnOneLog[]
+
+  @@index([managerId])
+  @@index([employeeId])
+  @@index([scheduledAt])
+  @@map("one_on_one_sessions")
+}
+
+/// 1on1 ログ (Requirement 7.3, 7.4, 7.5)
+model OneOnOneLog {
+  id          String             @id @default(cuid())
+  sessionId   String
+  agenda      String?
+  content     String
+  nextActions String?
+  visibility  OneOnOneVisibility @default(MANAGER_ONLY)
+  recordedBy  String
+  recordedAt  DateTime           @default(now())
+
+  session  OneOnOneSession @relation(fields: [sessionId], references: [id], onDelete: Cascade)
+  recorder User            @relation("OneOnOneLogRecorder", fields: [recordedBy], references: [id])
+
+  @@index([sessionId])
+  @@index([recordedAt])
+  @@map("one_on_one_logs")
 }

--- a/src/app/api/one-on-one/sessions/[id]/route.ts
+++ b/src/app/api/one-on-one/sessions/[id]/route.ts
@@ -1,0 +1,84 @@
+/**
+ * Issue #47 / Task 14.1: 1on1 セッション詳細・更新 API (Req 7.1, 7.2)
+ *
+ * - GET   /api/one-on-one/sessions/[id] — セッション詳細
+ * - PATCH /api/one-on-one/sessions/[id] — 予定更新（MANAGER のみ）
+ */
+import { type NextRequest, NextResponse } from 'next/server'
+import { oneOnOneSessionInputSchema } from '@/lib/one-on-one/one-on-one-types'
+import {
+  OneOnOneSessionNotFoundError,
+  OneOnOneSessionAccessDeniedError,
+} from '@/lib/one-on-one/one-on-one-types'
+import {
+  parseJsonBody,
+  requireAuthenticated,
+  requireManager,
+} from '@/lib/skill/skill-route-helpers'
+import { getOneOnOneSessionService } from '@/lib/one-on-one/one-on-one-session-service-di'
+
+export {
+  setOneOnOneSessionServiceForTesting,
+  clearOneOnOneSessionServiceForTesting,
+} from '@/lib/one-on-one/one-on-one-session-service-di'
+
+type RouteContext = { params: Promise<{ id: string }> }
+
+export async function GET(_request: NextRequest, context: RouteContext): Promise<NextResponse> {
+  const guard = await requireAuthenticated()
+  if (!guard.ok) return guard.response
+
+  const { id } = await context.params
+
+  let svc: ReturnType<typeof getOneOnOneSessionService>
+  try {
+    svc = getOneOnOneSessionService()
+  } catch {
+    return NextResponse.json({ error: 'OneOnOneSession service not initialized' }, { status: 503 })
+  }
+
+  try {
+    const session = await svc.getSession(id)
+    if (!session) {
+      return NextResponse.json({ error: 'Session not found' }, { status: 404 })
+    }
+    return NextResponse.json({ success: true, data: session })
+  } catch {
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}
+
+export async function PATCH(request: NextRequest, context: RouteContext): Promise<NextResponse> {
+  const guard = await requireManager()
+  if (!guard.ok) return guard.response
+
+  const { id } = await context.params
+
+  const parsedBody = await parseJsonBody(request)
+  if (!parsedBody.ok) return parsedBody.response
+
+  const validated = oneOnOneSessionInputSchema.partial().safeParse(parsedBody.body)
+  if (!validated.success) {
+    return NextResponse.json({ error: validated.error.flatten() }, { status: 422 })
+  }
+
+  let svc: ReturnType<typeof getOneOnOneSessionService>
+  try {
+    svc = getOneOnOneSessionService()
+  } catch {
+    return NextResponse.json({ error: 'OneOnOneSession service not initialized' }, { status: 503 })
+  }
+
+  try {
+    const session = await svc.updateSession(id, guard.session.userId, validated.data)
+    return NextResponse.json({ success: true, data: session })
+  } catch (err) {
+    if (err instanceof OneOnOneSessionNotFoundError) {
+      return NextResponse.json({ error: 'Session not found' }, { status: 404 })
+    }
+    if (err instanceof OneOnOneSessionAccessDeniedError) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/api/one-on-one/sessions/route.ts
+++ b/src/app/api/one-on-one/sessions/route.ts
@@ -1,0 +1,65 @@
+/**
+ * Issue #47 / Task 14.1: 1on1 セッション API (Req 7.1, 7.2)
+ *
+ * - POST /api/one-on-one/sessions — セッション作成（MANAGER 以上のみ）
+ * - GET  /api/one-on-one/sessions — 自分のセッション一覧
+ */
+import { type NextRequest, NextResponse } from 'next/server'
+import { oneOnOneSessionInputSchema } from '@/lib/one-on-one/one-on-one-types'
+import {
+  parseJsonBody,
+  requireAuthenticated,
+  requireManager,
+} from '@/lib/skill/skill-route-helpers'
+import { getOneOnOneSessionService } from '@/lib/one-on-one/one-on-one-session-service-di'
+
+export {
+  setOneOnOneSessionServiceForTesting,
+  clearOneOnOneSessionServiceForTesting,
+} from '@/lib/one-on-one/one-on-one-session-service-di'
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const guard = await requireManager()
+  if (!guard.ok) return guard.response
+
+  const parsedBody = await parseJsonBody(request)
+  if (!parsedBody.ok) return parsedBody.response
+
+  const validated = oneOnOneSessionInputSchema.safeParse(parsedBody.body)
+  if (!validated.success) {
+    return NextResponse.json({ error: validated.error.flatten() }, { status: 422 })
+  }
+
+  let svc: ReturnType<typeof getOneOnOneSessionService>
+  try {
+    svc = getOneOnOneSessionService()
+  } catch {
+    return NextResponse.json({ error: 'OneOnOneSession service not initialized' }, { status: 503 })
+  }
+
+  try {
+    const session = await svc.createSession(guard.session.userId, validated.data)
+    return NextResponse.json({ success: true, data: session }, { status: 201 })
+  } catch {
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}
+
+export async function GET(): Promise<NextResponse> {
+  const guard = await requireAuthenticated()
+  if (!guard.ok) return guard.response
+
+  let svc: ReturnType<typeof getOneOnOneSessionService>
+  try {
+    svc = getOneOnOneSessionService()
+  } catch {
+    return NextResponse.json({ error: 'OneOnOneSession service not initialized' }, { status: 503 })
+  }
+
+  try {
+    const sessions = await svc.listMySessions(guard.session.userId, guard.session.role)
+    return NextResponse.json({ success: true, data: sessions })
+  } catch {
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/lib/one-on-one/one-on-one-session-service-di.ts
+++ b/src/lib/one-on-one/one-on-one-session-service-di.ts
@@ -1,0 +1,30 @@
+/**
+ * Issue #47 / Task 14.1: OneOnOneSessionService DI コンテナ
+ *
+ * テストでは setOneOnOneSessionServiceForTesting() を使用。
+ * プロダクションでは initOneOnOneSessionService() をサーバー起動前に呼ぶ。
+ */
+import type { OneOnOneSessionService } from './one-on-one-session-service'
+
+let _service: OneOnOneSessionService | null = null
+
+export function setOneOnOneSessionServiceForTesting(svc: OneOnOneSessionService): void {
+  _service = svc
+}
+
+export function clearOneOnOneSessionServiceForTesting(): void {
+  _service = null
+}
+
+export function getOneOnOneSessionService(): OneOnOneSessionService {
+  if (_service) return _service
+  throw new Error(
+    'OneOnOneSessionService is not initialized. ' +
+      'テストでは setOneOnOneSessionServiceForTesting() を呼んでください。' +
+      'プロダクションではサーバー起動前に initOneOnOneSessionService() を呼んでください。',
+  )
+}
+
+export function initOneOnOneSessionService(svc: OneOnOneSessionService): void {
+  _service = svc
+}

--- a/src/lib/one-on-one/one-on-one-session-service.ts
+++ b/src/lib/one-on-one/one-on-one-session-service.ts
@@ -1,0 +1,160 @@
+/**
+ * Issue #47 / Task 14.1: 1on1 予定登録と通知 — サービス (Req 7.1, 7.2)
+ *
+ * - MANAGER が予定日時・所要時間・アジェンダを登録
+ * - 対象部下（employeeId）に ONE_ON_ONE_REMINDER 通知を送信
+ */
+import type { PrismaClient } from '@prisma/client'
+import type { NotificationEmitter } from '@/lib/notification/notification-emitter'
+import {
+  OneOnOneSessionNotFoundError,
+  OneOnOneSessionAccessDeniedError,
+  type OneOnOneSessionInput,
+  type OneOnOneSessionRecord,
+} from './one-on-one-types'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Service interface
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface OneOnOneSessionService {
+  /** MANAGER が予定を登録し、部下に通知 (Req 7.1, 7.2) */
+  createSession(managerId: string, input: OneOnOneSessionInput): Promise<OneOnOneSessionRecord>
+  /** 自分が関わるセッション一覧 (MANAGER: 自分設定, EMPLOYEE: 自分向け) */
+  listMySessions(userId: string, role: string): Promise<OneOnOneSessionRecord[]>
+  /** セッション詳細取得 */
+  getSession(sessionId: string): Promise<OneOnOneSessionRecord | null>
+  /** 予定更新（MANAGER のみ） */
+  updateSession(
+    sessionId: string,
+    managerId: string,
+    input: Partial<OneOnOneSessionInput>,
+  ): Promise<OneOnOneSessionRecord>
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Prisma row → domain record mapper
+// ─────────────────────────────────────────────────────────────────────────────
+
+type PrismaOneOnOneSession = {
+  id: string
+  managerId: string
+  employeeId: string
+  scheduledAt: Date
+  durationMin: number
+  agenda: string | null
+  createdAt: Date
+  updatedAt: Date
+}
+
+function toRecord(row: PrismaOneOnOneSession): OneOnOneSessionRecord {
+  return {
+    id: row.id,
+    managerId: row.managerId,
+    employeeId: row.employeeId,
+    scheduledAt: row.scheduledAt,
+    durationMin: row.durationMin,
+    agenda: row.agenda,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Implementation
+// ─────────────────────────────────────────────────────────────────────────────
+
+const MANAGER_ROLES = ['MANAGER', 'HR_MANAGER', 'ADMIN'] as const
+
+class OneOnOneSessionServiceImpl implements OneOnOneSessionService {
+  constructor(
+    private readonly db: PrismaClient,
+    private readonly notificationEmitter: NotificationEmitter | null,
+  ) {}
+
+  async createSession(
+    managerId: string,
+    input: OneOnOneSessionInput,
+  ): Promise<OneOnOneSessionRecord> {
+    const row = await this.db.oneOnOneSession.create({
+      data: {
+        managerId,
+        employeeId: input.employeeId,
+        scheduledAt: input.scheduledAt,
+        durationMin: input.durationMin,
+        agenda: input.agenda ?? null,
+      },
+    })
+
+    // 部下への予定通知 (Req 7.2)
+    if (this.notificationEmitter) {
+      try {
+        await this.notificationEmitter.emit({
+          userId: input.employeeId,
+          category: 'ONE_ON_ONE_REMINDER',
+          title: '1on1 予定が登録されました',
+          body: `${row.scheduledAt.toISOString()} に 1on1 が設定されました。所要時間: ${row.durationMin} 分`,
+          payload: { sessionId: row.id, managerId, scheduledAt: row.scheduledAt.toISOString() },
+        })
+      } catch {
+        // 通知失敗はセッション作成の成功に影響しない
+      }
+    }
+
+    return toRecord(row)
+  }
+
+  async listMySessions(userId: string, role: string): Promise<OneOnOneSessionRecord[]> {
+    const isManager = (MANAGER_ROLES as readonly string[]).includes(role)
+
+    const rows = await this.db.oneOnOneSession.findMany({
+      where: isManager ? { managerId: userId } : { employeeId: userId },
+      orderBy: { scheduledAt: 'asc' },
+    })
+
+    return rows.map(toRecord)
+  }
+
+  async getSession(sessionId: string): Promise<OneOnOneSessionRecord | null> {
+    const row = await this.db.oneOnOneSession.findUnique({ where: { id: sessionId } })
+    return row ? toRecord(row) : null
+  }
+
+  async updateSession(
+    sessionId: string,
+    managerId: string,
+    input: Partial<OneOnOneSessionInput>,
+  ): Promise<OneOnOneSessionRecord> {
+    const existing = await this.db.oneOnOneSession.findUnique({ where: { id: sessionId } })
+    if (!existing) {
+      throw new OneOnOneSessionNotFoundError(sessionId)
+    }
+    if (existing.managerId !== managerId) {
+      throw new OneOnOneSessionAccessDeniedError(
+        'Only the manager who created the session can update it',
+      )
+    }
+
+    const row = await this.db.oneOnOneSession.update({
+      where: { id: sessionId },
+      data: {
+        ...(input.scheduledAt !== undefined && { scheduledAt: input.scheduledAt }),
+        ...(input.durationMin !== undefined && { durationMin: input.durationMin }),
+        ...(input.agenda !== undefined && { agenda: input.agenda }),
+      },
+    })
+
+    return toRecord(row)
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Factory
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function createOneOnOneSessionService(
+  db: PrismaClient,
+  notificationEmitter: NotificationEmitter | null,
+): OneOnOneSessionService {
+  return new OneOnOneSessionServiceImpl(db, notificationEmitter)
+}

--- a/src/lib/one-on-one/one-on-one-types.ts
+++ b/src/lib/one-on-one/one-on-one-types.ts
@@ -1,0 +1,55 @@
+/**
+ * Issue #47 / Task 14.1: 1on1 予定登録と通知 — 型定義 (Req 7.1, 7.2)
+ */
+import { z } from 'zod'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Input schema
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const oneOnOneSessionInputSchema = z.object({
+  employeeId: z.string().min(1),
+  scheduledAt: z.coerce.date(),
+  durationMin: z.number().int().min(15).max(240),
+  agenda: z.string().max(1000).optional(),
+})
+
+export interface OneOnOneSessionInput {
+  employeeId: string
+  scheduledAt: Date
+  durationMin: number
+  agenda?: string
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Record type
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface OneOnOneSessionRecord {
+  id: string
+  managerId: string
+  employeeId: string
+  scheduledAt: Date
+  durationMin: number
+  agenda: string | null
+  createdAt: Date
+  updatedAt: Date
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Domain errors
+// ─────────────────────────────────────────────────────────────────────────────
+
+export class OneOnOneSessionNotFoundError extends Error {
+  constructor(sessionId: string) {
+    super(`OneOnOneSession not found: ${sessionId}`)
+    this.name = 'OneOnOneSessionNotFoundError'
+  }
+}
+
+export class OneOnOneSessionAccessDeniedError extends Error {
+  constructor(reason: string) {
+    super(`Access denied: ${reason}`)
+    this.name = 'OneOnOneSessionAccessDeniedError'
+  }
+}

--- a/src/tests/one-on-one/one-on-one-session-service.test.ts
+++ b/src/tests/one-on-one/one-on-one-session-service.test.ts
@@ -1,0 +1,260 @@
+/**
+ * Issue #47 / Task 14.1: OneOnOneSessionService 単体テスト (Req 7.1, 7.2)
+ *
+ * テスト対象:
+ * - セッション作成（通知が呼ばれることを確認）
+ * - 一覧取得（MANAGER は自分設定のもの、EMPLOYEE は自分向けのもの）
+ * - 予定更新（成功 / 存在しない / 権限なし）
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { createOneOnOneSessionService } from '@/lib/one-on-one/one-on-one-session-service'
+import {
+  OneOnOneSessionNotFoundError,
+  OneOnOneSessionAccessDeniedError,
+  type OneOnOneSessionRecord,
+} from '@/lib/one-on-one/one-on-one-types'
+import type { NotificationEmitter } from '@/lib/notification/notification-emitter'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fixtures
+// ─────────────────────────────────────────────────────────────────────────────
+
+const FIXED_NOW = new Date('2026-04-19T09:00:00.000Z')
+const SCHEDULED_AT = new Date('2026-04-25T10:00:00.000Z')
+
+function makeSessionRecord(overrides: Partial<OneOnOneSessionRecord> = {}): OneOnOneSessionRecord {
+  return {
+    id: 'session-1',
+    managerId: 'user-manager',
+    employeeId: 'user-employee',
+    scheduledAt: SCHEDULED_AT,
+    durationMin: 30,
+    agenda: 'Q2 目標確認',
+    createdAt: FIXED_NOW,
+    updatedAt: FIXED_NOW,
+    ...overrides,
+  }
+}
+
+function makePrisma(record: OneOnOneSessionRecord) {
+  return {
+    oneOnOneSession: {
+      create: vi.fn().mockResolvedValue(record),
+      findUnique: vi.fn().mockResolvedValue(record),
+      findMany: vi.fn().mockResolvedValue([record]),
+      update: vi.fn().mockResolvedValue(record),
+    },
+  }
+}
+
+function makeNotificationEmitter(): NotificationEmitter {
+  return { emit: vi.fn().mockResolvedValue(undefined) }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('OneOnOneSessionService', () => {
+  describe('createSession', () => {
+    it('セッションを作成して記録を返す', async () => {
+      // Arrange
+      const record = makeSessionRecord()
+      const db = makePrisma(record)
+      const emitter = makeNotificationEmitter()
+      const svc = createOneOnOneSessionService(db as never, emitter)
+
+      // Act
+      const result = await svc.createSession('user-manager', {
+        employeeId: 'user-employee',
+        scheduledAt: SCHEDULED_AT,
+        durationMin: 30,
+        agenda: 'Q2 目標確認',
+      })
+
+      // Assert
+      expect(result).toEqual(record)
+      expect(db.oneOnOneSession.create).toHaveBeenCalledOnce()
+    })
+
+    it('部下（employeeId）に ONE_ON_ONE_REMINDER 通知を送信する', async () => {
+      // Arrange
+      const record = makeSessionRecord()
+      const db = makePrisma(record)
+      const emitter = makeNotificationEmitter()
+      const svc = createOneOnOneSessionService(db as never, emitter)
+
+      // Act
+      await svc.createSession('user-manager', {
+        employeeId: 'user-employee',
+        scheduledAt: SCHEDULED_AT,
+        durationMin: 30,
+      })
+
+      // Assert
+      expect(emitter.emit).toHaveBeenCalledOnce()
+      expect(emitter.emit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: 'user-employee',
+          category: 'ONE_ON_ONE_REMINDER',
+        }),
+      )
+    })
+
+    it('通知エミッターが null のときも作成は成功する', async () => {
+      // Arrange
+      const record = makeSessionRecord()
+      const db = makePrisma(record)
+      const svc = createOneOnOneSessionService(db as never, null)
+
+      // Act & Assert
+      await expect(
+        svc.createSession('user-manager', {
+          employeeId: 'user-employee',
+          scheduledAt: SCHEDULED_AT,
+          durationMin: 30,
+        }),
+      ).resolves.toEqual(record)
+    })
+
+    it('通知送信が失敗してもセッション作成は成功を返す', async () => {
+      // Arrange
+      const record = makeSessionRecord()
+      const db = makePrisma(record)
+      const emitter: NotificationEmitter = {
+        emit: vi.fn().mockRejectedValue(new Error('queue down')),
+      }
+      const svc = createOneOnOneSessionService(db as never, emitter)
+
+      // Act & Assert
+      await expect(
+        svc.createSession('user-manager', {
+          employeeId: 'user-employee',
+          scheduledAt: SCHEDULED_AT,
+          durationMin: 30,
+        }),
+      ).resolves.toEqual(record)
+    })
+  })
+
+  describe('listMySessions', () => {
+    it('MANAGER ロールは managerId でフィルタする', async () => {
+      // Arrange
+      const record = makeSessionRecord()
+      const db = makePrisma(record)
+      const svc = createOneOnOneSessionService(db as never, null)
+
+      // Act
+      const result = await svc.listMySessions('user-manager', 'MANAGER')
+
+      // Assert
+      expect(result).toEqual([record])
+      expect(db.oneOnOneSession.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { managerId: 'user-manager' } }),
+      )
+    })
+
+    it('EMPLOYEE ロールは employeeId でフィルタする', async () => {
+      // Arrange
+      const record = makeSessionRecord()
+      const db = makePrisma(record)
+      const svc = createOneOnOneSessionService(db as never, null)
+
+      // Act
+      const result = await svc.listMySessions('user-employee', 'EMPLOYEE')
+
+      // Assert
+      expect(result).toEqual([record])
+      expect(db.oneOnOneSession.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { employeeId: 'user-employee' } }),
+      )
+    })
+
+    it('HR_MANAGER ロールは managerId でフィルタする', async () => {
+      // Arrange
+      const record = makeSessionRecord({ managerId: 'user-hr' })
+      const db = makePrisma(record)
+      const svc = createOneOnOneSessionService(db as never, null)
+
+      // Act
+      await svc.listMySessions('user-hr', 'HR_MANAGER')
+
+      // Assert
+      expect(db.oneOnOneSession.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { managerId: 'user-hr' } }),
+      )
+    })
+  })
+
+  describe('getSession', () => {
+    it('存在するセッションを返す', async () => {
+      // Arrange
+      const record = makeSessionRecord()
+      const db = makePrisma(record)
+      const svc = createOneOnOneSessionService(db as never, null)
+
+      // Act
+      const result = await svc.getSession('session-1')
+
+      // Assert
+      expect(result).toEqual(record)
+    })
+
+    it('存在しないセッションは null を返す', async () => {
+      // Arrange
+      const record = makeSessionRecord()
+      const db = makePrisma(record)
+      db.oneOnOneSession.findUnique = vi.fn().mockResolvedValue(null)
+      const svc = createOneOnOneSessionService(db as never, null)
+
+      // Act
+      const result = await svc.getSession('not-found')
+
+      // Assert
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('updateSession', () => {
+    it('MANAGER が自分のセッションを更新できる', async () => {
+      // Arrange
+      const original = makeSessionRecord()
+      const updated = makeSessionRecord({ durationMin: 60 })
+      const db = makePrisma(original)
+      db.oneOnOneSession.update = vi.fn().mockResolvedValue(updated)
+      const svc = createOneOnOneSessionService(db as never, null)
+
+      // Act
+      const result = await svc.updateSession('session-1', 'user-manager', { durationMin: 60 })
+
+      // Assert
+      expect(result.durationMin).toBe(60)
+      expect(db.oneOnOneSession.update).toHaveBeenCalledOnce()
+    })
+
+    it('セッションが存在しない場合は OneOnOneSessionNotFoundError をスローする', async () => {
+      // Arrange
+      const record = makeSessionRecord()
+      const db = makePrisma(record)
+      db.oneOnOneSession.findUnique = vi.fn().mockResolvedValue(null)
+      const svc = createOneOnOneSessionService(db as never, null)
+
+      // Act & Assert
+      await expect(
+        svc.updateSession('not-found', 'user-manager', { durationMin: 60 }),
+      ).rejects.toThrow(OneOnOneSessionNotFoundError)
+    })
+
+    it('別の MANAGER がセッションを更新しようとすると OneOnOneSessionAccessDeniedError をスローする', async () => {
+      // Arrange
+      const record = makeSessionRecord({ managerId: 'user-manager' })
+      const db = makePrisma(record)
+      const svc = createOneOnOneSessionService(db as never, null)
+
+      // Act & Assert
+      await expect(
+        svc.updateSession('session-1', 'other-manager', { durationMin: 60 }),
+      ).rejects.toThrow(OneOnOneSessionAccessDeniedError)
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- MANAGER が予定日時・所要時間・アジェンダを登録し、部下に通知（Req 7.1, 7.2）
- 通知カテゴリ: `ONE_ON_ONE_REMINDER`

## Prismaスキーマ追加
- `OneOnOneVisibility` enum（MANAGER_ONLY / BOTH）
- `OneOnOneSession` モデル
- `OneOnOneLog` モデル
- User にリレーション追加

**このPRが #48, #49 のスキーマ基盤です。最初にマージしてください。**

## 追加ファイル
- `src/lib/one-on-one/one-on-one-types.ts` — 型定義・Zodスキーマ・ドメインエラー
- `src/lib/one-on-one/one-on-one-session-service.ts` — セッション CRUD + 通知
- `src/lib/one-on-one/one-on-one-session-service-di.ts` — DI
- `src/app/api/one-on-one/sessions/` — POST/GET/PATCH
- `src/tests/one-on-one/one-on-one-session-service.test.ts` — 12件テスト全通過

## Test plan
- [ ] `POST /api/one-on-one/sessions` — MANAGER以上のみ
- [ ] セッション作成時に部下へ通知が送られる
- [ ] EMPLOYEE は自分向けセッションのみ閲覧可

Closes #47