### PR TITLE
[#50] 共有EvaluationEventBusの構築

### DIFF
--- a/src/app/api/evaluation/events/route.ts
+++ b/src/app/api/evaluation/events/route.ts
@@ -1,0 +1,77 @@
+/**
+ * Issue #50 / Task 15.1: テスト用イベント発火 API
+ *
+ * POST /api/evaluation/events — ADMIN のみ
+ * body: { name: EvaluationEventName, payload: unknown }
+ *
+ * Zod バリデーション後に EvaluationEventBus.publish を呼ぶ。
+ */
+import { type NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+import {
+  EVALUATION_EVENT_NAMES,
+  evaluationEventSchema,
+} from '@/lib/evaluation/evaluation-event-types'
+import { getEvaluationEventBus } from '@/lib/evaluation/evaluation-event-bus-di'
+import { requireAuthenticated } from '@/lib/skill/skill-route-helpers'
+
+export {
+  setEvaluationEventBusForTesting,
+  clearEvaluationEventBusForTesting,
+} from '@/lib/evaluation/evaluation-event-bus-di'
+
+// リクエストボディのスキーマ（name のみ先に検証）
+const requestBodySchema = z.object({
+  name: z.enum(EVALUATION_EVENT_NAMES),
+  payload: z.unknown(),
+})
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  // 認証 & ADMIN ロールチェック
+  const guard = await requireAuthenticated()
+  if (!guard.ok) return guard.response
+  if (guard.session.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden: ADMIN role required' }, { status: 403 })
+  }
+
+  // JSON パース
+  let body: unknown
+  try {
+    body = (await request.json()) as unknown
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
+  }
+
+  // name + payload の構造チェック
+  const parsed = requestBodySchema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.flatten() }, { status: 422 })
+  }
+
+  const { name, payload } = parsed.data
+
+  // name に対応するスキーマでペイロードをバリデーション
+  const payloadSchema = evaluationEventSchema[name]
+  const payloadResult = payloadSchema.safeParse(payload)
+  if (!payloadResult.success) {
+    return NextResponse.json({ error: payloadResult.error.flatten() }, { status: 422 })
+  }
+
+  // バスを取得して publish
+  let bus: ReturnType<typeof getEvaluationEventBus>
+  try {
+    bus = getEvaluationEventBus()
+  } catch {
+    return NextResponse.json({ error: 'EvaluationEventBus not initialized' }, { status: 503 })
+  }
+
+  try {
+    // payloadResult.data は name に対応した型になっているが、
+    // 型システム上は union になるため型アサーションで解決する
+    await bus.publish(name, payloadResult.data as Parameters<typeof bus.publish>[1])
+    return NextResponse.json({ success: true }, { status: 200 })
+  } catch (err) {
+    console.error('[POST /api/evaluation/events] publish error:', err)
+    return NextResponse.json({ error: 'Failed to publish event' }, { status: 500 })
+  }
+}

--- a/src/lib/evaluation/create-evaluation-event-bus.ts
+++ b/src/lib/evaluation/create-evaluation-event-bus.ts
@@ -1,0 +1,16 @@
+/**
+ * Issue #50 / Task 15.1: EvaluationEventBus ファクトリ
+ *
+ * Redis Pub/Sub 用に publisher / subscriber で別々の接続を生成する。
+ * ioredis の仕様上、subscribe モードに入った接続は publish に使えないため分離が必要。
+ */
+import { Redis } from 'ioredis'
+import type { EvaluationEventBus } from './evaluation-event-bus'
+import { RedisEvaluationEventBus } from './evaluation-event-bus'
+
+export function createEvaluationEventBus(): EvaluationEventBus {
+  const url = process.env.REDIS_URL ?? 'redis://localhost:6379'
+  const publisher = new Redis(url)
+  const subscriber = new Redis(url)
+  return new RedisEvaluationEventBus(publisher, subscriber)
+}

