### PR TITLE
[#51] 評価サイクルの作成・開始・状態管理

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -103,28 +103,16 @@ model User {
   anonymizedAt     DateTime?
 
   // Relations
-  profile         Profile?
-  passwordHistory PasswordHistory[]
-  sessions        Session[]
-  careerWishes    CareerWish[]
-  personalGoals   PersonalGoal[]
-  managedSessions  OneOnOneSession[] @relation("OneOnOneAsManager")
-  employeeSessions OneOnOneSession[] @relation("OneOnOneAsEmployee")
-  oneOnOneLogs     OneOnOneLog[]     @relation("OneOnOneLogRecorder")
-  profile          Profile?
-  passwordHistory  PasswordHistory[]
-  sessions         Session[]
-  careerWishes     CareerWish[]
-  personalGoals    PersonalGoal[]
-  managedSessions  OneOnOneSession[] @relation("OneOnOneAsManager")
-  employeeSessions OneOnOneSession[] @relation("OneOnOneAsEmployee")
-  oneOnOneLogs     OneOnOneLog[]     @relation("OneOnOneLogRecorder")
-  profile            Profile?
-  passwordHistory    PasswordHistory[]
-  sessions           Session[]
-  careerWishes       CareerWish[]
-  personalGoals      PersonalGoal[]
-  goalAchievements   GoalAchievement[]
+  profile              Profile?
+  passwordHistory      PasswordHistory[]
+  sessions             Session[]
+  careerWishes         CareerWish[]
+  personalGoals        PersonalGoal[]
+  managedSessions      OneOnOneSession[] @relation("OneOnOneAsManager")
+  employeeSessions     OneOnOneSession[] @relation("OneOnOneAsEmployee")
+  oneOnOneLogs         OneOnOneLog[]     @relation("OneOnOneLogRecorder")
+  goalAchievements     GoalAchievement[]
+  createdReviewCycles  ReviewCycle[]     @relation("ReviewCycleCreator")
 
   @@index([emailHash])
   @@index([status])
@@ -574,6 +562,8 @@ model OneOnOneLog {
   @@index([sessionId])
   @@index([recordedAt])
   @@map("one_on_one_logs")
+}
+
 // 評価サイクル・目標達成率連携 (Requirement 6.9)
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -610,4 +600,43 @@ model GoalAchievement {
   @@index([cycleId])
   @@index([userId])
   @@map("goal_achievements")
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 360度評価サイクル管理 (Requirement 8.1, 8.2)
+// ─────────────────────────────────────────────────────────────────────────────
+
+enum ReviewCycleStatus {
+  DRAFT
+  ACTIVE
+  AGGREGATING
+  PENDING_FEEDBACK_APPROVAL
+  FINALIZED
+  CLOSED
+}
+
+/// 360度評価サイクル (Requirement 8.1, 8.2)
+/// EvaluationCycle（目標達成率用）とは別物
+model ReviewCycle {
+  id           String            @id @default(cuid())
+  name         String
+  status       ReviewCycleStatus @default(DRAFT)
+  startDate    DateTime
+  endDate      DateTime
+  items        String[]
+  incentiveK   Float
+  minReviewers Int
+  maxTargets   Int
+  activatedAt  DateTime?
+  finalizedAt  DateTime?
+  closedAt     DateTime?
+  createdBy    String
+  createdAt    DateTime          @default(now())
+  updatedAt    DateTime          @updatedAt
+
+  creator User @relation("ReviewCycleCreator", fields: [createdBy], references: [id])
+
+  @@index([status])
+  @@index([startDate, endDate])
+  @@map("review_cycles")
 }

--- a/src/app/api/evaluation/cycles/[id]/activate/route.ts
+++ b/src/app/api/evaluation/cycles/[id]/activate/route.ts
@@ -1,0 +1,48 @@
+/**
+ * Issue #51 / Task 15.2: 評価サイクル ACTIVE 遷移 API (Req 8.1, 8.2)
+ *
+ * - POST /api/evaluation/cycles/[id]/activate — DRAFT → ACTIVE（HR_MANAGER/ADMIN）
+ */
+import { type NextRequest, NextResponse } from 'next/server'
+import { requireAuthenticated } from '@/lib/skill/skill-route-helpers'
+import { getReviewCycleService } from '@/lib/evaluation/review-cycle-service-di'
+import {
+  ReviewCycleNotFoundError,
+  ReviewCycleInvalidTransitionError,
+} from '@/lib/evaluation/review-cycle-types'
+
+const HR_OR_ADMIN_ROLES = ['HR_MANAGER', 'ADMIN'] as const
+
+export async function POST(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const guard = await requireAuthenticated()
+  if (!guard.ok) return guard.response
+
+  if (!HR_OR_ADMIN_ROLES.includes(guard.session.role as (typeof HR_OR_ADMIN_ROLES)[number])) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const { id } = await params
+
+  let svc: ReturnType<typeof getReviewCycleService>
+  try {
+    svc = getReviewCycleService()
+  } catch {
+    return NextResponse.json({ error: 'ReviewCycle service not initialized' }, { status: 503 })
+  }
+
+  try {
+    const cycle = await svc.activateCycle(id)
+    return NextResponse.json({ success: true, data: cycle })
+  } catch (err) {
+    if (err instanceof ReviewCycleNotFoundError) {
+      return NextResponse.json({ error: 'ReviewCycle not found' }, { status: 404 })
+    }
+    if (err instanceof ReviewCycleInvalidTransitionError) {
+      return NextResponse.json({ error: err.message }, { status: 409 })
+    }
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/api/evaluation/cycles/[id]/aggregate/route.ts
+++ b/src/app/api/evaluation/cycles/[id]/aggregate/route.ts
@@ -1,0 +1,48 @@
+/**
+ * Issue #51 / Task 15.2: 評価サイクル AGGREGATING 遷移 API (Req 8.1, 8.2)
+ *
+ * - POST /api/evaluation/cycles/[id]/aggregate — ACTIVE → AGGREGATING（HR_MANAGER/ADMIN）
+ */
+import { type NextRequest, NextResponse } from 'next/server'
+import { requireAuthenticated } from '@/lib/skill/skill-route-helpers'
+import { getReviewCycleService } from '@/lib/evaluation/review-cycle-service-di'
+import {
+  ReviewCycleNotFoundError,
+  ReviewCycleInvalidTransitionError,
+} from '@/lib/evaluation/review-cycle-types'
+
+const HR_OR_ADMIN_ROLES = ['HR_MANAGER', 'ADMIN'] as const
+
+export async function POST(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const guard = await requireAuthenticated()
+  if (!guard.ok) return guard.response
+
+  if (!HR_OR_ADMIN_ROLES.includes(guard.session.role as (typeof HR_OR_ADMIN_ROLES)[number])) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const { id } = await params
+
+  let svc: ReturnType<typeof getReviewCycleService>
+  try {
+    svc = getReviewCycleService()
+  } catch {
+    return NextResponse.json({ error: 'ReviewCycle service not initialized' }, { status: 503 })
+  }
+
+  try {
+    const cycle = await svc.startAggregating(id)
+    return NextResponse.json({ success: true, data: cycle })
+  } catch (err) {
+    if (err instanceof ReviewCycleNotFoundError) {
+      return NextResponse.json({ error: 'ReviewCycle not found' }, { status: 404 })
+    }
+    if (err instanceof ReviewCycleInvalidTransitionError) {
+      return NextResponse.json({ error: err.message }, { status: 409 })
+    }
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/api/evaluation/cycles/[id]/close/route.ts
+++ b/src/app/api/evaluation/cycles/[id]/close/route.ts
@@ -1,0 +1,48 @@
+/**
+ * Issue #51 / Task 15.2: 評価サイクル CLOSED 遷移 API (Req 8.1, 8.2)
+ *
+ * - POST /api/evaluation/cycles/[id]/close — FINALIZED → CLOSED（HR_MANAGER/ADMIN）
+ */
+import { type NextRequest, NextResponse } from 'next/server'
+import { requireAuthenticated } from '@/lib/skill/skill-route-helpers'
+import { getReviewCycleService } from '@/lib/evaluation/review-cycle-service-di'
+import {
+  ReviewCycleNotFoundError,
+  ReviewCycleInvalidTransitionError,
+} from '@/lib/evaluation/review-cycle-types'
+
+const HR_OR_ADMIN_ROLES = ['HR_MANAGER', 'ADMIN'] as const
+
+export async function POST(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const guard = await requireAuthenticated()
+  if (!guard.ok) return guard.response
+
+  if (!HR_OR_ADMIN_ROLES.includes(guard.session.role as (typeof HR_OR_ADMIN_ROLES)[number])) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const { id } = await params
+
+  let svc: ReturnType<typeof getReviewCycleService>
+  try {
+    svc = getReviewCycleService()
+  } catch {
+    return NextResponse.json({ error: 'ReviewCycle service not initialized' }, { status: 503 })
+  }
+
+  try {
+    const cycle = await svc.closeCycle(id)
+    return NextResponse.json({ success: true, data: cycle })
+  } catch (err) {
+    if (err instanceof ReviewCycleNotFoundError) {
+      return NextResponse.json({ error: 'ReviewCycle not found' }, { status: 404 })
+    }
+    if (err instanceof ReviewCycleInvalidTransitionError) {
+      return NextResponse.json({ error: err.message }, { status: 409 })
+    }
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/api/evaluation/cycles/[id]/finalize/route.ts
+++ b/src/app/api/evaluation/cycles/[id]/finalize/route.ts
@@ -1,0 +1,48 @@
+/**
+ * Issue #51 / Task 15.2: 評価サイクル FINALIZED 遷移 API (Req 8.1, 8.2)
+ *
+ * - POST /api/evaluation/cycles/[id]/finalize — PENDING_FEEDBACK_APPROVAL → FINALIZED（HR_MANAGER/ADMIN）
+ */
+import { type NextRequest, NextResponse } from 'next/server'
+import { requireAuthenticated } from '@/lib/skill/skill-route-helpers'
+import { getReviewCycleService } from '@/lib/evaluation/review-cycle-service-di'
+import {
+  ReviewCycleNotFoundError,
+  ReviewCycleInvalidTransitionError,
+} from '@/lib/evaluation/review-cycle-types'
+
+const HR_OR_ADMIN_ROLES = ['HR_MANAGER', 'ADMIN'] as const
+
+export async function POST(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const guard = await requireAuthenticated()
+  if (!guard.ok) return guard.response
+
+  if (!HR_OR_ADMIN_ROLES.includes(guard.session.role as (typeof HR_OR_ADMIN_ROLES)[number])) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const { id } = await params
+
+  let svc: ReturnType<typeof getReviewCycleService>
+  try {
+    svc = getReviewCycleService()
+  } catch {
+    return NextResponse.json({ error: 'ReviewCycle service not initialized' }, { status: 503 })
+  }
+
+  try {
+    const cycle = await svc.finalizeCycle(id)
+    return NextResponse.json({ success: true, data: cycle })
+  } catch (err) {
+    if (err instanceof ReviewCycleNotFoundError) {
+      return NextResponse.json({ error: 'ReviewCycle not found' }, { status: 404 })
+    }
+    if (err instanceof ReviewCycleInvalidTransitionError) {
+      return NextResponse.json({ error: err.message }, { status: 409 })
+    }
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/api/evaluation/cycles/[id]/pending-approval/route.ts
+++ b/src/app/api/evaluation/cycles/[id]/pending-approval/route.ts
@@ -1,0 +1,48 @@
+/**
+ * Issue #51 / Task 15.2: 評価サイクル PENDING_FEEDBACK_APPROVAL 遷移 API (Req 8.1, 8.2)
+ *
+ * - POST /api/evaluation/cycles/[id]/pending-approval — AGGREGATING → PENDING_FEEDBACK_APPROVAL（HR_MANAGER/ADMIN）
+ */
+import { type NextRequest, NextResponse } from 'next/server'
+import { requireAuthenticated } from '@/lib/skill/skill-route-helpers'
+import { getReviewCycleService } from '@/lib/evaluation/review-cycle-service-di'
+import {
+  ReviewCycleNotFoundError,
+  ReviewCycleInvalidTransitionError,
+} from '@/lib/evaluation/review-cycle-types'
+
+const HR_OR_ADMIN_ROLES = ['HR_MANAGER', 'ADMIN'] as const
+
+export async function POST(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const guard = await requireAuthenticated()
+  if (!guard.ok) return guard.response
+
+  if (!HR_OR_ADMIN_ROLES.includes(guard.session.role as (typeof HR_OR_ADMIN_ROLES)[number])) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const { id } = await params
+
+  let svc: ReturnType<typeof getReviewCycleService>
+  try {
+    svc = getReviewCycleService()
+  } catch {
+    return NextResponse.json({ error: 'ReviewCycle service not initialized' }, { status: 503 })
+  }
+
+  try {
+    const cycle = await svc.pendingApproval(id)
+    return NextResponse.json({ success: true, data: cycle })
+  } catch (err) {
+    if (err instanceof ReviewCycleNotFoundError) {
+      return NextResponse.json({ error: 'ReviewCycle not found' }, { status: 404 })
+    }
+    if (err instanceof ReviewCycleInvalidTransitionError) {
+      return NextResponse.json({ error: err.message }, { status: 409 })
+    }
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/api/evaluation/cycles/[id]/route.ts
+++ b/src/app/api/evaluation/cycles/[id]/route.ts
@@ -1,0 +1,35 @@
+/**
+ * Issue #51 / Task 15.2: 360度評価サイクル 個別取得 API (Req 8.1, 8.2)
+ *
+ * - GET /api/evaluation/cycles/[id] — 個別取得（認証済み全員）
+ */
+import { type NextRequest, NextResponse } from 'next/server'
+import { requireAuthenticated } from '@/lib/skill/skill-route-helpers'
+import { getReviewCycleService } from '@/lib/evaluation/review-cycle-service-di'
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const guard = await requireAuthenticated()
+  if (!guard.ok) return guard.response
+
+  const { id } = await params
+
+  let svc: ReturnType<typeof getReviewCycleService>
+  try {
+    svc = getReviewCycleService()
+  } catch {
+    return NextResponse.json({ error: 'ReviewCycle service not initialized' }, { status: 503 })
+  }
+
+  try {
+    const cycle = await svc.getCycle(id)
+    if (!cycle) {
+      return NextResponse.json({ error: 'ReviewCycle not found' }, { status: 404 })
+    }
+    return NextResponse.json({ success: true, data: cycle })
+  } catch {
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/api/evaluation/cycles/route.ts
+++ b/src/app/api/evaluation/cycles/route.ts
@@ -1,0 +1,70 @@
+/**
+ * Issue #51 / Task 15.2: 360度評価サイクル API (Req 8.1, 8.2)
+ *
+ * - POST /api/evaluation/cycles — サイクル作成（HR_MANAGER/ADMIN）
+ * - GET  /api/evaluation/cycles — 一覧取得（認証済み全員）
+ */
+import { type NextRequest, NextResponse } from 'next/server'
+import { reviewCycleInputSchema } from '@/lib/evaluation/review-cycle-types'
+import { parseJsonBody, requireAuthenticated } from '@/lib/skill/skill-route-helpers'
+import { getReviewCycleService } from '@/lib/evaluation/review-cycle-service-di'
+
+export {
+  setReviewCycleServiceForTesting,
+  clearReviewCycleServiceForTesting,
+} from '@/lib/evaluation/review-cycle-service-di'
+
+const HR_OR_ADMIN_ROLES = ['HR_MANAGER', 'ADMIN'] as const
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const guard = await requireAuthenticated()
+  if (!guard.ok) return guard.response
+
+  if (!HR_OR_ADMIN_ROLES.includes(guard.session.role as (typeof HR_OR_ADMIN_ROLES)[number])) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const parsedBody = await parseJsonBody(request)
+  if (!parsedBody.ok) return parsedBody.response
+
+  const validated = reviewCycleInputSchema.safeParse(parsedBody.body)
+  if (!validated.success) {
+    return NextResponse.json({ error: validated.error.flatten() }, { status: 422 })
+  }
+
+  let svc: ReturnType<typeof getReviewCycleService>
+  try {
+    svc = getReviewCycleService()
+  } catch {
+    return NextResponse.json({ error: 'ReviewCycle service not initialized' }, { status: 503 })
+  }
+
+  try {
+    const cycle = await svc.createCycle(guard.session.userId, validated.data)
+    return NextResponse.json({ success: true, data: cycle }, { status: 201 })
+  } catch {
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const guard = await requireAuthenticated()
+  if (!guard.ok) return guard.response
+
+  const { searchParams } = new URL(request.url)
+  const statusParam = searchParams.get('status') ?? undefined
+
+  let svc: ReturnType<typeof getReviewCycleService>
+  try {
+    svc = getReviewCycleService()
+  } catch {
+    return NextResponse.json({ error: 'ReviewCycle service not initialized' }, { status: 503 })
+  }
+
+  try {
+    const cycles = await svc.listCycles(statusParam ? { status: statusParam as never } : undefined)
+    return NextResponse.json({ success: true, data: cycles })
+  } catch {
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/lib/evaluation/review-cycle-service-di.ts
+++ b/src/lib/evaluation/review-cycle-service-di.ts
@@ -1,0 +1,30 @@
+/**
+ * Issue #51 / Task 15.2: ReviewCycleService DI コンテナ
+ *
+ * テストでは setReviewCycleServiceForTesting() を使用。
+ * プロダクションでは initReviewCycleService() を起動前に呼ぶ。
+ */
+import type { ReviewCycleService } from './review-cycle-service'
+
+let _service: ReviewCycleService | null = null
+
+export function setReviewCycleServiceForTesting(svc: ReviewCycleService): void {
+  _service = svc
+}
+
+export function clearReviewCycleServiceForTesting(): void {
+  _service = null
+}
+
+export function getReviewCycleService(): ReviewCycleService {
+  if (_service) return _service
+  throw new Error(
+    'ReviewCycleService is not initialized. ' +
+      'テストでは setReviewCycleServiceForTesting() を呼んでください。' +
+      'プロダクションではサーバー起動前に initReviewCycleService() を呼んでください。',
+  )
+}
+
+export function initReviewCycleService(svc: ReviewCycleService): void {
+  _service = svc
+}

--- a/src/lib/evaluation/review-cycle-service.ts
+++ b/src/lib/evaluation/review-cycle-service.ts
@@ -1,0 +1,285 @@
+/**
+ * Issue #51 / Task 15.2: 360度評価サイクル サービス (Req 8.1, 8.2)
+ *
+ * ステートマシン:
+ *   DRAFT → ACTIVE → AGGREGATING → PENDING_FEEDBACK_APPROVAL → FINALIZED → CLOSED
+ *
+ * - activateCycle: 全アクティブ社員に EVAL_INVITATION 通知
+ * - finalizeCycle: CycleFinalized イベントを EvaluationEventBus に publish
+ */
+import type { PrismaClient } from '@prisma/client'
+import type { NotificationEmitter } from '@/lib/notification/notification-emitter'
+import type { EvaluationEventBus } from './evaluation-event-bus'
+import {
+  ReviewCycleNotFoundError,
+  ReviewCycleInvalidTransitionError,
+  type ReviewCycleInput,
+  type ReviewCycleRecord,
+  type ReviewCycleStatus,
+} from './review-cycle-types'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 許可された状態遷移マップ
+// ─────────────────────────────────────────────────────────────────────────────
+
+const ALLOWED_TRANSITIONS: Record<ReviewCycleStatus, readonly ReviewCycleStatus[]> = {
+  DRAFT: ['ACTIVE'],
+  ACTIVE: ['AGGREGATING'],
+  AGGREGATING: ['PENDING_FEEDBACK_APPROVAL'],
+  PENDING_FEEDBACK_APPROVAL: ['FINALIZED'],
+  FINALIZED: ['CLOSED'],
+  CLOSED: [],
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Service interface
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface ReviewCycleService {
+  /** DRAFT でサイクルを作成 */
+  createCycle(createdBy: string, input: ReviewCycleInput): Promise<ReviewCycleRecord>
+  /** DRAFT → ACTIVE: 全対象社員に EVAL_INVITATION 通知 */
+  activateCycle(cycleId: string): Promise<ReviewCycleRecord>
+  /** ACTIVE → AGGREGATING */
+  startAggregating(cycleId: string): Promise<ReviewCycleRecord>
+  /** AGGREGATING → PENDING_FEEDBACK_APPROVAL */
+  pendingApproval(cycleId: string): Promise<ReviewCycleRecord>
+  /** PENDING_FEEDBACK_APPROVAL → FINALIZED: CycleFinalized イベントを publish */
+  finalizeCycle(cycleId: string): Promise<ReviewCycleRecord>
+  /** FINALIZED → CLOSED */
+  closeCycle(cycleId: string): Promise<ReviewCycleRecord>
+  /** 一覧取得 */
+  listCycles(filters?: { status?: ReviewCycleStatus }): Promise<ReviewCycleRecord[]>
+  /** 個別取得 */
+  getCycle(cycleId: string): Promise<ReviewCycleRecord | null>
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Repository helper — Prisma の ReviewCycle を型安全に変換
+// ─────────────────────────────────────────────────────────────────────────────
+
+type PrismaReviewCycle = {
+  id: string
+  name: string
+  status: string
+  startDate: Date
+  endDate: Date
+  items: string[]
+  incentiveK: number
+  minReviewers: number
+  maxTargets: number
+  activatedAt: Date | null
+  finalizedAt: Date | null
+  closedAt: Date | null
+  createdBy: string
+  createdAt: Date
+  updatedAt: Date
+}
+
+function toRecord(row: PrismaReviewCycle): ReviewCycleRecord {
+  return {
+    id: row.id,
+    name: row.name,
+    status: row.status as ReviewCycleStatus,
+    startDate: row.startDate,
+    endDate: row.endDate,
+    items: row.items,
+    incentiveK: row.incentiveK,
+    minReviewers: row.minReviewers,
+    maxTargets: row.maxTargets,
+    activatedAt: row.activatedAt,
+    finalizedAt: row.finalizedAt,
+    closedAt: row.closedAt,
+    createdBy: row.createdBy,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// State machine helper
+// ─────────────────────────────────────────────────────────────────────────────
+
+function assertTransition(current: ReviewCycleStatus, next: ReviewCycleStatus): void {
+  const allowed = ALLOWED_TRANSITIONS[current]
+  if (!allowed.includes(next)) {
+    throw new ReviewCycleInvalidTransitionError(current, next)
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Implementation
+// ─────────────────────────────────────────────────────────────────────────────
+
+class ReviewCycleServiceImpl implements ReviewCycleService {
+  constructor(
+    private readonly db: PrismaClient,
+    private readonly notificationEmitter: NotificationEmitter | null,
+    private readonly eventBus: EvaluationEventBus | null,
+    private readonly clock: () => Date,
+  ) {}
+
+  async createCycle(createdBy: string, input: ReviewCycleInput): Promise<ReviewCycleRecord> {
+    const row = await this.db.reviewCycle.create({
+      data: {
+        name: input.name,
+        status: 'DRAFT',
+        startDate: input.startDate,
+        endDate: input.endDate,
+        items: input.items,
+        incentiveK: input.incentiveK,
+        minReviewers: input.minReviewers,
+        maxTargets: input.maxTargets,
+        createdBy,
+      },
+    })
+    return toRecord(row)
+  }
+
+  async activateCycle(cycleId: string): Promise<ReviewCycleRecord> {
+    const current = await this.db.reviewCycle.findUnique({ where: { id: cycleId } })
+    if (!current) throw new ReviewCycleNotFoundError(cycleId)
+
+    assertTransition(current.status as ReviewCycleStatus, 'ACTIVE')
+
+    const now = this.clock()
+    const updated = await this.db.reviewCycle.update({
+      where: { id: cycleId },
+      data: { status: 'ACTIVE', activatedAt: now },
+    })
+
+    await this.sendInvitationNotifications(updated.name, cycleId)
+
+    return toRecord(updated)
+  }
+
+  async startAggregating(cycleId: string): Promise<ReviewCycleRecord> {
+    const current = await this.db.reviewCycle.findUnique({ where: { id: cycleId } })
+    if (!current) throw new ReviewCycleNotFoundError(cycleId)
+
+    assertTransition(current.status as ReviewCycleStatus, 'AGGREGATING')
+
+    const updated = await this.db.reviewCycle.update({
+      where: { id: cycleId },
+      data: { status: 'AGGREGATING' },
+    })
+    return toRecord(updated)
+  }
+
+  async pendingApproval(cycleId: string): Promise<ReviewCycleRecord> {
+    const current = await this.db.reviewCycle.findUnique({ where: { id: cycleId } })
+    if (!current) throw new ReviewCycleNotFoundError(cycleId)
+
+    assertTransition(current.status as ReviewCycleStatus, 'PENDING_FEEDBACK_APPROVAL')
+
+    const updated = await this.db.reviewCycle.update({
+      where: { id: cycleId },
+      data: { status: 'PENDING_FEEDBACK_APPROVAL' },
+    })
+    return toRecord(updated)
+  }
+
+  async finalizeCycle(cycleId: string): Promise<ReviewCycleRecord> {
+    const current = await this.db.reviewCycle.findUnique({ where: { id: cycleId } })
+    if (!current) throw new ReviewCycleNotFoundError(cycleId)
+
+    assertTransition(current.status as ReviewCycleStatus, 'FINALIZED')
+
+    const now = this.clock()
+    const updated = await this.db.reviewCycle.update({
+      where: { id: cycleId },
+      data: { status: 'FINALIZED', finalizedAt: now },
+    })
+
+    await this.publishCycleFinalized(updated.id, updated.name, now)
+
+    return toRecord(updated)
+  }
+
+  async closeCycle(cycleId: string): Promise<ReviewCycleRecord> {
+    const current = await this.db.reviewCycle.findUnique({ where: { id: cycleId } })
+    if (!current) throw new ReviewCycleNotFoundError(cycleId)
+
+    assertTransition(current.status as ReviewCycleStatus, 'CLOSED')
+
+    const now = this.clock()
+    const updated = await this.db.reviewCycle.update({
+      where: { id: cycleId },
+      data: { status: 'CLOSED', closedAt: now },
+    })
+    return toRecord(updated)
+  }
+
+  async listCycles(filters?: { status?: ReviewCycleStatus }): Promise<ReviewCycleRecord[]> {
+    const rows = await this.db.reviewCycle.findMany({
+      where: filters?.status ? { status: filters.status } : {},
+      orderBy: { createdAt: 'desc' },
+    })
+    return rows.map(toRecord)
+  }
+
+  async getCycle(cycleId: string): Promise<ReviewCycleRecord | null> {
+    const row = await this.db.reviewCycle.findUnique({ where: { id: cycleId } })
+    return row ? toRecord(row) : null
+  }
+
+  // ─── private ──────────────────────────────────────────────────────────────
+
+  private async sendInvitationNotifications(cycleName: string, cycleId: string): Promise<void> {
+    if (!this.notificationEmitter) return
+
+    let activeUsers: { id: string }[] = []
+    try {
+      activeUsers = await this.db.user.findMany({
+        where: { status: 'ACTIVE' },
+        select: { id: true },
+      })
+    } catch {
+      return
+    }
+
+    for (const user of activeUsers) {
+      try {
+        await this.notificationEmitter.emit({
+          userId: user.id,
+          category: 'EVAL_INVITATION',
+          title: '360度評価が開始されました',
+          body: `「${cycleName}」の360度評価が開始されました。評価を実施してください。`,
+          payload: { cycleId },
+        })
+      } catch {
+        // 個別通知の失敗は無視して継続
+      }
+    }
+  }
+
+  private async publishCycleFinalized(
+    cycleId: string,
+    cycleName: string,
+    finalizedAt: Date,
+  ): Promise<void> {
+    if (!this.eventBus) return
+    try {
+      await this.eventBus.publish('CycleFinalized', {
+        cycleId,
+        cycleName,
+        finalizedAt: finalizedAt.toISOString(),
+      })
+    } catch {
+      // バスが未初期化または失敗した場合は無視
+    }
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Factory
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function createReviewCycleService(
+  db: PrismaClient,
+  notificationEmitter: NotificationEmitter | null = null,
+  eventBus: EvaluationEventBus | null = null,
+  clock: () => Date = () => new Date(),
+): ReviewCycleService {
+  return new ReviewCycleServiceImpl(db, notificationEmitter, eventBus, clock)
+}

--- a/src/lib/evaluation/review-cycle-types.ts
+++ b/src/lib/evaluation/review-cycle-types.ts
@@ -1,0 +1,71 @@
+/**
+ * Issue #51 / Task 15.2: 360度評価サイクル型定義 (Req 8.1, 8.2)
+ */
+import { z } from 'zod'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Input schema
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const reviewCycleInputSchema = z.object({
+  name: z.string().min(1).max(200),
+  startDate: z.coerce.date(),
+  endDate: z.coerce.date(),
+  items: z.array(z.string().min(1)).min(1).max(20),
+  incentiveK: z.number().positive().max(10),
+  minReviewers: z.number().int().min(1).max(50),
+  maxTargets: z.number().int().min(1).max(1000),
+})
+
+export type ReviewCycleInput = z.infer<typeof reviewCycleInputSchema>
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Domain types
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type ReviewCycleStatus =
+  | 'DRAFT'
+  | 'ACTIVE'
+  | 'AGGREGATING'
+  | 'PENDING_FEEDBACK_APPROVAL'
+  | 'FINALIZED'
+  | 'CLOSED'
+
+export interface ReviewCycleRecord {
+  id: string
+  name: string
+  status: ReviewCycleStatus
+  startDate: Date
+  endDate: Date
+  items: string[]
+  incentiveK: number
+  minReviewers: number
+  maxTargets: number
+  activatedAt: Date | null
+  finalizedAt: Date | null
+  closedAt: Date | null
+  createdBy: string
+  createdAt: Date
+  updatedAt: Date
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Domain errors
+// ─────────────────────────────────────────────────────────────────────────────
+
+export class ReviewCycleNotFoundError extends Error {
+  constructor(id: string) {
+    super(`ReviewCycle not found: ${id}`)
+    this.name = 'ReviewCycleNotFoundError'
+  }
+}
+
+export class ReviewCycleInvalidTransitionError extends Error {
+  constructor(
+    public readonly from: ReviewCycleStatus,
+    public readonly to: ReviewCycleStatus,
+  ) {
+    super(`Invalid transition: ${from} → ${to}`)
+    this.name = 'ReviewCycleInvalidTransitionError'
+  }
+}

--- a/src/tests/evaluation/review-cycle-service.test.ts
+++ b/src/tests/evaluation/review-cycle-service.test.ts
@@ -1,0 +1,350 @@
+/**
+ * Issue #51 / Task 15.2: ReviewCycleService 単体テスト (Req 8.1, 8.2)
+ *
+ * テスト対象:
+ * - DRAFT → ACTIVE 遷移テスト（通知が呼ばれることを確認）
+ * - 各ステート遷移の正常系テスト
+ * - 無効な遷移でエラーになるテスト（DRAFT → FINALIZED は不可）
+ * - FINALIZED 時に CycleFinalized イベントが publish されるテスト
+ * - listCycles のフィルタリングテスト
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { createReviewCycleService } from '@/lib/evaluation/review-cycle-service'
+import {
+  ReviewCycleNotFoundError,
+  ReviewCycleInvalidTransitionError,
+  type ReviewCycleRecord,
+} from '@/lib/evaluation/review-cycle-types'
+import type { NotificationEmitter } from '@/lib/notification/notification-emitter'
+import type { EvaluationEventBus } from '@/lib/evaluation/evaluation-event-bus'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fixtures
+// ─────────────────────────────────────────────────────────────────────────────
+
+const FIXED_NOW = new Date('2026-04-19T09:00:00.000Z')
+
+function makeCycleRecord(overrides: Partial<ReviewCycleRecord> = {}): ReviewCycleRecord {
+  return {
+    id: 'cycle-1',
+    name: 'Q2 360度評価',
+    status: 'DRAFT',
+    startDate: new Date('2026-04-01'),
+    endDate: new Date('2026-06-30'),
+    items: ['コミュニケーション', 'リーダーシップ'],
+    incentiveK: 1.5,
+    minReviewers: 3,
+    maxTargets: 100,
+    activatedAt: null,
+    finalizedAt: null,
+    closedAt: null,
+    createdBy: 'user-hr',
+    createdAt: FIXED_NOW,
+    updatedAt: FIXED_NOW,
+    ...overrides,
+  }
+}
+
+function makeActiveUser(id: string) {
+  return { id, status: 'ACTIVE' }
+}
+
+function makePrisma(
+  cycleRecord: ReviewCycleRecord,
+  activeUsers: { id: string; status: string }[] = [],
+) {
+  return {
+    reviewCycle: {
+      create: vi.fn().mockResolvedValue(cycleRecord),
+      findUnique: vi.fn().mockResolvedValue(cycleRecord),
+      findMany: vi.fn().mockResolvedValue([cycleRecord]),
+      update: vi.fn(),
+    },
+    user: {
+      findMany: vi.fn().mockResolvedValue(activeUsers),
+    },
+  }
+}
+
+function makeNotificationEmitter(): NotificationEmitter {
+  return { emit: vi.fn().mockResolvedValue(undefined) }
+}
+
+function makeEventBus(): EvaluationEventBus {
+  return {
+    publish: vi.fn().mockResolvedValue(undefined),
+    subscribe: vi.fn(),
+    close: vi.fn().mockResolvedValue(undefined),
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('ReviewCycleService', () => {
+  describe('createCycle', () => {
+    it('DRAFT ステータスでサイクルを作成する', async () => {
+      // Arrange
+      const record = makeCycleRecord({ status: 'DRAFT' })
+      const db = makePrisma(record)
+      const svc = createReviewCycleService(db as never, null, null, () => FIXED_NOW)
+
+      // Act
+      const result = await svc.createCycle('user-hr', {
+        name: 'Q2 360度評価',
+        startDate: new Date('2026-04-01'),
+        endDate: new Date('2026-06-30'),
+        items: ['コミュニケーション', 'リーダーシップ'],
+        incentiveK: 1.5,
+        minReviewers: 3,
+        maxTargets: 100,
+      })
+
+      // Assert
+      expect(result.status).toBe('DRAFT')
+      expect(result.name).toBe('Q2 360度評価')
+      expect(db.reviewCycle.create).toHaveBeenCalledOnce()
+    })
+  })
+
+  describe('activateCycle', () => {
+    it('DRAFT → ACTIVE に遷移し、全アクティブ社員に EVAL_INVITATION 通知を送る', async () => {
+      // Arrange
+      const draftRecord = makeCycleRecord({ status: 'DRAFT' })
+      const activeRecord = makeCycleRecord({ status: 'ACTIVE', activatedAt: FIXED_NOW })
+      const activeUsers = [makeActiveUser('user-1'), makeActiveUser('user-2')]
+      const db = makePrisma(draftRecord, activeUsers)
+      db.reviewCycle.update.mockResolvedValue(activeRecord)
+      const emitter = makeNotificationEmitter()
+      const svc = createReviewCycleService(db as never, emitter, null, () => FIXED_NOW)
+
+      // Act
+      const result = await svc.activateCycle('cycle-1')
+
+      // Assert
+      expect(result.status).toBe('ACTIVE')
+      expect(result.activatedAt).toEqual(FIXED_NOW)
+      expect(emitter.emit).toHaveBeenCalledTimes(2)
+      expect(emitter.emit).toHaveBeenCalledWith(
+        expect.objectContaining({ category: 'EVAL_INVITATION', userId: 'user-1' }),
+      )
+      expect(emitter.emit).toHaveBeenCalledWith(
+        expect.objectContaining({ category: 'EVAL_INVITATION', userId: 'user-2' }),
+      )
+    })
+
+    it('通知エミッターが null の場合もエラーなく ACTIVE に遷移する', async () => {
+      // Arrange
+      const draftRecord = makeCycleRecord({ status: 'DRAFT' })
+      const activeRecord = makeCycleRecord({ status: 'ACTIVE', activatedAt: FIXED_NOW })
+      const db = makePrisma(draftRecord, [])
+      db.reviewCycle.update.mockResolvedValue(activeRecord)
+      const svc = createReviewCycleService(db as never, null, null, () => FIXED_NOW)
+
+      // Act & Assert
+      await expect(svc.activateCycle('cycle-1')).resolves.toMatchObject({ status: 'ACTIVE' })
+    })
+
+    it('存在しないサイクルは ReviewCycleNotFoundError をスローする', async () => {
+      // Arrange
+      const db = makePrisma(makeCycleRecord())
+      db.reviewCycle.findUnique.mockResolvedValue(null)
+      const svc = createReviewCycleService(db as never, null, null, () => FIXED_NOW)
+
+      // Act & Assert
+      await expect(svc.activateCycle('not-exist')).rejects.toBeInstanceOf(ReviewCycleNotFoundError)
+    })
+  })
+
+  describe('startAggregating', () => {
+    it('ACTIVE → AGGREGATING に遷移する', async () => {
+      // Arrange
+      const activeRecord = makeCycleRecord({ status: 'ACTIVE', activatedAt: FIXED_NOW })
+      const aggregatingRecord = makeCycleRecord({ status: 'AGGREGATING', activatedAt: FIXED_NOW })
+      const db = makePrisma(activeRecord)
+      db.reviewCycle.update.mockResolvedValue(aggregatingRecord)
+      const svc = createReviewCycleService(db as never, null, null, () => FIXED_NOW)
+
+      // Act
+      const result = await svc.startAggregating('cycle-1')
+
+      // Assert
+      expect(result.status).toBe('AGGREGATING')
+    })
+  })
+
+  describe('pendingApproval', () => {
+    it('AGGREGATING → PENDING_FEEDBACK_APPROVAL に遷移する', async () => {
+      // Arrange
+      const aggregatingRecord = makeCycleRecord({ status: 'AGGREGATING' })
+      const pendingRecord = makeCycleRecord({ status: 'PENDING_FEEDBACK_APPROVAL' })
+      const db = makePrisma(aggregatingRecord)
+      db.reviewCycle.update.mockResolvedValue(pendingRecord)
+      const svc = createReviewCycleService(db as never, null, null, () => FIXED_NOW)
+
+      // Act
+      const result = await svc.pendingApproval('cycle-1')
+
+      // Assert
+      expect(result.status).toBe('PENDING_FEEDBACK_APPROVAL')
+    })
+  })
+
+  describe('finalizeCycle', () => {
+    it('PENDING_FEEDBACK_APPROVAL → FINALIZED に遷移し、CycleFinalized イベントを publish する', async () => {
+      // Arrange
+      const pendingRecord = makeCycleRecord({ status: 'PENDING_FEEDBACK_APPROVAL' })
+      const finalizedRecord = makeCycleRecord({ status: 'FINALIZED', finalizedAt: FIXED_NOW })
+      const db = makePrisma(pendingRecord)
+      db.reviewCycle.update.mockResolvedValue(finalizedRecord)
+      const bus = makeEventBus()
+      const svc = createReviewCycleService(db as never, null, bus, () => FIXED_NOW)
+
+      // Act
+      const result = await svc.finalizeCycle('cycle-1')
+
+      // Assert
+      expect(result.status).toBe('FINALIZED')
+      expect(result.finalizedAt).toEqual(FIXED_NOW)
+      expect(bus.publish).toHaveBeenCalledOnce()
+      expect(bus.publish).toHaveBeenCalledWith(
+        'CycleFinalized',
+        expect.objectContaining({
+          cycleId: 'cycle-1',
+          cycleName: 'Q2 360度評価',
+        }),
+      )
+    })
+
+    it('イベントバスが null の場合もエラーなく FINALIZED に遷移する', async () => {
+      // Arrange
+      const pendingRecord = makeCycleRecord({ status: 'PENDING_FEEDBACK_APPROVAL' })
+      const finalizedRecord = makeCycleRecord({ status: 'FINALIZED', finalizedAt: FIXED_NOW })
+      const db = makePrisma(pendingRecord)
+      db.reviewCycle.update.mockResolvedValue(finalizedRecord)
+      const svc = createReviewCycleService(db as never, null, null, () => FIXED_NOW)
+
+      // Act & Assert
+      await expect(svc.finalizeCycle('cycle-1')).resolves.toMatchObject({ status: 'FINALIZED' })
+    })
+  })
+
+  describe('closeCycle', () => {
+    it('FINALIZED → CLOSED に遷移する', async () => {
+      // Arrange
+      const finalizedRecord = makeCycleRecord({ status: 'FINALIZED', finalizedAt: FIXED_NOW })
+      const closedRecord = makeCycleRecord({ status: 'CLOSED', closedAt: FIXED_NOW })
+      const db = makePrisma(finalizedRecord)
+      db.reviewCycle.update.mockResolvedValue(closedRecord)
+      const svc = createReviewCycleService(db as never, null, null, () => FIXED_NOW)
+
+      // Act
+      const result = await svc.closeCycle('cycle-1')
+
+      // Assert
+      expect(result.status).toBe('CLOSED')
+      expect(result.closedAt).toEqual(FIXED_NOW)
+    })
+  })
+
+  describe('無効な遷移', () => {
+    it('DRAFT → FINALIZED は ReviewCycleInvalidTransitionError をスローする', async () => {
+      // Arrange
+      const draftRecord = makeCycleRecord({ status: 'DRAFT' })
+      const db = makePrisma(draftRecord)
+      const svc = createReviewCycleService(db as never, null, null, () => FIXED_NOW)
+
+      // Act & Assert
+      await expect(svc.finalizeCycle('cycle-1')).rejects.toBeInstanceOf(
+        ReviewCycleInvalidTransitionError,
+      )
+    })
+
+    it('DRAFT → AGGREGATING は ReviewCycleInvalidTransitionError をスローする', async () => {
+      // Arrange
+      const draftRecord = makeCycleRecord({ status: 'DRAFT' })
+      const db = makePrisma(draftRecord)
+      const svc = createReviewCycleService(db as never, null, null, () => FIXED_NOW)
+
+      // Act & Assert
+      await expect(svc.startAggregating('cycle-1')).rejects.toBeInstanceOf(
+        ReviewCycleInvalidTransitionError,
+      )
+    })
+
+    it('CLOSED → ACTIVE は ReviewCycleInvalidTransitionError をスローする', async () => {
+      // Arrange
+      const closedRecord = makeCycleRecord({ status: 'CLOSED', closedAt: FIXED_NOW })
+      const db = makePrisma(closedRecord)
+      const svc = createReviewCycleService(db as never, null, null, () => FIXED_NOW)
+
+      // Act & Assert
+      await expect(svc.activateCycle('cycle-1')).rejects.toBeInstanceOf(
+        ReviewCycleInvalidTransitionError,
+      )
+    })
+  })
+
+  describe('listCycles', () => {
+    it('フィルターなしで全サイクルを返す', async () => {
+      // Arrange
+      const record = makeCycleRecord()
+      const db = makePrisma(record)
+      const svc = createReviewCycleService(db as never, null, null, () => FIXED_NOW)
+
+      // Act
+      const results = await svc.listCycles()
+
+      // Assert
+      expect(results).toHaveLength(1)
+      expect(db.reviewCycle.findMany).toHaveBeenCalledWith(expect.objectContaining({ where: {} }))
+    })
+
+    it('status フィルターで絞り込む', async () => {
+      // Arrange
+      const record = makeCycleRecord({ status: 'ACTIVE' })
+      const db = makePrisma(record)
+      db.reviewCycle.findMany.mockResolvedValue([record])
+      const svc = createReviewCycleService(db as never, null, null, () => FIXED_NOW)
+
+      // Act
+      const results = await svc.listCycles({ status: 'ACTIVE' })
+
+      // Assert
+      expect(db.reviewCycle.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { status: 'ACTIVE' } }),
+      )
+      expect(results[0]?.status).toBe('ACTIVE')
+    })
+  })
+
+  describe('getCycle', () => {
+    it('存在するサイクルを返す', async () => {
+      // Arrange
+      const record = makeCycleRecord()
+      const db = makePrisma(record)
+      const svc = createReviewCycleService(db as never, null, null, () => FIXED_NOW)
+
+      // Act
+      const result = await svc.getCycle('cycle-1')
+
+      // Assert
+      expect(result).not.toBeNull()
+      expect(result?.id).toBe('cycle-1')
+    })
+
+    it('存在しないサイクルは null を返す', async () => {
+      // Arrange
+      const db = makePrisma(makeCycleRecord())
+      db.reviewCycle.findUnique.mockResolvedValue(null)
+      const svc = createReviewCycleService(db as never, null, null, () => FIXED_NOW)
+
+      // Act
+      const result = await svc.getCycle('not-exist')
+
+      // Assert
+      expect(result).toBeNull()
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- 360度評価サイクル（ReviewCycle）のステートマシンを実装（Req 8.1, 8.2）
- 遷移: DRAFT → ACTIVE → AGGREGATING → PENDING_FEEDBACK_APPROVAL → FINALIZED → CLOSED
- ACTIVE 化時に全アクティブ社員へ `EVAL_INVITATION` 通知を送信
- FINALIZED 時に `CycleFinalized` イベントを EvaluationEventBus に publish

## Prismaスキーマ追加
- `ReviewCycleStatus` enum（6ステート）
- `ReviewCycle` モデル（name/startDate/endDate/items/incentiveK/minReviewers/maxTargets/status/タイムスタンプ）
- User に `createdReviewCycles` リレーション追加

## 追加ファイル
- `src/lib/evaluation/review-cycle-types.ts` — Zodスキーマ・型定義・ドメインエラー
- `src/lib/evaluation/review-cycle-service.ts` — ステートマシン実装（明示的遷移マップ）
- `src/lib/evaluation/review-cycle-service-di.ts` — DI
- `src/app/api/evaluation/cycles/` — 10エンドポイント（CRUD + 各ステート遷移）
- `src/tests/evaluation/review-cycle-service.test.ts` — 16件テスト全通過

## Test plan
- [ ] `POST /api/evaluation/cycles` — HR_MANAGER/ADMIN のみ作成可
- [ ] DRAFT → ACTIVE → 全社員に通知送信
- [ ] FINALIZED → CycleFinalized イベントが publish される
- [ ] 無効な遷移（DRAFT → FINALIZED）→ 422
- [ ] `GET /api/evaluation/cycles?status=ACTIVE` — ステータスフィルタ

Closes #51