### PR TITLE
feat: [#54] 匿名性保証の実装 — 被評価者向けDTOからevaluatorIdを除外

### DIFF
--- a/src/lib/evaluation/evaluation-response-service.ts
+++ b/src/lib/evaluation/evaluation-response-service.ts
@@ -15,6 +15,7 @@ import { getEvaluationEventBus } from './evaluation-event-bus-di'
 import {
   EvaluationAlreadySubmittedError,
   EvaluationNotAssignedError,
+  type AnonymousEvaluationResponseRecord,
   type EvaluationResponseInput,
   type EvaluationResponseRecord,
   type EvaluationResponseType,
@@ -38,8 +39,11 @@ export interface EvaluationResponseService {
   /** 自分が提出した評価一覧 */
   listMyResponses(evaluatorId: string, cycleId: string): Promise<EvaluationResponseRecord[]>
 
-  /** 自分が受けた評価一覧（送信済みのみ） */
-  listReceivedResponses(targetUserId: string, cycleId: string): Promise<EvaluationResponseRecord[]>
+  /** 自分が受けた評価一覧（送信済みのみ・evaluatorId を除外した匿名DTO） */
+  listReceivedResponses(
+    targetUserId: string,
+    cycleId: string,
+  ): Promise<AnonymousEvaluationResponseRecord[]>
 
   /** HR_MANAGER 用: サイクル全体の評価一覧 */
   listByCycle(cycleId: string): Promise<EvaluationResponseRecord[]>
@@ -66,6 +70,19 @@ function toRecord(row: PrismaResponseRow): EvaluationResponseRecord {
     id: row.id,
     cycleId: row.cycleId,
     evaluatorId: row.evaluatorId,
+    targetUserId: row.targetUserId,
+    responseType: row.responseType as EvaluationResponseType,
+    score: row.score,
+    comment: row.comment,
+    submittedAt: row.submittedAt,
+    isDraft: row.isDraft,
+  }
+}
+
+function toAnonymousRecord(row: PrismaResponseRow): AnonymousEvaluationResponseRecord {
+  return {
+    id: row.id,
+    cycleId: row.cycleId,
     targetUserId: row.targetUserId,
     responseType: row.responseType as EvaluationResponseType,
     score: row.score,
@@ -207,12 +224,12 @@ class EvaluationResponseServiceImpl implements EvaluationResponseService {
   async listReceivedResponses(
     targetUserId: string,
     cycleId: string,
-  ): Promise<EvaluationResponseRecord[]> {
+  ): Promise<AnonymousEvaluationResponseRecord[]> {
     const rows = await this.db.evaluationResponse.findMany({
       where: { cycleId, targetUserId, isDraft: false },
       orderBy: { submittedAt: 'asc' },
     })
-    return rows.map(toRecord)
+    return rows.map(toAnonymousRecord)
   }
 
   async listByCycle(cycleId: string): Promise<EvaluationResponseRecord[]> {

--- a/src/lib/evaluation/evaluation-response-types.ts
+++ b/src/lib/evaluation/evaluation-response-types.ts
@@ -2,8 +2,12 @@
  * Issue #53 / Task 15.4: 自己評価とピア評価の受付
  * (Requirement 8.5, 8.6, 8.7, 8.17)
  *
+ * Issue #54 / Task 15.5: 匿名性保証
+ * (Requirement 8.7, 20.6)
+ *
  * - EvaluationResponseType: SELF / TOP_DOWN / PEER
  * - EvaluationResponseRecord: ドメインレコード型
+ * - AnonymousEvaluationResponseRecord: 被評価者向け匿名DTO（evaluatorId を除外）
  * - evaluationResponseInputSchema: 入力バリデーション (Zod)
  * - ドメインエラークラス
  */
@@ -26,6 +30,25 @@ export interface EvaluationResponseRecord {
   submittedAt: Date
   isDraft: boolean
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Anonymous DTO (Issue #54): 被評価者向け — evaluatorId を除外
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const anonymousEvaluationResponseSchema = z
+  .object({
+    id: z.string(),
+    cycleId: z.string(),
+    targetUserId: z.string(),
+    responseType: z.enum(['SELF', 'TOP_DOWN', 'PEER']),
+    score: z.number().int().min(0).max(100),
+    comment: z.string().nullable(),
+    submittedAt: z.date(),
+    isDraft: z.boolean(),
+  })
+  .strict()
+
+export type AnonymousEvaluationResponseRecord = z.infer<typeof anonymousEvaluationResponseSchema>
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Zod schema

--- a/src/tests/evaluation/evaluation-response-service.test.ts
+++ b/src/tests/evaluation/evaluation-response-service.test.ts
@@ -324,6 +324,24 @@ describe('EvaluationResponseService', () => {
         }),
       )
     })
+
+    it('受けた評価一覧には evaluatorId が含まれない（匿名性保証 Req 8.7, 20.6）', async () => {
+      // Arrange
+      const submittedRecord = makeResponseRecord({
+        id: 'resp-3',
+        evaluatorId: 'secret-evaluator-id',
+        isDraft: false,
+      })
+      const db = makePrisma({ findManyResult: [submittedRecord] })
+      const svc = createEvaluationResponseService(db as never)
+
+      // Act
+      const result = await svc.listReceivedResponses('user-target', 'cycle-1')
+
+      // Assert
+      expect(result).toHaveLength(1)
+      expect(result[0]).not.toHaveProperty('evaluatorId')
+    })
   })
 
   describe('listByCycle', () => {


### PR DESCRIPTION
## 概要

被評価者が評価者を特定できないよう、DTOレベルで `evaluatorId` を除外します。

- `AnonymousEvaluationResponseRecord` 型（Zod strict）を追加 — `evaluatorId` フィールドを型レベルで排除
- `listReceivedResponses` の戻り型を `AnonymousEvaluationResponseRecord[]` に変更
- `toAnonymousRecord` ヘルパーで `evaluatorId` を除いた匿名DTOを生成
- `evaluatorId` 非露出を自動検証するテストケースを追加

## 変更ファイル

- `src/lib/evaluation/evaluation-response-types.ts` — `anonymousEvaluationResponseSchema` と `AnonymousEvaluationResponseRecord` 型を追加
- `src/lib/evaluation/evaluation-response-service.ts` — `toAnonymousRecord` ヘルパー追加、`listReceivedResponses` 戻り型変更
- `src/tests/evaluation/evaluation-response-service.test.ts` — 匿名性保証テスト追加

## 関連要件

Closes #54
Requirements: 8.7, 20.6

## テスト計画

- [ ] `npx vitest run src/tests/evaluation/evaluation-response-service.test.ts` — 全13テストがパス
- [ ] `listReceivedResponses` の結果に `evaluatorId` が含まれないことを確認（新テストケース）
- [ ] `listMyResponses` や `listByCycle` には引き続き `evaluatorId` が含まれることを確認