--- a/src/lib/evaluation/evaluation-event-bus-di.ts
+++ b/src/lib/evaluation/evaluation-event-bus-di.ts
@@ -1,0 +1,30 @@
+/**
+ * Issue #50 / Task 15.1: EvaluationEventBus DI シングルトン
+ *
+ * - テスト: setEvaluationEventBusForTesting / clearEvaluationEventBusForTesting で差し替え
+ * - プロダクション: アプリ起動時に initEvaluationEventBus を呼んで初期化
+ */
+import type { EvaluationEventBus } from './evaluation-event-bus'
+
+let _bus: EvaluationEventBus | null = null
+
+export function initEvaluationEventBus(bus: EvaluationEventBus): void {
+  _bus = bus
+}
+
+export function getEvaluationEventBus(): EvaluationEventBus {
+  if (_bus) return _bus
+  throw new Error(
+    'EvaluationEventBus is not initialized. ' +
+      'テストでは setEvaluationEventBusForTesting() を呼んでください。' +
+      'プロダクションではサーバー起動前に initEvaluationEventBus() を呼んでください。',
+  )
+}
+
+export function setEvaluationEventBusForTesting(bus: EvaluationEventBus): void {
+  _bus = bus
+}
+
+export function clearEvaluationEventBusForTesting(): void {
+  _bus = null
+}

