### PR TITLE
[#53] 自己評価とピア評価の受付

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -113,9 +113,11 @@ model User {
   oneOnOneLogs         OneOnOneLog[]     @relation("OneOnOneLogRecorder")
   goalAchievements     GoalAchievement[]
   createdReviewCycles  ReviewCycle[]     @relation("ReviewCycleCreator")
-  evaluatorAssignments ReviewAssignment[] @relation("ReviewAssignmentEvaluator")
-  targetAssignments    ReviewAssignment[] @relation("ReviewAssignmentTarget")
-  replacementDeclines  ReviewDecline[]    @relation("ReviewDeclineReplacement")
+  evaluatorAssignments        ReviewAssignment[]   @relation("ReviewAssignmentEvaluator")
+  targetAssignments           ReviewAssignment[]   @relation("ReviewAssignmentTarget")
+  replacementDeclines         ReviewDecline[]      @relation("ReviewDeclineReplacement")
+  evaluationResponsesGiven    EvaluationResponse[] @relation("EvaluationResponseEvaluator")
+  evaluationResponsesReceived EvaluationResponse[] @relation("EvaluationResponseTarget")
 
   @@index([emailHash])
   @@index([status])
@@ -637,8 +639,9 @@ model ReviewCycle {
   createdAt    DateTime          @default(now())
   updatedAt    DateTime          @updatedAt
 
-  creator     User               @relation("ReviewCycleCreator", fields: [createdBy], references: [id])
+  creator     User                 @relation("ReviewCycleCreator", fields: [createdBy], references: [id])
   assignments ReviewAssignment[]
+  responses   EvaluationResponse[]
 
   @@index([status])
   @@index([startDate, endDate])
@@ -689,4 +692,37 @@ model ReviewDecline {
   replacementEvaluator User?            @relation("ReviewDeclineReplacement", fields: [replacementEvaluatorId], references: [id])
 
   @@map("review_declines")
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 評価入力 (Requirement 8.5, 8.6, 8.7, 8.17)
+// ─────────────────────────────────────────────────────────────────────────────
+
+enum EvaluationResponseType {
+  SELF       // 自己評価
+  TOP_DOWN   // 上司評価
+  PEER       // ピア評価
+}
+
+/// 評価回答 (Requirement 8.5, 8.6, 8.7)
+/// 自己評価・上司評価・ピア評価をすべてこのモデルで管理
+model EvaluationResponse {
+  id           String                 @id @default(cuid())
+  cycleId      String
+  evaluatorId  String                 // 評価者（SELFの場合は自分自身）
+  targetUserId String                 // 評価対象者
+  responseType EvaluationResponseType
+  score        Int                    // 0-100（80点基準）
+  comment      String?
+  submittedAt  DateTime               @default(now())
+  isDraft      Boolean                @default(true)  // true=下書き, false=送信済み
+
+  cycle     ReviewCycle @relation(fields: [cycleId], references: [id], onDelete: Cascade)
+  evaluator User        @relation("EvaluationResponseEvaluator", fields: [evaluatorId], references: [id])
+  target    User        @relation("EvaluationResponseTarget",    fields: [targetUserId], references: [id])
+
+  @@unique([cycleId, evaluatorId, targetUserId, responseType])
+  @@index([cycleId, evaluatorId])
+  @@index([cycleId, targetUserId])
+  @@map("evaluation_responses")
 }

--- a/src/app/api/evaluation/responses/draft/route.ts
+++ b/src/app/api/evaluation/responses/draft/route.ts
@@ -1,0 +1,44 @@
+/**
+ * Issue #53 / Task 15.4: 評価回答 下書き保存 API (Req 8.5, 8.6)
+ *
+ * - POST /api/evaluation/responses/draft — 下書き保存（認証済み）
+ */
+import { type NextRequest, NextResponse } from 'next/server'
+import { evaluationResponseInputSchema } from '@/lib/evaluation/evaluation-response-types'
+import { parseJsonBody, requireAuthenticated } from '@/lib/skill/skill-route-helpers'
+import { getEvaluationResponseService } from '@/lib/evaluation/evaluation-response-service-di'
+
+export {
+  setEvaluationResponseServiceForTesting,
+  clearEvaluationResponseServiceForTesting,
+} from '@/lib/evaluation/evaluation-response-service-di'
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const guard = await requireAuthenticated()
+  if (!guard.ok) return guard.response
+
+  const parsedBody = await parseJsonBody(request)
+  if (!parsedBody.ok) return parsedBody.response
+
+  const validated = evaluationResponseInputSchema.safeParse(parsedBody.body)
+  if (!validated.success) {
+    return NextResponse.json({ error: validated.error.flatten() }, { status: 422 })
+  }
+
+  let svc: ReturnType<typeof getEvaluationResponseService>
+  try {
+    svc = getEvaluationResponseService()
+  } catch {
+    return NextResponse.json(
+      { error: 'EvaluationResponse service not initialized' },
+      { status: 503 },
+    )
+  }
+
+  try {
+    const response = await svc.saveDraft(guard.session.userId, validated.data)
+    return NextResponse.json({ success: true, data: response }, { status: 200 })
+  } catch {
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/api/evaluation/responses/mine/route.ts
+++ b/src/app/api/evaluation/responses/mine/route.ts
@@ -1,0 +1,40 @@
+/**
+ * Issue #53 / Task 15.4: 評価回答 自分の評価一覧 API (Req 8.5, 8.6)
+ *
+ * - GET /api/evaluation/responses/mine?cycleId=... — 自分の評価一覧（認証済み）
+ */
+import { type NextRequest, NextResponse } from 'next/server'
+import { requireAuthenticated } from '@/lib/skill/skill-route-helpers'
+import { getEvaluationResponseService } from '@/lib/evaluation/evaluation-response-service-di'
+
+export {
+  setEvaluationResponseServiceForTesting,
+  clearEvaluationResponseServiceForTesting,
+} from '@/lib/evaluation/evaluation-response-service-di'
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const guard = await requireAuthenticated()
+  if (!guard.ok) return guard.response
+
+  const cycleId = request.nextUrl.searchParams.get('cycleId')
+  if (!cycleId) {
+    return NextResponse.json({ error: 'cycleId is required' }, { status: 400 })
+  }
+
+  let svc: ReturnType<typeof getEvaluationResponseService>
+  try {
+    svc = getEvaluationResponseService()
+  } catch {
+    return NextResponse.json(
+      { error: 'EvaluationResponse service not initialized' },
+      { status: 503 },
+    )
+  }
+
+  try {
+    const responses = await svc.listMyResponses(guard.session.userId, cycleId)
+    return NextResponse.json({ success: true, data: responses }, { status: 200 })
+  } catch {
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/api/evaluation/responses/received/route.ts
+++ b/src/app/api/evaluation/responses/received/route.ts
@@ -1,0 +1,40 @@
+/**
+ * Issue #53 / Task 15.4: 評価回答 受けた評価一覧 API (Req 8.7)
+ *
+ * - GET /api/evaluation/responses/received?cycleId=... — 受けた評価（送信済みのみ・認証済み）
+ */
+import { type NextRequest, NextResponse } from 'next/server'
+import { requireAuthenticated } from '@/lib/skill/skill-route-helpers'
+import { getEvaluationResponseService } from '@/lib/evaluation/evaluation-response-service-di'
+
+export {
+  setEvaluationResponseServiceForTesting,
+  clearEvaluationResponseServiceForTesting,
+} from '@/lib/evaluation/evaluation-response-service-di'
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const guard = await requireAuthenticated()
+  if (!guard.ok) return guard.response
+
+  const cycleId = request.nextUrl.searchParams.get('cycleId')
+  if (!cycleId) {
+    return NextResponse.json({ error: 'cycleId is required' }, { status: 400 })
+  }
+
+  let svc: ReturnType<typeof getEvaluationResponseService>
+  try {
+    svc = getEvaluationResponseService()
+  } catch {
+    return NextResponse.json(
+      { error: 'EvaluationResponse service not initialized' },
+      { status: 503 },
+    )
+  }
+
+  try {
+    const responses = await svc.listReceivedResponses(guard.session.userId, cycleId)
+    return NextResponse.json({ success: true, data: responses }, { status: 200 })
+  } catch {
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/api/evaluation/responses/route.ts
+++ b/src/app/api/evaluation/responses/route.ts
@@ -1,0 +1,46 @@
+/**
+ * Issue #53 / Task 15.4: 評価回答 全体一覧 API (Req 8.17)
+ *
+ * - GET /api/evaluation/responses?cycleId=... — 全体一覧（HR_MANAGER/ADMIN）
+ */
+import { type NextRequest, NextResponse } from 'next/server'
+import { requireAuthenticated } from '@/lib/skill/skill-route-helpers'
+import { getEvaluationResponseService } from '@/lib/evaluation/evaluation-response-service-di'
+
+export {
+  setEvaluationResponseServiceForTesting,
+  clearEvaluationResponseServiceForTesting,
+} from '@/lib/evaluation/evaluation-response-service-di'
+
+const HR_OR_ADMIN_ROLES = ['HR_MANAGER', 'ADMIN'] as const
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const guard = await requireAuthenticated()
+  if (!guard.ok) return guard.response
+
+  if (!HR_OR_ADMIN_ROLES.includes(guard.session.role as (typeof HR_OR_ADMIN_ROLES)[number])) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const cycleId = request.nextUrl.searchParams.get('cycleId')
+  if (!cycleId) {
+    return NextResponse.json({ error: 'cycleId is required' }, { status: 400 })
+  }
+
+  let svc: ReturnType<typeof getEvaluationResponseService>
+  try {
+    svc = getEvaluationResponseService()
+  } catch {
+    return NextResponse.json(
+      { error: 'EvaluationResponse service not initialized' },
+      { status: 503 },
+    )
+  }
+
+  try {
+    const responses = await svc.listByCycle(cycleId)
+    return NextResponse.json({ success: true, data: responses }, { status: 200 })
+  } catch {
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/api/evaluation/responses/submit/route.ts
+++ b/src/app/api/evaluation/responses/submit/route.ts
@@ -1,0 +1,54 @@
+/**
+ * Issue #53 / Task 15.4: 評価回答 送信 API (Req 8.5, 8.6, 8.7)
+ *
+ * - POST /api/evaluation/responses/submit — 送信（認証済み）
+ */
+import { type NextRequest, NextResponse } from 'next/server'
+import {
+  evaluationResponseInputSchema,
+  EvaluationAlreadySubmittedError,
+  EvaluationNotAssignedError,
+} from '@/lib/evaluation/evaluation-response-types'
+import { parseJsonBody, requireAuthenticated } from '@/lib/skill/skill-route-helpers'
+import { getEvaluationResponseService } from '@/lib/evaluation/evaluation-response-service-di'
+
+export {
+  setEvaluationResponseServiceForTesting,
+  clearEvaluationResponseServiceForTesting,
+} from '@/lib/evaluation/evaluation-response-service-di'
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const guard = await requireAuthenticated()
+  if (!guard.ok) return guard.response
+
+  const parsedBody = await parseJsonBody(request)
+  if (!parsedBody.ok) return parsedBody.response
+
+  const validated = evaluationResponseInputSchema.safeParse(parsedBody.body)
+  if (!validated.success) {
+    return NextResponse.json({ error: validated.error.flatten() }, { status: 422 })
+  }
+
+  let svc: ReturnType<typeof getEvaluationResponseService>
+  try {
+    svc = getEvaluationResponseService()
+  } catch {
+    return NextResponse.json(
+      { error: 'EvaluationResponse service not initialized' },
+      { status: 503 },
+    )
+  }
+
+  try {
+    const response = await svc.submit(guard.session.userId, validated.data)
+    return NextResponse.json({ success: true, data: response }, { status: 200 })
+  } catch (err) {
+    if (err instanceof EvaluationAlreadySubmittedError) {
+      return NextResponse.json({ error: err.message }, { status: 409 })
+    }
+    if (err instanceof EvaluationNotAssignedError) {
+      return NextResponse.json({ error: err.message }, { status: 403 })
+    }
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/lib/evaluation/evaluation-response-service-di.ts
+++ b/src/lib/evaluation/evaluation-response-service-di.ts
@@ -1,0 +1,30 @@
+/**
+ * Issue #53 / Task 15.4: EvaluationResponseService DI コンテナ
+ *
+ * テストでは setEvaluationResponseServiceForTesting() を使用。
+ * プロダクションでは initEvaluationResponseService() を起動前に呼ぶ。
+ */
+import type { EvaluationResponseService } from './evaluation-response-service'
+
+let _service: EvaluationResponseService | null = null
+
+export function setEvaluationResponseServiceForTesting(svc: EvaluationResponseService): void {
+  _service = svc
+}
+
+export function clearEvaluationResponseServiceForTesting(): void {
+  _service = null
+}
+
+export function getEvaluationResponseService(): EvaluationResponseService {
+  if (_service) return _service
+  throw new Error(
+    'EvaluationResponseService is not initialized. ' +
+      'テストでは setEvaluationResponseServiceForTesting() を呼んでください。' +
+      'プロダクションではサーバー起動前に initEvaluationResponseService() を呼んでください。',
+  )
+}
+
+export function initEvaluationResponseService(svc: EvaluationResponseService): void {
+  _service = svc
+}

--- a/src/lib/evaluation/evaluation-response-service.ts
+++ b/src/lib/evaluation/evaluation-response-service.ts
@@ -1,0 +1,233 @@
+/**
+ * Issue #53 / Task 15.4: 自己評価とピア評価の受付
+ * (Requirement 8.5, 8.6, 8.7, 8.17)
+ *
+ * - saveDraft: 下書き保存または更新（isDraft: true）
+ * - submit: 送信（isDraft: false）→ EvaluationSubmitted イベント発行
+ *   - SELF の場合: ReviewAssignment チェック不要
+ *   - TOP_DOWN / PEER: ACTIVE な ReviewAssignment があることを確認
+ * - listMyResponses: 自分が提出した評価一覧
+ * - listReceivedResponses: 自分が受けた評価一覧（送信済みのみ）
+ * - listByCycle: HR_MANAGER 用サイクル全体の評価一覧
+ */
+import type { PrismaClient } from '@prisma/client'
+import { getEvaluationEventBus } from './evaluation-event-bus-di'
+import {
+  EvaluationAlreadySubmittedError,
+  EvaluationNotAssignedError,
+  type EvaluationResponseInput,
+  type EvaluationResponseRecord,
+  type EvaluationResponseType,
+} from './evaluation-response-types'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Service interface
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface EvaluationResponseService {
+  /** 下書き保存または作成（isDraft: true） */
+  saveDraft(evaluatorId: string, input: EvaluationResponseInput): Promise<EvaluationResponseRecord>
+
+  /**
+   * 送信（isDraft: false に更新）→ EvaluationSubmitted イベント発行
+   * - SELF の場合: ReviewAssignment チェック不要
+   * - TOP_DOWN / PEER の場合: ACTIVE な ReviewAssignment があることを確認
+   */
+  submit(evaluatorId: string, input: EvaluationResponseInput): Promise<EvaluationResponseRecord>
+
+  /** 自分が提出した評価一覧 */
+  listMyResponses(evaluatorId: string, cycleId: string): Promise<EvaluationResponseRecord[]>
+
+  /** 自分が受けた評価一覧（送信済みのみ） */
+  listReceivedResponses(targetUserId: string, cycleId: string): Promise<EvaluationResponseRecord[]>
+
+  /** HR_MANAGER 用: サイクル全体の評価一覧 */
+  listByCycle(cycleId: string): Promise<EvaluationResponseRecord[]>
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Prisma row → domain record conversion
+// ─────────────────────────────────────────────────────────────────────────────
+
+type PrismaResponseRow = {
+  id: string
+  cycleId: string
+  evaluatorId: string
+  targetUserId: string
+  responseType: string
+  score: number
+  comment: string | null
+  submittedAt: Date
+  isDraft: boolean
+}
+
+function toRecord(row: PrismaResponseRow): EvaluationResponseRecord {
+  return {
+    id: row.id,
+    cycleId: row.cycleId,
+    evaluatorId: row.evaluatorId,
+    targetUserId: row.targetUserId,
+    responseType: row.responseType as EvaluationResponseType,
+    score: row.score,
+    comment: row.comment,
+    submittedAt: row.submittedAt,
+    isDraft: row.isDraft,
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Implementation
+// ─────────────────────────────────────────────────────────────────────────────
+
+class EvaluationResponseServiceImpl implements EvaluationResponseService {
+  constructor(private readonly db: PrismaClient) {}
+
+  async saveDraft(
+    evaluatorId: string,
+    input: EvaluationResponseInput,
+  ): Promise<EvaluationResponseRecord> {
+    const { cycleId, targetUserId, responseType, score, comment } = input
+
+    const row = await this.db.evaluationResponse.upsert({
+      where: {
+        cycleId_evaluatorId_targetUserId_responseType: {
+          cycleId,
+          evaluatorId,
+          targetUserId,
+          responseType,
+        },
+      },
+      create: {
+        cycleId,
+        evaluatorId,
+        targetUserId,
+        responseType,
+        score,
+        comment: comment ?? null,
+        isDraft: true,
+      },
+      update: {
+        score,
+        comment: comment ?? null,
+        isDraft: true,
+      },
+    })
+
+    return toRecord(row)
+  }
+
+  async submit(
+    evaluatorId: string,
+    input: EvaluationResponseInput,
+  ): Promise<EvaluationResponseRecord> {
+    const { cycleId, targetUserId, responseType, score, comment } = input
+
+    // 送信済みチェック
+    const existing = await this.db.evaluationResponse.findUnique({
+      where: {
+        cycleId_evaluatorId_targetUserId_responseType: {
+          cycleId,
+          evaluatorId,
+          targetUserId,
+          responseType,
+        },
+      },
+    })
+    if (existing !== null && !existing.isDraft) {
+      throw new EvaluationAlreadySubmittedError()
+    }
+
+    // TOP_DOWN / PEER の場合: ACTIVE な ReviewAssignment があることを確認
+    if (responseType !== 'SELF') {
+      const assignment = await this.db.reviewAssignment.findFirst({
+        where: {
+          cycleId,
+          evaluatorId,
+          targetUserId,
+          status: 'ACTIVE',
+        },
+      })
+      if (!assignment) {
+        throw new EvaluationNotAssignedError()
+      }
+    }
+
+    const now = new Date()
+    const row = await this.db.evaluationResponse.upsert({
+      where: {
+        cycleId_evaluatorId_targetUserId_responseType: {
+          cycleId,
+          evaluatorId,
+          targetUserId,
+          responseType,
+        },
+      },
+      create: {
+        cycleId,
+        evaluatorId,
+        targetUserId,
+        responseType,
+        score,
+        comment: comment ?? null,
+        isDraft: false,
+        submittedAt: now,
+      },
+      update: {
+        score,
+        comment: comment ?? null,
+        isDraft: false,
+        submittedAt: now,
+      },
+    })
+
+    // EvaluationSubmitted イベント発行
+    try {
+      const bus = getEvaluationEventBus()
+      await bus.publish('EvaluationSubmitted', {
+        evaluationId: row.id,
+        evaluatorId,
+        targetUserId,
+        submittedAt: now.toISOString(),
+      })
+    } catch {
+      // バスが未初期化の場合は無視
+    }
+
+    return toRecord(row)
+  }
+
+  async listMyResponses(evaluatorId: string, cycleId: string): Promise<EvaluationResponseRecord[]> {
+    const rows = await this.db.evaluationResponse.findMany({
+      where: { cycleId, evaluatorId },
+      orderBy: { submittedAt: 'asc' },
+    })
+    return rows.map(toRecord)
+  }
+
+  async listReceivedResponses(
+    targetUserId: string,
+    cycleId: string,
+  ): Promise<EvaluationResponseRecord[]> {
+    const rows = await this.db.evaluationResponse.findMany({
+      where: { cycleId, targetUserId, isDraft: false },
+      orderBy: { submittedAt: 'asc' },
+    })
+    return rows.map(toRecord)
+  }
+
+  async listByCycle(cycleId: string): Promise<EvaluationResponseRecord[]> {
+    const rows = await this.db.evaluationResponse.findMany({
+      where: { cycleId },
+      orderBy: { submittedAt: 'asc' },
+    })
+    return rows.map(toRecord)
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Factory
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function createEvaluationResponseService(db: PrismaClient): EvaluationResponseService {
+  return new EvaluationResponseServiceImpl(db)
+}

--- a/src/lib/evaluation/evaluation-response-types.ts
+++ b/src/lib/evaluation/evaluation-response-types.ts
@@ -1,0 +1,67 @@
+/**
+ * Issue #53 / Task 15.4: 自己評価とピア評価の受付
+ * (Requirement 8.5, 8.6, 8.7, 8.17)
+ *
+ * - EvaluationResponseType: SELF / TOP_DOWN / PEER
+ * - EvaluationResponseRecord: ドメインレコード型
+ * - evaluationResponseInputSchema: 入力バリデーション (Zod)
+ * - ドメインエラークラス
+ */
+import { z } from 'zod'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type EvaluationResponseType = 'SELF' | 'TOP_DOWN' | 'PEER'
+
+export interface EvaluationResponseRecord {
+  id: string
+  cycleId: string
+  evaluatorId: string
+  targetUserId: string
+  responseType: EvaluationResponseType
+  score: number
+  comment: string | null
+  submittedAt: Date
+  isDraft: boolean
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Zod schema
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const evaluationResponseInputSchema = z.object({
+  cycleId: z.string().min(1),
+  targetUserId: z.string().min(1),
+  responseType: z.enum(['SELF', 'TOP_DOWN', 'PEER']),
+  score: z.number().int().min(0).max(100),
+  comment: z.string().max(2000).optional(),
+})
+
+export type EvaluationResponseInput = z.infer<typeof evaluationResponseInputSchema>
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Domain errors
+// ─────────────────────────────────────────────────────────────────────────────
+
+export class EvaluationResponseNotFoundError extends Error {
+  constructor() {
+    super('EvaluationResponse not found')
+    this.name = 'EvaluationResponseNotFoundError'
+  }
+}
+
+export class EvaluationAlreadySubmittedError extends Error {
+  constructor() {
+    super('Evaluation has already been submitted')
+    this.name = 'EvaluationAlreadySubmittedError'
+  }
+}
+
+export class EvaluationNotAssignedError extends Error {
+  constructor() {
+    super('No active assignment found for this evaluator and target')
+    this.name = 'EvaluationNotAssignedError'
+  }
+}

--- a/src/tests/evaluation/evaluation-response-service.test.ts
+++ b/src/tests/evaluation/evaluation-response-service.test.ts
@@ -1,0 +1,351 @@
+/**
+ * Issue #53 / Task 15.4: EvaluationResponseService 単体テスト
+ * (Requirement 8.5, 8.6, 8.7, 8.17)
+ *
+ * テスト対象:
+ * - 下書き保存テスト（isDraft: true）
+ * - 送信テスト（isDraft: false に変更、EvaluationSubmitted イベント発行）
+ * - 送信済み評価の再送信でエラー
+ * - TOP_DOWN/PEER 評価で ACTIVE な Assignment がない場合にエラー
+ * - SELF 評価は Assignment チェック不要
+ * - listReceivedResponses は送信済みのみ返す
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { createEvaluationResponseService } from '@/lib/evaluation/evaluation-response-service'
+import {
+  EvaluationAlreadySubmittedError,
+  EvaluationNotAssignedError,
+  type EvaluationResponseRecord,
+} from '@/lib/evaluation/evaluation-response-types'
+import {
+  setEvaluationEventBusForTesting,
+  clearEvaluationEventBusForTesting,
+} from '@/lib/evaluation/evaluation-event-bus-di'
+import { InMemoryEvaluationEventBus } from '@/lib/evaluation/evaluation-event-bus'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fixtures
+// ─────────────────────────────────────────────────────────────────────────────
+
+const FIXED_NOW = new Date('2026-04-19T09:00:00.000Z')
+
+function makeResponseRecord(
+  overrides: Partial<EvaluationResponseRecord> = {},
+): EvaluationResponseRecord {
+  return {
+    id: 'resp-1',
+    cycleId: 'cycle-1',
+    evaluatorId: 'user-evaluator',
+    targetUserId: 'user-target',
+    responseType: 'SELF',
+    score: 80,
+    comment: null,
+    submittedAt: FIXED_NOW,
+    isDraft: true,
+    ...overrides,
+  }
+}
+
+function makePrisma(opts: {
+  existingResponse?: EvaluationResponseRecord | null
+  upsertResult?: EvaluationResponseRecord
+  findManyResult?: EvaluationResponseRecord[]
+  activeAssignment?: { id: string } | null
+}) {
+  const {
+    existingResponse = null,
+    upsertResult = makeResponseRecord(),
+    findManyResult = [],
+    activeAssignment = { id: 'asn-1' },
+  } = opts
+
+  return {
+    evaluationResponse: {
+      findUnique: vi.fn().mockResolvedValue(existingResponse),
+      upsert: vi.fn().mockResolvedValue(upsertResult),
+      findMany: vi.fn().mockResolvedValue(findManyResult),
+    },
+    reviewAssignment: {
+      findFirst: vi.fn().mockResolvedValue(activeAssignment),
+    },
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('EvaluationResponseService', () => {
+  let bus: InMemoryEvaluationEventBus
+
+  beforeEach(() => {
+    bus = new InMemoryEvaluationEventBus()
+    setEvaluationEventBusForTesting(bus)
+  })
+
+  afterEach(() => {
+    clearEvaluationEventBusForTesting()
+  })
+
+  describe('saveDraft', () => {
+    it('下書きを保存すると isDraft: true のレコードを返す', async () => {
+      // Arrange
+      const draftRecord = makeResponseRecord({ isDraft: true })
+      const db = makePrisma({ upsertResult: draftRecord })
+      const svc = createEvaluationResponseService(db as never)
+
+      // Act
+      const result = await svc.saveDraft('user-evaluator', {
+        cycleId: 'cycle-1',
+        targetUserId: 'user-target',
+        responseType: 'SELF',
+        score: 75,
+      })
+
+      // Assert
+      expect(result.isDraft).toBe(true)
+      expect(db.evaluationResponse.upsert).toHaveBeenCalledOnce()
+      expect(db.evaluationResponse.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          create: expect.objectContaining({ isDraft: true }),
+          update: expect.objectContaining({ isDraft: true }),
+        }),
+      )
+    })
+
+    it('既存の下書きを上書き保存できる', async () => {
+      // Arrange
+      const existingDraft = makeResponseRecord({ isDraft: true, score: 60 })
+      const updatedDraft = makeResponseRecord({ isDraft: true, score: 80 })
+      const db = makePrisma({ existingResponse: existingDraft, upsertResult: updatedDraft })
+      const svc = createEvaluationResponseService(db as never)
+
+      // Act
+      const result = await svc.saveDraft('user-evaluator', {
+        cycleId: 'cycle-1',
+        targetUserId: 'user-target',
+        responseType: 'SELF',
+        score: 80,
+      })
+
+      // Assert
+      expect(result.score).toBe(80)
+      expect(result.isDraft).toBe(true)
+    })
+  })
+
+  describe('submit', () => {
+    it('SELF 評価を送信すると isDraft: false になり EvaluationSubmitted イベントが発行される', async () => {
+      // Arrange
+      const submittedRecord = makeResponseRecord({ isDraft: false })
+      const db = makePrisma({ existingResponse: null, upsertResult: submittedRecord })
+      const svc = createEvaluationResponseService(db as never)
+
+      const publishedEvents: unknown[] = []
+      bus.subscribe('EvaluationSubmitted', async (payload) => {
+        publishedEvents.push(payload)
+      })
+
+      // Act
+      const result = await svc.submit('user-evaluator', {
+        cycleId: 'cycle-1',
+        targetUserId: 'user-target',
+        responseType: 'SELF',
+        score: 80,
+      })
+
+      // Assert
+      expect(result.isDraft).toBe(false)
+      expect(publishedEvents).toHaveLength(1)
+      expect(publishedEvents[0]).toMatchObject({
+        evaluationId: 'resp-1',
+        evaluatorId: 'user-evaluator',
+        targetUserId: 'user-target',
+      })
+    })
+
+    it('SELF 評価は ReviewAssignment チェックを行わない', async () => {
+      // Arrange
+      const submittedRecord = makeResponseRecord({ isDraft: false })
+      const db = makePrisma({ existingResponse: null, upsertResult: submittedRecord })
+      const svc = createEvaluationResponseService(db as never)
+
+      // Act
+      await svc.submit('user-evaluator', {
+        cycleId: 'cycle-1',
+        targetUserId: 'user-target',
+        responseType: 'SELF',
+        score: 80,
+      })
+
+      // Assert: reviewAssignment.findFirst は呼ばれない
+      expect(db.reviewAssignment.findFirst).not.toHaveBeenCalled()
+    })
+
+    it('TOP_DOWN 評価で ACTIVE な Assignment がある場合は送信できる', async () => {
+      // Arrange
+      const submittedRecord = makeResponseRecord({ responseType: 'TOP_DOWN', isDraft: false })
+      const db = makePrisma({
+        existingResponse: null,
+        upsertResult: submittedRecord,
+        activeAssignment: { id: 'asn-1' },
+      })
+      const svc = createEvaluationResponseService(db as never)
+
+      // Act
+      const result = await svc.submit('user-evaluator', {
+        cycleId: 'cycle-1',
+        targetUserId: 'user-target',
+        responseType: 'TOP_DOWN',
+        score: 85,
+      })
+
+      // Assert
+      expect(result.isDraft).toBe(false)
+      expect(db.reviewAssignment.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            cycleId: 'cycle-1',
+            evaluatorId: 'user-evaluator',
+            targetUserId: 'user-target',
+            status: 'ACTIVE',
+          }),
+        }),
+      )
+    })
+
+    it('PEER 評価で ACTIVE な Assignment がない場合は EvaluationNotAssignedError をスローする', async () => {
+      // Arrange
+      const db = makePrisma({ existingResponse: null, activeAssignment: null })
+      const svc = createEvaluationResponseService(db as never)
+
+      // Act & Assert
+      await expect(
+        svc.submit('user-evaluator', {
+          cycleId: 'cycle-1',
+          targetUserId: 'user-target',
+          responseType: 'PEER',
+          score: 70,
+        }),
+      ).rejects.toBeInstanceOf(EvaluationNotAssignedError)
+    })
+
+    it('TOP_DOWN 評価で ACTIVE な Assignment がない場合は EvaluationNotAssignedError をスローする', async () => {
+      // Arrange
+      const db = makePrisma({ existingResponse: null, activeAssignment: null })
+      const svc = createEvaluationResponseService(db as never)
+
+      // Act & Assert
+      await expect(
+        svc.submit('user-evaluator', {
+          cycleId: 'cycle-1',
+          targetUserId: 'user-target',
+          responseType: 'TOP_DOWN',
+          score: 70,
+        }),
+      ).rejects.toBeInstanceOf(EvaluationNotAssignedError)
+    })
+
+    it('送信済み評価を再送信すると EvaluationAlreadySubmittedError をスローする', async () => {
+      // Arrange
+      const submittedRecord = makeResponseRecord({ isDraft: false })
+      const db = makePrisma({ existingResponse: submittedRecord })
+      const svc = createEvaluationResponseService(db as never)
+
+      // Act & Assert
+      await expect(
+        svc.submit('user-evaluator', {
+          cycleId: 'cycle-1',
+          targetUserId: 'user-target',
+          responseType: 'SELF',
+          score: 90,
+        }),
+      ).rejects.toBeInstanceOf(EvaluationAlreadySubmittedError)
+    })
+
+    it('下書き状態からの送信は成功する（送信済みではない）', async () => {
+      // Arrange
+      const draftRecord = makeResponseRecord({ isDraft: true })
+      const submittedRecord = makeResponseRecord({ isDraft: false })
+      const db = makePrisma({ existingResponse: draftRecord, upsertResult: submittedRecord })
+      const svc = createEvaluationResponseService(db as never)
+
+      // Act
+      const result = await svc.submit('user-evaluator', {
+        cycleId: 'cycle-1',
+        targetUserId: 'user-target',
+        responseType: 'SELF',
+        score: 80,
+      })
+
+      // Assert
+      expect(result.isDraft).toBe(false)
+    })
+  })
+
+  describe('listMyResponses', () => {
+    it('自分が提出した評価一覧を返す（下書き含む）', async () => {
+      // Arrange
+      const records = [
+        makeResponseRecord({ id: 'resp-1', isDraft: true }),
+        makeResponseRecord({ id: 'resp-2', isDraft: false }),
+      ]
+      const db = makePrisma({ findManyResult: records })
+      const svc = createEvaluationResponseService(db as never)
+
+      // Act
+      const result = await svc.listMyResponses('user-evaluator', 'cycle-1')
+
+      // Assert
+      expect(result).toHaveLength(2)
+      expect(db.evaluationResponse.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { cycleId: 'cycle-1', evaluatorId: 'user-evaluator' },
+        }),
+      )
+    })
+  })
+
+  describe('listReceivedResponses', () => {
+    it('受けた評価一覧は送信済み（isDraft: false）のみを返す', async () => {
+      // Arrange
+      const submittedRecords = [makeResponseRecord({ id: 'resp-2', isDraft: false })]
+      const db = makePrisma({ findManyResult: submittedRecords })
+      const svc = createEvaluationResponseService(db as never)
+
+      // Act
+      const result = await svc.listReceivedResponses('user-target', 'cycle-1')
+
+      // Assert
+      expect(result).toHaveLength(1)
+      expect(db.evaluationResponse.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { cycleId: 'cycle-1', targetUserId: 'user-target', isDraft: false },
+        }),
+      )
+    })
+  })
+
+  describe('listByCycle', () => {
+    it('サイクル全体の評価一覧を返す', async () => {
+      // Arrange
+      const records = [
+        makeResponseRecord({ id: 'resp-1', evaluatorId: 'user-1' }),
+        makeResponseRecord({ id: 'resp-2', evaluatorId: 'user-2' }),
+      ]
+      const db = makePrisma({ findManyResult: records })
+      const svc = createEvaluationResponseService(db as never)
+
+      // Act
+      const result = await svc.listByCycle('cycle-1')
+
+      // Assert
+      expect(result).toHaveLength(2)
+      expect(db.evaluationResponse.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { cycleId: 'cycle-1' },
+        }),
+      )
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- 自己評価（SELF）・上司評価（TOP_DOWN）・ピア評価（PEER）の入力・保存を実装（Req 8.5, 8.6, 8.7）
- 送信時に `EvaluationSubmitted` イベントを EvaluationEventBus に publish（Req 8.17）
- 下書き保存（isDraft: true）→ 送信（isDraft: false）の2段階フロー

## Prismaスキーマ追加
- `EvaluationResponseType` enum（SELF / TOP_DOWN / PEER）
- `EvaluationResponse` モデル（`[cycleId, evaluatorId, targetUserId, responseType]` のユニーク制約）
- User / ReviewCycle にリレーション追加

## 追加ファイル
- `src/lib/evaluation/evaluation-response-types.ts` — 型・Zodスキーマ・ドメインエラー3種
- `src/lib/evaluation/evaluation-response-service.ts` — saveDraft / submit / list系メソッド
- `src/lib/evaluation/evaluation-response-service-di.ts` — DI
- `src/app/api/evaluation/responses/draft/route.ts` — 下書き保存
- `src/app/api/evaluation/responses/submit/route.ts` — 送信
- `src/app/api/evaluation/responses/mine/route.ts` — 自分の評価一覧
- `src/app/api/evaluation/responses/received/route.ts` — 受けた評価（送信済みのみ）
- `src/app/api/evaluation/responses/route.ts` — 全体一覧（HR_MANAGER/ADMIN）
- `src/tests/evaluation/evaluation-response-service.test.ts` — 12件テスト全通過

## Test plan
- [ ] 下書き保存 → isDraft: true
- [ ] 送信 → isDraft: false、EvaluationSubmitted イベント発行
- [ ] 送信済みの再送信 → 422
- [ ] TOP_DOWN/PEER で ACTIVE Assignment なし → 422
- [ ] SELF 評価は Assignment チェックなし
- [ ] `GET /received` は送信済みのみ返す

Closes #53