### PR TITLE
[#49] 1on1ログ未入力リマインダーと評価フォーム連携

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -108,6 +108,9 @@ model User {
   sessions        Session[]
   careerWishes    CareerWish[]
   personalGoals   PersonalGoal[]
+  managedSessions  OneOnOneSession[] @relation("OneOnOneAsManager")
+  employeeSessions OneOnOneSession[] @relation("OneOnOneAsEmployee")
+  oneOnOneLogs     OneOnOneLog[]     @relation("OneOnOneLogRecorder")
 
   @@index([emailHash])
   @@index([status])
@@ -506,4 +509,51 @@ model GoalProgressHistory {
 
   @@index([goalId, recordedAt])
   @@map("goal_progress_history")
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 1on1 管理 (Requirement 7)
+// ─────────────────────────────────────────────────────────────────────────────
+
+enum OneOnOneVisibility {
+  MANAGER_ONLY
+  BOTH
+}
+
+model OneOnOneSession {
+  id          String   @id @default(cuid())
+  managerId   String
+  employeeId  String
+  scheduledAt DateTime
+  durationMin Int
+  agenda      String?
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  manager  User          @relation("OneOnOneAsManager",  fields: [managerId],  references: [id])
+  employee User          @relation("OneOnOneAsEmployee", fields: [employeeId], references: [id])
+  logs     OneOnOneLog[]
+
+  @@index([managerId])
+  @@index([employeeId])
+  @@index([scheduledAt])
+  @@map("one_on_one_sessions")
+}
+
+model OneOnOneLog {
+  id          String             @id @default(cuid())
+  sessionId   String
+  agenda      String?
+  content     String
+  nextActions String?
+  visibility  OneOnOneVisibility @default(MANAGER_ONLY)
+  recordedBy  String
+  recordedAt  DateTime           @default(now())
+
+  session  OneOnOneSession @relation(fields: [sessionId], references: [id], onDelete: Cascade)
+  recorder User            @relation("OneOnOneLogRecorder", fields: [recordedBy], references: [id])
+
+  @@index([sessionId])
+  @@index([recordedAt])
+  @@map("one_on_one_logs")
 }

--- a/src/app/api/one-on-one/admin/logs/route.ts
+++ b/src/app/api/one-on-one/admin/logs/route.ts
@@ -1,0 +1,115 @@
+/**
+ * Issue #49 / Req 7.8: HR_MANAGER 向け全 1on1 ログ一覧 API
+ *
+ * GET /api/one-on-one/admin/logs?page=1&limit=20&from=...&to=...
+ * - HR_MANAGER 以上のみ参照可能
+ * - 200: { data: AllLogEntry[]; total: number }
+ * - 400: クエリパラメータ不正
+ * - 401 / 403: 認証/認可エラー
+ * - 503: サービス未初期化
+ */
+import { getServerSession } from 'next-auth'
+import { type NextRequest, NextResponse } from 'next/server'
+import {
+  createOneOnOneReminderService,
+  type OneOnOneReminderService,
+} from '@/lib/one-on-one/one-on-one-reminder-service'
+import { createInMemoryNotificationRepository } from '@/lib/notification/notification-repository'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// DI（テスト差し替え用）
+// ─────────────────────────────────────────────────────────────────────────────
+
+let _service: OneOnOneReminderService | null = null
+
+export function setAdminLogsServiceForTesting(s: OneOnOneReminderService): void {
+  _service = s
+}
+
+export function clearAdminLogsServiceForTesting(): void {
+  _service = null
+}
+
+function getService(): OneOnOneReminderService {
+  if (_service) return _service
+  return createOneOnOneReminderService({
+    subordinateRepo: {
+      async findAllSubordinatesWithLastLog() {
+        return []
+      },
+    },
+    sessionRepo: {
+      async findSessionsInRange() {
+        return []
+      },
+      async listAllLogs() {
+        return { data: [], total: 0 }
+      },
+    },
+    notificationRepo: createInMemoryNotificationRepository(),
+  })
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 認可: HR_MANAGER 以上
+// ─────────────────────────────────────────────────────────────────────────────
+
+const ALLOWED_ROLES = new Set(['ADMIN', 'HR_MANAGER'])
+
+function authorize(
+  serverSession: Awaited<ReturnType<typeof getServerSession>>,
+): { ok: true } | { ok: false; response: NextResponse } {
+  if (!serverSession?.user?.email) {
+    return { ok: false, response: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
+  }
+  const sess = serverSession as Record<string, unknown>
+  const role = typeof sess.role === 'string' ? sess.role : undefined
+  if (role === undefined || !ALLOWED_ROLES.has(role)) {
+    return { ok: false, response: NextResponse.json({ error: 'Forbidden' }, { status: 403 }) }
+  }
+  return { ok: true }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /api/one-on-one/admin/logs
+// ─────────────────────────────────────────────────────────────────────────────
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const serverSession = await getServerSession()
+  const auth = authorize(serverSession)
+  if (!auth.ok) return auth.response
+
+  const { searchParams } = req.nextUrl
+  const pageStr = searchParams.get('page') ?? '1'
+  const limitStr = searchParams.get('limit') ?? '20'
+  const fromStr = searchParams.get('from')
+  const toStr = searchParams.get('to')
+
+  const page = parseInt(pageStr, 10)
+  const limit = parseInt(limitStr, 10)
+
+  if (isNaN(page) || page < 1 || isNaN(limit) || limit < 1) {
+    return NextResponse.json(
+      { error: 'Invalid page or limit parameter' },
+      { status: 400 },
+    )
+  }
+
+  const from = fromStr ? new Date(fromStr) : undefined
+  const to = toStr ? new Date(toStr) : undefined
+
+  if (from && isNaN(from.getTime())) {
+    return NextResponse.json({ error: 'Invalid date format for from' }, { status: 400 })
+  }
+  if (to && isNaN(to.getTime())) {
+    return NextResponse.json({ error: 'Invalid date format for to' }, { status: 400 })
+  }
+
+  try {
+    const service = getService()
+    const result = await service.listAllLogs({ page, limit, from, to })
+    return NextResponse.json(result, { status: 200 })
+  } catch {
+    return NextResponse.json({ error: 'Service unavailable' }, { status: 503 })
+  }
+}

--- a/src/app/api/one-on-one/evaluation-links/route.ts
+++ b/src/app/api/one-on-one/evaluation-links/route.ts
@@ -1,0 +1,114 @@
+/**
+ * Issue #49 / Req 7.7: 評価フォーム用 1on1 ログ参照リンク API
+ *
+ * GET /api/one-on-one/evaluation-links?employeeId=...&from=...&to=...
+ * - 本人 または MANAGER 以上のみ参照可能
+ * - 200: EvaluationLogLink[]
+ * - 400: クエリパラメータ不正
+ * - 401 / 403: 認証/認可エラー
+ * - 503: サービス未初期化
+ */
+import { getServerSession } from 'next-auth'
+import { type NextRequest, NextResponse } from 'next/server'
+import {
+  createOneOnOneReminderService,
+  type OneOnOneReminderService,
+} from '@/lib/one-on-one/one-on-one-reminder-service'
+import { createInMemoryNotificationRepository } from '@/lib/notification/notification-repository'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// DI（テスト差し替え用）
+// ─────────────────────────────────────────────────────────────────────────────
+
+let _service: OneOnOneReminderService | null = null
+
+export function setEvaluationLinksServiceForTesting(s: OneOnOneReminderService): void {
+  _service = s
+}
+
+export function clearEvaluationLinksServiceForTesting(): void {
+  _service = null
+}
+
+function getService(): OneOnOneReminderService {
+  if (_service) return _service
+  return createOneOnOneReminderService({
+    subordinateRepo: {
+      async findAllSubordinatesWithLastLog() {
+        return []
+      },
+    },
+    sessionRepo: {
+      async findSessionsInRange() {
+        return []
+      },
+      async listAllLogs() {
+        return { data: [], total: 0 }
+      },
+    },
+    notificationRepo: createInMemoryNotificationRepository(),
+  })
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 認可: 本人 または MANAGER 以上
+// ─────────────────────────────────────────────────────────────────────────────
+
+const ALLOWED_ROLES = new Set(['ADMIN', 'HR_MANAGER', 'MANAGER'])
+
+function authorize(
+  serverSession: Awaited<ReturnType<typeof getServerSession>>,
+  employeeId: string,
+): { ok: true } | { ok: false; response: NextResponse } {
+  if (!serverSession?.user?.email) {
+    return { ok: false, response: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
+  }
+  const sess = serverSession as Record<string, unknown>
+  const role = typeof sess.role === 'string' ? sess.role : undefined
+  const userId = typeof sess.id === 'string' ? sess.id : undefined
+
+  const isSelf = userId === employeeId
+  const isManagerOrAbove = role !== undefined && ALLOWED_ROLES.has(role)
+
+  if (!isSelf && !isManagerOrAbove) {
+    return { ok: false, response: NextResponse.json({ error: 'Forbidden' }, { status: 403 }) }
+  }
+  return { ok: true }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /api/one-on-one/evaluation-links
+// ─────────────────────────────────────────────────────────────────────────────
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const { searchParams } = req.nextUrl
+  const employeeId = searchParams.get('employeeId')
+  const fromStr = searchParams.get('from')
+  const toStr = searchParams.get('to')
+
+  if (!employeeId || !fromStr || !toStr) {
+    return NextResponse.json(
+      { error: 'Missing required query parameters: employeeId, from, to' },
+      { status: 400 },
+    )
+  }
+
+  const from = new Date(fromStr)
+  const to = new Date(toStr)
+
+  if (isNaN(from.getTime()) || isNaN(to.getTime())) {
+    return NextResponse.json({ error: 'Invalid date format for from or to' }, { status: 400 })
+  }
+
+  const serverSession = await getServerSession()
+  const auth = authorize(serverSession, employeeId)
+  if (!auth.ok) return auth.response
+
+  try {
+    const service = getService()
+    const links = await service.getEvaluationLinks(employeeId, from, to)
+    return NextResponse.json(links, { status: 200 })
+  } catch {
+    return NextResponse.json({ error: 'Service unavailable' }, { status: 503 })
+  }
+}

--- a/src/app/api/one-on-one/reminder/scan/route.ts
+++ b/src/app/api/one-on-one/reminder/scan/route.ts
@@ -1,0 +1,86 @@
+/**
+ * Issue #49 / Req 7.6: 1on1ログ未入力リマインダー手動トリガー API
+ *
+ * POST /api/one-on-one/reminder/scan
+ * - ADMIN のみ実行可能
+ * - 200: { notified: number; skipped: number }
+ * - 401 / 403: 認証/認可エラー
+ * - 503: サービス未初期化
+ */
+import { getServerSession } from 'next-auth'
+import { type NextRequest, NextResponse } from 'next/server'
+import {
+  createOneOnOneReminderService,
+  type OneOnOneReminderService,
+} from '@/lib/one-on-one/one-on-one-reminder-service'
+import { createInMemoryNotificationRepository } from '@/lib/notification/notification-repository'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// DI（テスト差し替え用）
+// ─────────────────────────────────────────────────────────────────────────────
+
+let _service: OneOnOneReminderService | null = null
+
+export function setOneOnOneReminderServiceForTesting(s: OneOnOneReminderService): void {
+  _service = s
+}
+
+export function clearOneOnOneReminderServiceForTesting(): void {
+  _service = null
+}
+
+function getService(): OneOnOneReminderService {
+  if (_service) return _service
+  return createOneOnOneReminderService({
+    subordinateRepo: {
+      async findAllSubordinatesWithLastLog() {
+        return []
+      },
+    },
+    sessionRepo: {
+      async findSessionsInRange() {
+        return []
+      },
+      async listAllLogs() {
+        return { data: [], total: 0 }
+      },
+    },
+    notificationRepo: createInMemoryNotificationRepository(),
+  })
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 認可
+// ─────────────────────────────────────────────────────────────────────────────
+
+function authorize(
+  serverSession: Awaited<ReturnType<typeof getServerSession>>,
+): { ok: true } | { ok: false; response: NextResponse } {
+  if (!serverSession?.user?.email) {
+    return { ok: false, response: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
+  }
+  const sess = serverSession as Record<string, unknown>
+  const role = typeof sess.role === 'string' ? sess.role : undefined
+  if (role !== 'ADMIN') {
+    return { ok: false, response: NextResponse.json({ error: 'Forbidden' }, { status: 403 }) }
+  }
+  return { ok: true }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// POST /api/one-on-one/reminder/scan
+// ─────────────────────────────────────────────────────────────────────────────
+
+export async function POST(_req: NextRequest): Promise<NextResponse> {
+  const serverSession = await getServerSession()
+  const auth = authorize(serverSession)
+  if (!auth.ok) return auth.response
+
+  try {
+    const service = getService()
+    const result = await service.scanMissingLogs()
+    return NextResponse.json(result, { status: 200 })
+  } catch {
+    return NextResponse.json({ error: 'Service unavailable' }, { status: 503 })
+  }
+}

--- a/src/lib/jobs/job-types.ts
+++ b/src/lib/jobs/job-types.ts
@@ -14,6 +14,7 @@ export const JOB_NAMES = [
   'anonymize-user',
   'ai-feedback-generation',
   'goal-deadline-alert',
+  'one-on-one-reminder',
 ] as const
 
 export type JobName = (typeof JOB_NAMES)[number]
@@ -55,6 +56,10 @@ export const jobPayloadSchema = {
   }),
 
   'goal-deadline-alert': z.object({
+    triggeredAt: z.string().datetime(),
+  }),
+
+  'one-on-one-reminder': z.object({
     triggeredAt: z.string().datetime(),
   }),
 } satisfies Record<JobName, z.ZodTypeAny>

--- a/src/lib/jobs/one-on-one-reminder-worker.ts
+++ b/src/lib/jobs/one-on-one-reminder-worker.ts
@@ -1,0 +1,67 @@
+/**
+ * Issue #49 / Req 7.6: one-on-one-reminder ジョブワーカー
+ *
+ * BullMQ の one-on-one-reminder キューからジョブを取り出し、
+ * OneOnOneReminderService.scanMissingLogs() を呼び出して
+ * 30日以上ログがない部下を検出し通知を送信する。
+ *
+ * cron: '0 9 * * *' (JST 09:00)
+ */
+import type { Job } from 'bullmq'
+import { jobPayloadSchema } from '@/lib/jobs/job-types'
+import { createBaseWorker } from '@/lib/jobs/base-worker'
+import type { OneOnOneReminderService } from '@/lib/one-on-one/one-on-one-reminder-service'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Result type
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface OneOnOneReminderJobResult {
+  readonly triggeredAt: string
+  readonly notified: number
+  readonly skipped: number
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Payload validation
+// ─────────────────────────────────────────────────────────────────────────────
+
+function isOneOnOneReminderPayload(value: unknown): value is { triggeredAt: string } {
+  return jobPayloadSchema['one-on-one-reminder'].safeParse(value).success
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ジョブプロセッサ（テスト可能な関数として分離）
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * one-on-one-reminder ジョブを処理する。
+ * OneOnOneReminderService は DI で受け取る。
+ */
+export async function processOneOnOneReminderJob(
+  job: Job,
+  service: OneOnOneReminderService,
+): Promise<OneOnOneReminderJobResult> {
+  const payload = job.data as unknown
+
+  if (!isOneOnOneReminderPayload(payload)) {
+    throw new Error(`OneOnOneReminderWorker: invalid payload for job "${job.id ?? 'unknown'}"`)
+  }
+
+  const now = new Date(payload.triggeredAt)
+  const result = await service.scanMissingLogs(now)
+
+  return {
+    triggeredAt: payload.triggeredAt,
+    notified: result.notified,
+    skipped: result.skipped,
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ワーカー起動ファクトリ
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function createOneOnOneReminderWorker(service: OneOnOneReminderService) {
+  return createBaseWorker('one-on-one-reminder', (job) => processOneOnOneReminderJob(job, service))
+}

--- a/src/lib/one-on-one/one-on-one-reminder-service.ts
+++ b/src/lib/one-on-one/one-on-one-reminder-service.ts
@@ -1,0 +1,175 @@
+/**
+ * Issue #49 / Req 7.6, 7.7, 7.8: 1on1ログ未入力リマインダーサービス
+ *
+ * - 30日以上ログがない部下を検出し、MANAGERに DEADLINE_ALERT 通知
+ * - 評価フォーム用: 指定期間の 1on1 ログへの参照リンクを返す
+ * - HR_MANAGER 用: 全 1on1 ログ一覧（ページネーション付き）
+ */
+
+import type { NotificationRepository } from '@/lib/notification/notification-repository'
+import type {
+  AllLogsQuery,
+  AllLogsResult,
+  EvaluationLogLink,
+  MissingLogEmployee,
+} from './one-on-one-reminder-types'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 定数
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** ログ未入力とみなす閾値（日数） */
+export const MISSING_LOG_THRESHOLD_DAYS = 30
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Repository interfaces (依存性逆転)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** MANAGERとその部下の関係を取得するリポジトリ */
+export interface ManagerSubordinateRepository {
+  /**
+   * 全マネージャーとその部下ペア、および各部下の最終ログ日時を返す
+   * lastLogDate が null の場合は一度もログなし
+   */
+  findAllSubordinatesWithLastLog(now: Date): Promise<readonly MissingLogEmployee[]>
+}
+
+/** 1on1セッションを取得するリポジトリ */
+export interface OneOnOneSessionRepository {
+  /**
+   * 指定期間内に scheduledAt がある employeeId のセッション一覧を返す
+   * ログが存在するかどうかも含む
+   */
+  findSessionsInRange(
+    employeeId: string,
+    from: Date,
+    to: Date,
+  ): Promise<readonly EvaluationLogLink[]>
+
+  /**
+   * 全セッションに紐づくログ一覧をページネーション付きで返す
+   */
+  listAllLogs(query: AllLogsQuery): Promise<AllLogsResult>
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Service interface
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface ScanMissingLogsResult {
+  readonly notified: number
+  readonly skipped: number
+}
+
+export interface OneOnOneReminderService {
+  /**
+   * 30日以上ログがない部下を検出し、MANAGERに DEADLINE_ALERT 通知
+   * @param now スキャン基準日時（省略時は現在時刻）
+   */
+  scanMissingLogs(now?: Date): Promise<ScanMissingLogsResult>
+
+  /**
+   * 評価フォーム用: 指定期間の 1on1 ログへの参照リンクを返す
+   */
+  getEvaluationLinks(
+    employeeId: string,
+    from: Date,
+    to: Date,
+  ): Promise<readonly EvaluationLogLink[]>
+
+  /**
+   * HR_MANAGER 用: 全 1on1 ログ一覧（ページネーション付き）
+   */
+  listAllLogs(query: AllLogsQuery): Promise<AllLogsResult>
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 内部ヘルパ
+// ─────────────────────────────────────────────────────────────────────────────
+
+function calcDaysSince(now: Date, lastLogDate: Date): number {
+  const diffMs = now.getTime() - lastLogDate.getTime()
+  return Math.floor(diffMs / (1000 * 60 * 60 * 24))
+}
+
+function buildMissingLogNotificationTitle(): string {
+  return '1on1ログが未入力です'
+}
+
+function buildMissingLogNotificationBody(employeeId: string, daysSince: number): string {
+  return `部下（ID: ${employeeId}）の1on1ログが${daysSince}日間未入力です。早めに記録しましょう。`
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Implementation
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface Dependencies {
+  readonly subordinateRepo: ManagerSubordinateRepository
+  readonly sessionRepo: OneOnOneSessionRepository
+  readonly notificationRepo: NotificationRepository
+}
+
+class OneOnOneReminderServiceImpl implements OneOnOneReminderService {
+  constructor(private readonly deps: Dependencies) {}
+
+  async scanMissingLogs(now?: Date): Promise<ScanMissingLogsResult> {
+    const scanTime = now ?? new Date()
+    const subordinates = await this.deps.subordinateRepo.findAllSubordinatesWithLastLog(scanTime)
+
+    let notified = 0
+    let skipped = 0
+
+    for (const sub of subordinates) {
+      const daysSince =
+        sub.lastLogDate === null
+          ? MISSING_LOG_THRESHOLD_DAYS // 一度もログなし → 閾値以上とみなす
+          : calcDaysSince(scanTime, sub.lastLogDate)
+
+      if (daysSince < MISSING_LOG_THRESHOLD_DAYS) {
+        skipped += 1
+        continue
+      }
+
+      try {
+        await this.deps.notificationRepo.create({
+          userId: sub.managerId,
+          category: 'DEADLINE_ALERT',
+          title: buildMissingLogNotificationTitle(),
+          body: buildMissingLogNotificationBody(sub.employeeId, daysSince),
+          payload: {
+            employeeId: sub.employeeId,
+            daysSinceLastLog: daysSince,
+            lastLogDate: sub.lastLogDate?.toISOString() ?? null,
+          },
+        })
+        notified += 1
+      } catch {
+        // 通知サービスが未初期化の場合などは無視してスキップ扱い
+        skipped += 1
+      }
+    }
+
+    return { notified, skipped }
+  }
+
+  async getEvaluationLinks(
+    employeeId: string,
+    from: Date,
+    to: Date,
+  ): Promise<readonly EvaluationLogLink[]> {
+    return this.deps.sessionRepo.findSessionsInRange(employeeId, from, to)
+  }
+
+  async listAllLogs(query: AllLogsQuery): Promise<AllLogsResult> {
+    return this.deps.sessionRepo.listAllLogs(query)
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Factory
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function createOneOnOneReminderService(deps: Dependencies): OneOnOneReminderService {
+  return new OneOnOneReminderServiceImpl(deps)
+}

--- a/src/lib/one-on-one/one-on-one-reminder-types.ts
+++ b/src/lib/one-on-one/one-on-one-reminder-types.ts
@@ -1,0 +1,58 @@
+/**
+ * Issue #49 / Req 7.6, 7.7, 7.8: 1on1ログ未入力リマインダー型定義
+ */
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ログ未入力検出
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** 30日以上ログがない部下の情報 */
+export interface MissingLogEmployee {
+  readonly managerId: string
+  readonly employeeId: string
+  /** 最後にログが記録された日時。null = 一度もログなし */
+  readonly lastLogDate: Date | null
+  readonly daysSinceLastLog: number
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 評価フォーム連携
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** 評価フォーム用 1on1 セッションへの参照リンク */
+export interface EvaluationLogLink {
+  readonly sessionId: string
+  readonly scheduledAt: Date
+  readonly logId: string | null
+  readonly hasLog: boolean
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// HR_MANAGER 向け全ログ一覧
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** HR_MANAGER 向け全ログエントリ */
+export interface AllLogEntry {
+  readonly logId: string
+  readonly sessionId: string
+  readonly managerId: string
+  readonly employeeId: string
+  readonly scheduledAt: Date
+  readonly content: string
+  readonly visibility: 'MANAGER_ONLY' | 'BOTH'
+  readonly recordedAt: Date
+}
+
+/** 全ログ一覧クエリパラメータ */
+export interface AllLogsQuery {
+  readonly page: number
+  readonly limit: number
+  readonly from?: Date
+  readonly to?: Date
+}
+
+/** 全ログ一覧レスポンス */
+export interface AllLogsResult {
+  readonly data: readonly AllLogEntry[]
+  readonly total: number
+}

--- a/src/tests/one-on-one/one-on-one-reminder-service.test.ts
+++ b/src/tests/one-on-one/one-on-one-reminder-service.test.ts
@@ -1,0 +1,397 @@
+/**
+ * Issue #49 / Req 7.6, 7.7, 7.8: OneOnOneReminderService 単体テスト
+ *
+ * - 30日超のログなし部下が検出されるテスト
+ * - 29日以内のログある部下はスキップされるテスト
+ * - 評価期間リンク取得テスト
+ * - 全ログ一覧ページネーションテスト
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  createOneOnOneReminderService,
+  MISSING_LOG_THRESHOLD_DAYS,
+  type ManagerSubordinateRepository,
+  type OneOnOneSessionRepository,
+} from '@/lib/one-on-one/one-on-one-reminder-service'
+import { createInMemoryNotificationRepository } from '@/lib/notification/notification-repository'
+import type {
+  MissingLogEmployee,
+  EvaluationLogLink,
+  AllLogEntry,
+} from '@/lib/one-on-one/one-on-one-reminder-types'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+const NOW = new Date('2026-04-19T00:00:00.000Z')
+
+function daysAgo(days: number): Date {
+  return new Date(NOW.getTime() - days * 24 * 60 * 60 * 1000)
+}
+
+function makeSub(
+  overrides: Partial<MissingLogEmployee> & { managerId: string; employeeId: string },
+): MissingLogEmployee {
+  return {
+    lastLogDate: daysAgo(MISSING_LOG_THRESHOLD_DAYS),
+    daysSinceLastLog: MISSING_LOG_THRESHOLD_DAYS,
+    ...overrides,
+  }
+}
+
+function makeSubordinateRepo(subs: readonly MissingLogEmployee[]): ManagerSubordinateRepository {
+  return {
+    async findAllSubordinatesWithLastLog() {
+      return subs
+    },
+  }
+}
+
+function makeSessionRepo(
+  links: readonly EvaluationLogLink[] = [],
+  logs: readonly AllLogEntry[] = [],
+): OneOnOneSessionRepository {
+  return {
+    async findSessionsInRange() {
+      return links
+    },
+    async listAllLogs(query) {
+      const start = (query.page - 1) * query.limit
+      const paginated = logs.slice(start, start + query.limit)
+      return { data: paginated, total: logs.length }
+    },
+  }
+}
+
+function makeService(
+  subs: readonly MissingLogEmployee[],
+  links: readonly EvaluationLogLink[] = [],
+  logs: readonly AllLogEntry[] = [],
+) {
+  const notificationRepo = createInMemoryNotificationRepository()
+  const svc = createOneOnOneReminderService({
+    subordinateRepo: makeSubordinateRepo(subs),
+    sessionRepo: makeSessionRepo(links, logs),
+    notificationRepo,
+  })
+  return { svc, notificationRepo }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests: scanMissingLogs
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('OneOnOneReminderService.scanMissingLogs', () => {
+  describe('30日超のログなし部下が検出される', () => {
+    it('ちょうど30日前のログがある部下は通知される', async () => {
+      // Arrange
+      const sub = makeSub({
+        managerId: 'mgr-1',
+        employeeId: 'emp-1',
+        lastLogDate: daysAgo(30),
+        daysSinceLastLog: 30,
+      })
+      const { svc, notificationRepo } = makeService([sub])
+
+      // Act
+      const result = await svc.scanMissingLogs(NOW)
+
+      // Assert
+      expect(result.notified).toBe(1)
+      expect(result.skipped).toBe(0)
+      const notifications = await notificationRepo.listByUser('mgr-1')
+      expect(notifications).toHaveLength(1)
+      expect(notifications[0].category).toBe('DEADLINE_ALERT')
+      expect(notifications[0].userId).toBe('mgr-1')
+    })
+
+    it('31日前のログがある部下は通知される', async () => {
+      // Arrange
+      const sub = makeSub({
+        managerId: 'mgr-1',
+        employeeId: 'emp-2',
+        lastLogDate: daysAgo(31),
+        daysSinceLastLog: 31,
+      })
+      const { svc } = makeService([sub])
+
+      // Act
+      const result = await svc.scanMissingLogs(NOW)
+
+      // Assert
+      expect(result.notified).toBe(1)
+      expect(result.skipped).toBe(0)
+    })
+
+    it('一度もログがない部下は通知される', async () => {
+      // Arrange
+      const sub = makeSub({
+        managerId: 'mgr-2',
+        employeeId: 'emp-3',
+        lastLogDate: null,
+        daysSinceLastLog: MISSING_LOG_THRESHOLD_DAYS,
+      })
+      const { svc, notificationRepo } = makeService([sub])
+
+      // Act
+      const result = await svc.scanMissingLogs(NOW)
+
+      // Assert
+      expect(result.notified).toBe(1)
+      expect(result.skipped).toBe(0)
+      const notifications = await notificationRepo.listByUser('mgr-2')
+      expect(notifications[0].title).toBe('1on1ログが未入力です')
+    })
+
+    it('複数の部下が閾値超えの場合、全員通知される', async () => {
+      // Arrange
+      const subs = [
+        makeSub({
+          managerId: 'mgr-3',
+          employeeId: 'emp-4',
+          lastLogDate: daysAgo(35),
+          daysSinceLastLog: 35,
+        }),
+        makeSub({
+          managerId: 'mgr-3',
+          employeeId: 'emp-5',
+          lastLogDate: null,
+          daysSinceLastLog: 30,
+        }),
+      ]
+      const { svc } = makeService(subs)
+
+      // Act
+      const result = await svc.scanMissingLogs(NOW)
+
+      // Assert
+      expect(result.notified).toBe(2)
+      expect(result.skipped).toBe(0)
+    })
+  })
+
+  describe('29日以内のログがある部下はスキップされる', () => {
+    it('29日前のログがある部下はスキップされる', async () => {
+      // Arrange
+      const sub = makeSub({
+        managerId: 'mgr-4',
+        employeeId: 'emp-6',
+        lastLogDate: daysAgo(29),
+        daysSinceLastLog: 29,
+      })
+      const { svc } = makeService([sub])
+
+      // Act
+      const result = await svc.scanMissingLogs(NOW)
+
+      // Assert
+      expect(result.notified).toBe(0)
+      expect(result.skipped).toBe(1)
+    })
+
+    it('1日前のログがある部下はスキップされる', async () => {
+      // Arrange
+      const sub = makeSub({
+        managerId: 'mgr-4',
+        employeeId: 'emp-7',
+        lastLogDate: daysAgo(1),
+        daysSinceLastLog: 1,
+      })
+      const { svc } = makeService([sub])
+
+      // Act
+      const result = await svc.scanMissingLogs(NOW)
+
+      // Assert
+      expect(result.notified).toBe(0)
+      expect(result.skipped).toBe(1)
+    })
+
+    it('通知すべき部下とスキップすべき部下が混在する場合、それぞれ正しくカウントされる', async () => {
+      // Arrange
+      const subs = [
+        makeSub({
+          managerId: 'mgr-5',
+          employeeId: 'emp-8',
+          lastLogDate: daysAgo(30),
+          daysSinceLastLog: 30,
+        }), // 通知
+        makeSub({
+          managerId: 'mgr-5',
+          employeeId: 'emp-9',
+          lastLogDate: daysAgo(29),
+          daysSinceLastLog: 29,
+        }), // スキップ
+        makeSub({
+          managerId: 'mgr-5',
+          employeeId: 'emp-10',
+          lastLogDate: null,
+          daysSinceLastLog: 30,
+        }), // 通知
+        makeSub({
+          managerId: 'mgr-5',
+          employeeId: 'emp-11',
+          lastLogDate: daysAgo(10),
+          daysSinceLastLog: 10,
+        }), // スキップ
+      ]
+      const { svc } = makeService(subs)
+
+      // Act
+      const result = await svc.scanMissingLogs(NOW)
+
+      // Assert
+      expect(result.notified).toBe(2)
+      expect(result.skipped).toBe(2)
+    })
+  })
+
+  describe('部下がいない / now 省略', () => {
+    it('部下が0件のとき notified/skipped ともに 0', async () => {
+      // Arrange
+      const { svc } = makeService([])
+
+      // Act
+      const result = await svc.scanMissingLogs(NOW)
+
+      // Assert
+      expect(result.notified).toBe(0)
+      expect(result.skipped).toBe(0)
+    })
+
+    it('now を省略しても正常に動作する', async () => {
+      // Arrange
+      const { svc } = makeService([])
+
+      // Act
+      const result = await svc.scanMissingLogs()
+
+      // Assert
+      expect(result.notified).toBe(0)
+      expect(result.skipped).toBe(0)
+    })
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests: getEvaluationLinks
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('OneOnOneReminderService.getEvaluationLinks', () => {
+  it('指定期間のセッションリンクを返す', async () => {
+    // Arrange
+    const links: EvaluationLogLink[] = [
+      {
+        sessionId: 'sess-1',
+        scheduledAt: new Date('2026-03-01T10:00:00Z'),
+        logId: 'log-1',
+        hasLog: true,
+      },
+      {
+        sessionId: 'sess-2',
+        scheduledAt: new Date('2026-03-15T10:00:00Z'),
+        logId: null,
+        hasLog: false,
+      },
+    ]
+    const { svc } = makeService([], links)
+    const from = new Date('2026-03-01T00:00:00Z')
+    const to = new Date('2026-03-31T23:59:59Z')
+
+    // Act
+    const result = await svc.getEvaluationLinks('emp-1', from, to)
+
+    // Assert
+    expect(result).toHaveLength(2)
+    expect(result[0].sessionId).toBe('sess-1')
+    expect(result[0].hasLog).toBe(true)
+    expect(result[1].sessionId).toBe('sess-2')
+    expect(result[1].hasLog).toBe(false)
+    expect(result[1].logId).toBeNull()
+  })
+
+  it('対象期間にセッションがない場合は空配列を返す', async () => {
+    // Arrange
+    const { svc } = makeService([], [])
+    const from = new Date('2026-03-01T00:00:00Z')
+    const to = new Date('2026-03-31T23:59:59Z')
+
+    // Act
+    const result = await svc.getEvaluationLinks('emp-1', from, to)
+
+    // Assert
+    expect(result).toHaveLength(0)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests: listAllLogs (ページネーション)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('OneOnOneReminderService.listAllLogs', () => {
+  function makeLogs(count: number): AllLogEntry[] {
+    return Array.from({ length: count }, (_, i) => ({
+      logId: `log-${i + 1}`,
+      sessionId: `sess-${i + 1}`,
+      managerId: 'mgr-1',
+      employeeId: 'emp-1',
+      scheduledAt: new Date('2026-03-01T10:00:00Z'),
+      content: `ログ内容 ${i + 1}`,
+      visibility: (i % 2 === 0 ? 'MANAGER_ONLY' : 'BOTH') as 'MANAGER_ONLY' | 'BOTH',
+      recordedAt: new Date('2026-03-01T12:00:00Z'),
+    }))
+  }
+
+  it('page=1, limit=5 のとき最初の5件と total を返す', async () => {
+    // Arrange
+    const logs = makeLogs(12)
+    const { svc } = makeService([], [], logs)
+
+    // Act
+    const result = await svc.listAllLogs({ page: 1, limit: 5 })
+
+    // Assert
+    expect(result.data).toHaveLength(5)
+    expect(result.total).toBe(12)
+    expect(result.data[0].logId).toBe('log-1')
+  })
+
+  it('page=2, limit=5 のとき次の5件を返す', async () => {
+    // Arrange
+    const logs = makeLogs(12)
+    const { svc } = makeService([], [], logs)
+
+    // Act
+    const result = await svc.listAllLogs({ page: 2, limit: 5 })
+
+    // Assert
+    expect(result.data).toHaveLength(5)
+    expect(result.data[0].logId).toBe('log-6')
+  })
+
+  it('最終ページが端数の場合、残り件数のみ返す', async () => {
+    // Arrange
+    const logs = makeLogs(12)
+    const { svc } = makeService([], [], logs)
+
+    // Act
+    const result = await svc.listAllLogs({ page: 3, limit: 5 })
+
+    // Assert
+    expect(result.data).toHaveLength(2)
+    expect(result.total).toBe(12)
+  })
+
+  it('ログが0件のとき空配列と total=0 を返す', async () => {
+    // Arrange
+    const { svc } = makeService([], [], [])
+
+    // Act
+    const result = await svc.listAllLogs({ page: 1, limit: 20 })
+
+    // Assert
+    expect(result.data).toHaveLength(0)
+    expect(result.total).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary
- 30日以上ログがない部下を検出しMANAGERに通知する定期ジョブ（Req 7.6）
- 評価フォーム内への対象期間1on1ログ参照リンク（Req 7.7）
- HR_MANAGER以上が全1on1ログを参照可能（Req 7.8）

## 変更ファイル
- `src/lib/jobs/job-types.ts` — `one-on-one-reminder` ジョブ追加
- `src/lib/one-on-one/one-on-one-reminder-types.ts` — MissingLogEmployee・EvaluationLogLink等
- `src/lib/one-on-one/one-on-one-reminder-service.ts` — scanMissingLogs / getEvaluationLinks / listAllLogs
- `src/lib/jobs/one-on-one-reminder-worker.ts` — BullMQワーカー
- `src/app/api/one-on-one/reminder/scan/route.ts` — 手動トリガー（ADMIN）
- `src/app/api/one-on-one/evaluation-links/route.ts` — 評価リンク取得
- `src/app/api/one-on-one/admin/logs/route.ts` — 全ログ一覧（HR_MANAGER以上）
- `src/tests/one-on-one/one-on-one-reminder-service.test.ts` — 15件テスト全通過

## マージ順序の注意
**PR #133（#47）を先にマージ**してからこのPRをマージしてください。

## Test plan
- [ ] 30日超ログなし部下 → 通知送信
- [ ] 29日以内 → スキップ
- [ ] `GET /api/one-on-one/admin/logs` — HR_MANAGER以上のみ

Closes #49