--- a/src/lib/evaluation/evaluation-event-bus.ts
+++ b/src/lib/evaluation/evaluation-event-bus.ts
@@ -1,0 +1,213 @@
+/**
+ * Issue #50 / Task 15.1: 共有 EvaluationEventBus
+ *
+ * - EvaluationEventBus インターフェース
+ * - InMemoryEvaluationEventBus（テスト用スタブ）
+ * - RedisEvaluationEventBus（Redis Pub/Sub ベース本番実装）
+ */
+import type { Redis } from 'ioredis'
+import {
+  type EvaluationEventName,
+  type EvaluationEventPayloadMap,
+  evaluationEventSchema,
+} from './evaluation-event-types'
+
+// Redis Pub/Sub チャンネル名
+export const EVALUATION_EVENT_CHANNEL = 'hr:evaluation-events'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Re-exports for convenience
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type { EvaluationEventName, EvaluationEventPayloadMap }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Interface
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface EvaluationEventBus {
+  /** イベントを publish（publisher 接続を使用） */
+  publish<N extends EvaluationEventName>(
+    name: N,
+    payload: EvaluationEventPayloadMap[N],
+  ): Promise<void>
+
+  /** subscriber を登録（handler は型安全に受け取れる） */
+  subscribe<N extends EvaluationEventName>(
+    eventName: N,
+    handler: (payload: EvaluationEventPayloadMap[N]) => Promise<void>,
+  ): void
+
+  /** 全 subscriber を解除して接続をクローズ */
+  close(): Promise<void>
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// InMemoryEvaluationEventBus（テスト用スタブ）
+// ─────────────────────────────────────────────────────────────────────────────
+
+type AnyHandler = (payload: EvaluationEventPayloadMap[EvaluationEventName]) => Promise<void>
+
+export class InMemoryEvaluationEventBus implements EvaluationEventBus {
+  private readonly handlers = new Map<EvaluationEventName, AnyHandler[]>()
+
+  subscribe<N extends EvaluationEventName>(
+    eventName: N,
+    handler: (payload: EvaluationEventPayloadMap[N]) => Promise<void>,
+  ): void {
+    const existing = this.handlers.get(eventName) ?? []
+    this.handlers.set(eventName, [...existing, handler as AnyHandler])
+  }
+
+  async publish<N extends EvaluationEventName>(
+    name: N,
+    payload: EvaluationEventPayloadMap[N],
+  ): Promise<void> {
+    // Zod バリデーション — 失敗時はログのみ、handler を呼ばない
+    const schema = evaluationEventSchema[name]
+    const result = schema.safeParse(payload)
+    if (!result.success) {
+      console.error(
+        `[EvaluationEventBus] Invalid payload for event "${name}":`,
+        result.error.flatten(),
+      )
+      return
+    }
+
+    const eventHandlers = this.handlers.get(name) ?? []
+    for (const handler of eventHandlers) {
+      try {
+        await handler(payload)
+      } catch (err) {
+        console.error(`[EvaluationEventBus] Handler error for event "${name}":`, err)
+      }
+    }
+  }
+
+  async close(): Promise<void> {
+    this.handlers.clear()
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Wire format
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface EvaluationEventMessage {
+  name: EvaluationEventName
+  payload: EvaluationEventPayloadMap[EvaluationEventName]
+  publishedAt: string
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// RedisEvaluationEventBus（本番実装）
+// ─────────────────────────────────────────────────────────────────────────────
+
+export class RedisEvaluationEventBus implements EvaluationEventBus {
+  private readonly handlers = new Map<EvaluationEventName, AnyHandler[]>()
+  private isSubscribed = false
+
+  constructor(
+    private readonly publisher: Redis,
+    private readonly subscriber: Redis,
+  ) {}
+
+  subscribe<N extends EvaluationEventName>(
+    eventName: N,
+    handler: (payload: EvaluationEventPayloadMap[N]) => Promise<void>,
+  ): void {
+    const existing = this.handlers.get(eventName) ?? []
+    this.handlers.set(eventName, [...existing, handler as AnyHandler])
+
+    if (!this.isSubscribed) {
+      this.isSubscribed = true
+      this.subscriber.subscribe(EVALUATION_EVENT_CHANNEL, (err) => {
+        if (err) {
+          console.error('[EvaluationEventBus] Redis subscribe error:', err)
+        }
+      })
+      this.subscriber.on('message', (_channel: string, message: string) => {
+        void this.handleMessage(message)
+      })
+    }
+  }
+
+  async publish<N extends EvaluationEventName>(
+    name: N,
+    payload: EvaluationEventPayloadMap[N],
+  ): Promise<void> {
+    // Zod バリデーション — 失敗時はログのみ、例外を再throwしない
+    const schema = evaluationEventSchema[name]
+    const result = schema.safeParse(payload)
+    if (!result.success) {
+      console.error(
+        `[EvaluationEventBus] Invalid payload for event "${name}":`,
+        result.error.flatten(),
+      )
+      return
+    }
+
+    const message: EvaluationEventMessage = {
+      name,
+      payload,
+      publishedAt: new Date().toISOString(),
+    }
+
+    await this.publisher.publish(EVALUATION_EVENT_CHANNEL, JSON.stringify(message))
+  }
+
+  private async handleMessage(raw: string): Promise<void> {
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(raw) as unknown
+    } catch (err) {
+      console.error('[EvaluationEventBus] Failed to parse message:', err)
+      return
+    }
+
+    if (
+      typeof parsed !== 'object' ||
+      parsed === null ||
+      !('name' in parsed) ||
+      !('payload' in parsed)
+    ) {
+      console.error('[EvaluationEventBus] Malformed message structure:', parsed)
+      return
+    }
+
+    const { name, payload } = parsed as { name: unknown; payload: unknown }
+
+    if (typeof name !== 'string' || !(name in evaluationEventSchema)) {
+      console.error('[EvaluationEventBus] Unknown event name:', name)
+      return
+    }
+
+    const eventName = name as EvaluationEventName
+    const schema = evaluationEventSchema[eventName]
+    const result = schema.safeParse(payload)
+
+    if (!result.success) {
+      console.error(
+        `[EvaluationEventBus] Invalid payload for event "${eventName}":`,
+        result.error.flatten(),
+      )
+      return
+    }
+
+    const eventHandlers = this.handlers.get(eventName) ?? []
+    for (const handler of eventHandlers) {
+      try {
+        await handler(result.data as EvaluationEventPayloadMap[EvaluationEventName])
+      } catch (err) {
+        console.error(`[EvaluationEventBus] Handler error for event "${eventName}":`, err)
+      }
+    }
+  }
+
+  async close(): Promise<void> {
+    this.handlers.clear()
+    await this.subscriber.unsubscribe(EVALUATION_EVENT_CHANNEL)
+    this.subscriber.disconnect()
+    this.publisher.disconnect()
+  }
+}

--- a/src/lib/evaluation/evaluation-event-types.ts
+++ b/src/lib/evaluation/evaluation-event-types.ts
@@ -1,0 +1,39 @@
+import { z } from 'zod'
+
+// イベント名一覧
+export const EVALUATION_EVENT_NAMES = [
+  'EvaluationSubmitted',
+  'CycleFinalized',
+  'FeedbackPublished',
+] as const
+export type EvaluationEventName = (typeof EVALUATION_EVENT_NAMES)[number]
+
+// 各イベントのペイロードスキーマ
+export const evaluationEventSchema = {
+  EvaluationSubmitted: z.object({
+    evaluationId: z.string().min(1),
+    evaluatorId: z.string().min(1),
+    targetUserId: z.string().min(1),
+    submittedAt: z.string().datetime(),
+  }),
+  CycleFinalized: z.object({
+    cycleId: z.string().min(1),
+    cycleName: z.string().min(1),
+    finalizedAt: z.string().datetime(),
+  }),
+  FeedbackPublished: z.object({
+    feedbackId: z.string().min(1),
+    targetUserId: z.string().min(1),
+    publishedAt: z.string().datetime(),
+  }),
+} satisfies Record<EvaluationEventName, z.ZodTypeAny>
+
+export type EvaluationEventPayloadMap = {
+  [K in EvaluationEventName]: z.infer<(typeof evaluationEventSchema)[K]>
+}
+
+export interface EvaluationEvent<N extends EvaluationEventName = EvaluationEventName> {
+  name: N
+  payload: EvaluationEventPayloadMap[N]
+  publishedAt: string
+}

--- a/src/tests/evaluation/evaluation-event-bus.test.ts
+++ b/src/tests/evaluation/evaluation-event-bus.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Issue #50 / Task 15.1: EvaluationEventBus テスト
+ *
+ * InMemoryEvaluationEventBus を使用してRedisなしでテスト可能。
+ */
+import { describe, it, expect, vi } from 'vitest'
+import type {
+  EvaluationEventBus,
+  EvaluationEventPayloadMap,
+} from '@/lib/evaluation/evaluation-event-bus'
+import { InMemoryEvaluationEventBus } from '@/lib/evaluation/evaluation-event-bus'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+function createBus(): EvaluationEventBus {
+  return new InMemoryEvaluationEventBus()
+}
+
+const NOW = '2024-01-15T10:00:00.000Z'
+
+const validPayloads: EvaluationEventPayloadMap = {
+  EvaluationSubmitted: {
+    evaluationId: 'eval-1',
+    evaluatorId: 'user-1',
+    targetUserId: 'user-2',
+    submittedAt: NOW,
+  },
+  CycleFinalized: {
+    cycleId: 'cycle-1',
+    cycleName: '2024 Q1',
+    finalizedAt: NOW,
+  },
+  FeedbackPublished: {
+    feedbackId: 'feedback-1',
+    targetUserId: 'user-2',
+    publishedAt: NOW,
+  },
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('InMemoryEvaluationEventBus', () => {
+  describe('EvaluationSubmitted イベント', () => {
+    it('publish すると handler が正しい payload で呼ばれる', async () => {
+      // Arrange
+      const bus = createBus()
+      const handler = vi.fn(
+        async (_payload: EvaluationEventPayloadMap['EvaluationSubmitted']): Promise<void> => {},
+      )
+      bus.subscribe('EvaluationSubmitted', handler)
+
+      // Act
+      await bus.publish('EvaluationSubmitted', validPayloads.EvaluationSubmitted)
+
+      // Assert
+      expect(handler).toHaveBeenCalledOnce()
+      expect(handler).toHaveBeenCalledWith(validPayloads.EvaluationSubmitted)
+    })
+  })
+
+  describe('CycleFinalized イベント', () => {
+    it('対応 handler のみ呼ばれ、他イベントの handler は呼ばれない', async () => {
+      // Arrange
+      const bus = createBus()
+      const cycleFinalizedHandler = vi.fn(
+        async (_payload: EvaluationEventPayloadMap['CycleFinalized']): Promise<void> => {},
+      )
+      const evaluationSubmittedHandler = vi.fn(
+        async (_payload: EvaluationEventPayloadMap['EvaluationSubmitted']): Promise<void> => {},
+      )
+
+      bus.subscribe('CycleFinalized', cycleFinalizedHandler)
+      bus.subscribe('EvaluationSubmitted', evaluationSubmittedHandler)
+
+      // Act
+      await bus.publish('CycleFinalized', validPayloads.CycleFinalized)
+
+      // Assert
+      expect(cycleFinalizedHandler).toHaveBeenCalledOnce()
+      expect(cycleFinalizedHandler).toHaveBeenCalledWith(validPayloads.CycleFinalized)
+      expect(evaluationSubmittedHandler).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('FeedbackPublished イベント', () => {
+    it('publish すると handler が呼ばれる', async () => {
+      // Arrange
+      const bus = createBus()
+      const handler = vi.fn(
+        async (_payload: EvaluationEventPayloadMap['FeedbackPublished']): Promise<void> => {},
+      )
+      bus.subscribe('FeedbackPublished', handler)
+
+      // Act
+      await bus.publish('FeedbackPublished', validPayloads.FeedbackPublished)
+
+      // Assert
+      expect(handler).toHaveBeenCalledOnce()
+      expect(handler).toHaveBeenCalledWith(validPayloads.FeedbackPublished)
+    })
+  })
+
+  describe('不正ペイロード', () => {
+    it('不正ペイロードの場合 handler が呼ばれない', async () => {
+      // Arrange
+      const bus = createBus()
+      const handler = vi.fn(
+        async (_payload: EvaluationEventPayloadMap['EvaluationSubmitted']): Promise<void> => {},
+      )
+      bus.subscribe('EvaluationSubmitted', handler)
+
+      // Act — evaluatorId が空文字（min(1) 違反）
+      await bus.publish('EvaluationSubmitted', {
+        evaluationId: 'eval-1',
+        evaluatorId: '',
+        targetUserId: 'user-2',
+        submittedAt: NOW,
+      })
+
+      // Assert
+      expect(handler).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('handler エラー', () => {
+    it('handler でエラーが起きても publish は成功する', async () => {
+      // Arrange
+      const bus = createBus()
+      const errorHandler = vi.fn(
+        async (_payload: EvaluationEventPayloadMap['EvaluationSubmitted']): Promise<void> => {
+          throw new Error('handler error')
+        },
+      )
+      bus.subscribe('EvaluationSubmitted', errorHandler)
+
+      // Act & Assert — throw しない
+      await expect(
+        bus.publish('EvaluationSubmitted', validPayloads.EvaluationSubmitted),
+      ).resolves.toBeUndefined()
+      expect(errorHandler).toHaveBeenCalledOnce()
+    })
+  })
+
+  describe('close', () => {
+    it('close を呼んでも例外が発生しない', async () => {
+      const bus = createBus()
+      await expect(bus.close()).resolves.toBeUndefined()
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Redis Pub/Sub ベースの評価ドメイン間イベントバスを実装（Req 8, 10, 11 の疎結合化基盤）
- EvaluationSubmitted / CycleFinalized / FeedbackPublished の3イベントを定義
- publisher/subscriber を別 ioredis 接続で管理（Redis Pub/Sub 仕様準拠）

## 追加ファイル
- `src/lib/evaluation/evaluation-event-types.ts` — イベント名・Zodスキーマ・ペイロード型
- `src/lib/evaluation/evaluation-event-bus.ts` — EvaluationEventBus インターフェース + InMemoryEvaluationEventBus（テスト用）+ RedisEvaluationEventBus（本番用）
- `src/lib/evaluation/evaluation-event-bus-di.ts` — DIシングルトン
- `src/lib/evaluation/create-evaluation-event-bus.ts` — ファクトリ関数
- `src/app/api/evaluation/events/route.ts` — POST（ADMIN のみ、手動テスト用）
- `src/tests/evaluation/evaluation-event-bus.test.ts` — 6件テスト全通過

## 設計ポイント
- 不正ペイロード → Zodパース失敗時はログのみ、例外スローなし
- handlerエラー → `console.error` でキャッチしバスを継続
- Redis接続エラー → 起動時はfail-fastせず、publish時にスロー

## Test plan
- [ ] `POST /api/evaluation/events` — ADMIN のみアクセス可
- [ ] EvaluationSubmitted を publish → 登録した handler が正しい payload で呼ばれる
- [ ] 不正イベント名 → 422
- [ ] handler エラー → publish 自体は成功

Closes #50