### PR TITLE
feat: [#55] 進捗表示とリマインダーの実装

### DIFF
--- a/src/app/api/evaluation/cycles/[id]/progress/me/route.ts
+++ b/src/app/api/evaluation/cycles/[id]/progress/me/route.ts
@@ -1,0 +1,39 @@
+/**
+ * Issue #55 / Task 15.6: 評価サイクル進捗 API — 個人向け (Req 8.8)
+ *
+ * - GET /api/evaluation/cycles/[id]/progress/me — 認証済み全員
+ */
+import { type NextRequest, NextResponse } from 'next/server'
+import { requireAuthenticated } from '@/lib/skill/skill-route-helpers'
+import { getEvaluationProgressService } from '@/lib/evaluation/evaluation-progress-service-di'
+import { EvaluationProgressCycleNotFoundError } from '@/lib/evaluation/evaluation-progress-types'
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const guard = await requireAuthenticated()
+  if (!guard.ok) return guard.response
+
+  const { id } = await params
+
+  let svc: ReturnType<typeof getEvaluationProgressService>
+  try {
+    svc = getEvaluationProgressService()
+  } catch {
+    return NextResponse.json(
+      { error: 'EvaluationProgress service not initialized' },
+      { status: 503 },
+    )
+  }
+
+  try {
+    const progress = await svc.getEvaluatorProgress(id, guard.session.userId)
+    return NextResponse.json({ success: true, data: progress })
+  } catch (err) {
+    if (err instanceof EvaluationProgressCycleNotFoundError) {
+      return NextResponse.json({ error: 'ReviewCycle not found' }, { status: 404 })
+    }
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/api/evaluation/cycles/[id]/progress/route.ts
+++ b/src/app/api/evaluation/cycles/[id]/progress/route.ts
@@ -1,0 +1,50 @@
+/**
+ * Issue #55 / Task 15.6: 評価サイクル進捗 API — HR向け全体 (Req 8.8)
+ *
+ * - GET /api/evaluation/cycles/[id]/progress — HR_MANAGER/ADMIN のみ
+ */
+import { type NextRequest, NextResponse } from 'next/server'
+import { requireAuthenticated } from '@/lib/skill/skill-route-helpers'
+import { getEvaluationProgressService } from '@/lib/evaluation/evaluation-progress-service-di'
+import { EvaluationProgressCycleNotFoundError } from '@/lib/evaluation/evaluation-progress-types'
+
+export {
+  setEvaluationProgressServiceForTesting,
+  clearEvaluationProgressServiceForTesting,
+} from '@/lib/evaluation/evaluation-progress-service-di'
+
+const HR_OR_ADMIN_ROLES = ['HR_MANAGER', 'ADMIN'] as const
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const guard = await requireAuthenticated()
+  if (!guard.ok) return guard.response
+
+  if (!HR_OR_ADMIN_ROLES.includes(guard.session.role as (typeof HR_OR_ADMIN_ROLES)[number])) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const { id } = await params
+
+  let svc: ReturnType<typeof getEvaluationProgressService>
+  try {
+    svc = getEvaluationProgressService()
+  } catch {
+    return NextResponse.json(
+      { error: 'EvaluationProgress service not initialized' },
+      { status: 503 },
+    )
+  }
+
+  try {
+    const progress = await svc.getCycleProgress(id)
+    return NextResponse.json({ success: true, data: progress })
+  } catch (err) {
+    if (err instanceof EvaluationProgressCycleNotFoundError) {
+      return NextResponse.json({ error: 'ReviewCycle not found' }, { status: 404 })
+    }
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/api/evaluation/reminder/scan/route.ts
+++ b/src/app/api/evaluation/reminder/scan/route.ts
@@ -1,0 +1,40 @@
+/**
+ * Issue #55 / Task 15.6: 評価リマインダースキャン API (Req 8.9)
+ *
+ * - POST /api/evaluation/reminder/scan — ADMIN のみ
+ *   締切3日前のACTIVEサイクルの未提出者にリマインダー通知を送る
+ */
+import { type NextRequest, NextResponse } from 'next/server'
+import { requireAuthenticated } from '@/lib/skill/skill-route-helpers'
+import { getEvaluationProgressService } from '@/lib/evaluation/evaluation-progress-service-di'
+
+export {
+  setEvaluationProgressServiceForTesting,
+  clearEvaluationProgressServiceForTesting,
+} from '@/lib/evaluation/evaluation-progress-service-di'
+
+export async function POST(_request: NextRequest): Promise<NextResponse> {
+  const guard = await requireAuthenticated()
+  if (!guard.ok) return guard.response
+
+  if (guard.session.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  let svc: ReturnType<typeof getEvaluationProgressService>
+  try {
+    svc = getEvaluationProgressService()
+  } catch {
+    return NextResponse.json(
+      { error: 'EvaluationProgress service not initialized' },
+      { status: 503 },
+    )
+  }
+
+  try {
+    const result = await svc.scanAndSendReminders(new Date())
+    return NextResponse.json({ success: true, data: result })
+  } catch {
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/lib/evaluation/evaluation-progress-service-di.ts
+++ b/src/lib/evaluation/evaluation-progress-service-di.ts
@@ -1,0 +1,30 @@
+/**
+ * Issue #55 / Task 15.6: EvaluationProgressService DI コンテナ
+ *
+ * テストでは setEvaluationProgressServiceForTesting() を使用。
+ * プロダクションでは initEvaluationProgressService() を起動前に呼ぶ。
+ */
+import type { EvaluationProgressService } from './evaluation-progress-service'
+
+let _service: EvaluationProgressService | null = null
+
+export function setEvaluationProgressServiceForTesting(svc: EvaluationProgressService): void {
+  _service = svc
+}
+
+export function clearEvaluationProgressServiceForTesting(): void {
+  _service = null
+}
+
+export function getEvaluationProgressService(): EvaluationProgressService {
+  if (_service) return _service
+  throw new Error(
+    'EvaluationProgressService is not initialized. ' +
+      'テストでは setEvaluationProgressServiceForTesting() を呼んでください。' +
+      'プロダクションではサーバー起動前に initEvaluationProgressService() を呼んでください。',
+  )
+}
+
+export function initEvaluationProgressService(svc: EvaluationProgressService): void {
+  _service = svc
+}

--- a/src/lib/evaluation/evaluation-progress-service.ts
+++ b/src/lib/evaluation/evaluation-progress-service.ts
@@ -1,0 +1,194 @@
+/**
+ * Issue #55 / Task 15.6: 進捗表示とリマインダー サービス
+ * (Req 8.8, 8.9)
+ *
+ * - getCycleProgress: HR_MANAGER向け — サイクル全体の評価進捗を集計
+ * - getEvaluatorProgress: 個人向け — 自分の評価進捗を取得
+ * - scanAndSendReminders: 締切3日前のACTIVEサイクルの未提出者に通知
+ */
+import type { PrismaClient } from '@prisma/client'
+import type { NotificationEmitter } from '@/lib/notification/notification-emitter'
+import {
+  EvaluationProgressCycleNotFoundError,
+  type CycleProgressRecord,
+  type EvaluatorProgressRecord,
+  type ReminderScanResult,
+} from './evaluation-progress-types'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Service interface
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface EvaluationProgressService {
+  /** HR_MANAGER向け: サイクル全体の評価進捗を集計 */
+  getCycleProgress(cycleId: string): Promise<CycleProgressRecord>
+  /** 個人向け: 自分の評価進捗を取得 */
+  getEvaluatorProgress(cycleId: string, evaluatorId: string): Promise<EvaluatorProgressRecord>
+  /** 締切3日前のACTIVEサイクルの未提出者に通知を送る */
+  scanAndSendReminders(now: Date): Promise<ReminderScanResult>
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Implementation
+// ─────────────────────────────────────────────────────────────────────────────
+
+const REMINDER_DAYS_BEFORE = 3
+
+class EvaluationProgressServiceImpl implements EvaluationProgressService {
+  constructor(
+    private readonly db: PrismaClient,
+    private readonly notificationEmitter: NotificationEmitter | null,
+  ) {}
+
+  async getCycleProgress(cycleId: string): Promise<CycleProgressRecord> {
+    const cycle = await this.db.reviewCycle.findUnique({
+      where: { id: cycleId },
+      select: { id: true },
+    })
+    if (!cycle) throw new EvaluationProgressCycleNotFoundError(cycleId)
+
+    const assignments = await this.db.reviewAssignment.findMany({
+      where: { cycleId, status: 'ACTIVE' },
+      select: { evaluatorId: true, targetUserId: true },
+    })
+
+    const submitted = await this.db.evaluationResponse.findMany({
+      where: { cycleId, isDraft: false },
+      select: { evaluatorId: true, targetUserId: true },
+    })
+
+    const submittedSet = new Set(submitted.map((r) => `${r.evaluatorId}::${r.targetUserId}`))
+
+    const progressMap = new Map<string, { total: number; submittedCount: number }>()
+    for (const a of assignments) {
+      const entry = progressMap.get(a.evaluatorId) ?? { total: 0, submittedCount: 0 }
+      entry.total += 1
+      if (submittedSet.has(`${a.evaluatorId}::${a.targetUserId}`)) {
+        entry.submittedCount += 1
+      }
+      progressMap.set(a.evaluatorId, entry)
+    }
+
+    const evaluators: EvaluatorProgressRecord[] = Array.from(progressMap.entries()).map(
+      ([evaluatorId, { total, submittedCount }]) => ({
+        evaluatorId,
+        totalAssignments: total,
+        submittedCount,
+        pendingCount: total - submittedCount,
+      }),
+    )
+
+    return {
+      cycleId,
+      totalEvaluators: evaluators.length,
+      fullySubmittedCount: evaluators.filter((e) => e.pendingCount === 0).length,
+      evaluators,
+    }
+  }
+
+  async getEvaluatorProgress(
+    cycleId: string,
+    evaluatorId: string,
+  ): Promise<EvaluatorProgressRecord> {
+    const cycle = await this.db.reviewCycle.findUnique({
+      where: { id: cycleId },
+      select: { id: true },
+    })
+    if (!cycle) throw new EvaluationProgressCycleNotFoundError(cycleId)
+
+    const assignments = await this.db.reviewAssignment.findMany({
+      where: { cycleId, evaluatorId, status: 'ACTIVE' },
+      select: { targetUserId: true },
+    })
+
+    const totalAssignments = assignments.length
+
+    const submittedResponses = await this.db.evaluationResponse.findMany({
+      where: {
+        cycleId,
+        evaluatorId,
+        isDraft: false,
+        targetUserId: { in: assignments.map((a) => a.targetUserId) },
+      },
+      select: { targetUserId: true },
+    })
+
+    const submittedCount = submittedResponses.length
+
+    return {
+      evaluatorId,
+      totalAssignments,
+      submittedCount,
+      pendingCount: totalAssignments - submittedCount,
+    }
+  }
+
+  async scanAndSendReminders(now: Date): Promise<ReminderScanResult> {
+    const deadlineThreshold = new Date(now)
+    deadlineThreshold.setDate(deadlineThreshold.getDate() + REMINDER_DAYS_BEFORE)
+
+    const activeCycles = await this.db.reviewCycle.findMany({
+      where: {
+        status: 'ACTIVE',
+        endDate: { gte: now, lte: deadlineThreshold },
+      },
+      select: { id: true, name: true },
+    })
+
+    let notified = 0
+    let skipped = 0
+
+    for (const cycle of activeCycles) {
+      const assignments = await this.db.reviewAssignment.findMany({
+        where: { cycleId: cycle.id, status: 'ACTIVE' },
+        select: { evaluatorId: true, targetUserId: true },
+      })
+
+      const submitted = await this.db.evaluationResponse.findMany({
+        where: { cycleId: cycle.id, isDraft: false },
+        select: { evaluatorId: true, targetUserId: true },
+      })
+
+      const submittedSet = new Set(submitted.map((r) => `${r.evaluatorId}::${r.targetUserId}`))
+
+      const pendingEvaluatorIds = new Set<string>()
+      for (const a of assignments) {
+        if (!submittedSet.has(`${a.evaluatorId}::${a.targetUserId}`)) {
+          pendingEvaluatorIds.add(a.evaluatorId)
+        }
+      }
+
+      for (const evaluatorId of pendingEvaluatorIds) {
+        if (!this.notificationEmitter) {
+          skipped++
+          continue
+        }
+        try {
+          await this.notificationEmitter.emit({
+            userId: evaluatorId,
+            category: 'EVAL_REMINDER',
+            title: '評価の締め切りが近づいています',
+            body: `「${cycle.name}」の評価締め切りまであと${REMINDER_DAYS_BEFORE}日です。未提出の評価を完了してください。`,
+            payload: { cycleId: cycle.id },
+          })
+          notified++
+        } catch {
+          skipped++
+        }
+      }
+    }
+
+    return { notified, skipped }
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Factory
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function createEvaluationProgressService(
+  db: PrismaClient,
+  notificationEmitter: NotificationEmitter | null = null,
+): EvaluationProgressService {
+  return new EvaluationProgressServiceImpl(db, notificationEmitter)
+}

--- a/src/lib/evaluation/evaluation-progress-types.ts
+++ b/src/lib/evaluation/evaluation-progress-types.ts
@@ -1,0 +1,49 @@
+/**
+ * Issue #55 / Task 15.6: 進捗表示とリマインダー 型定義
+ * (Req 8.8, 8.9)
+ */
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Domain types
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** 評価者個人の進捗 */
+export interface EvaluatorProgressRecord {
+  evaluatorId: string
+  /** ACTIVE な割り当て総数 */
+  totalAssignments: number
+  /** 送信済み（isDraft: false）の評価数 */
+  submittedCount: number
+  /** 未送信（割り当てはあるが送信済みでない）の評価対象者数 */
+  pendingCount: number
+}
+
+/** サイクル全体の進捗（HR向け） */
+export interface CycleProgressRecord {
+  cycleId: string
+  /** 評価者総数 */
+  totalEvaluators: number
+  /** 全割り当て提出済みの評価者数 */
+  fullySubmittedCount: number
+  /** 評価者ごとの進捗一覧 */
+  evaluators: EvaluatorProgressRecord[]
+}
+
+/** リマインダースキャン結果 */
+export interface ReminderScanResult {
+  /** 通知送信数 */
+  notified: number
+  /** スキップ数（既に提出済み等） */
+  skipped: number
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Domain errors
+// ─────────────────────────────────────────────────────────────────────────────
+
+export class EvaluationProgressCycleNotFoundError extends Error {
+  constructor(cycleId: string) {
+    super(`ReviewCycle not found: ${cycleId}`)
+    this.name = 'EvaluationProgressCycleNotFoundError'
+  }
+}

--- a/src/tests/evaluation/evaluation-progress-service.test.ts
+++ b/src/tests/evaluation/evaluation-progress-service.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Issue #55 / Task 15.6: EvaluationProgressService 単体テスト
+ * (Req 8.8, 8.9)
+ *
+ * テスト対象:
+ * - getCycleProgress: HR向け全体進捗の集計
+ * - getEvaluatorProgress: 個人進捗の取得
+ * - scanAndSendReminders: 締切3日前の未提出者への通知
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { createEvaluationProgressService } from '@/lib/evaluation/evaluation-progress-service'
+import { EvaluationProgressCycleNotFoundError } from '@/lib/evaluation/evaluation-progress-types'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+function makePrisma(opts: {
+  cycle?: { id: string } | null
+  assignments?: { evaluatorId: string; targetUserId: string }[]
+  submitted?: { evaluatorId: string; targetUserId: string }[]
+  activeCycles?: { id: string; name: string }[]
+}) {
+  const { cycle = { id: 'cycle-1' }, assignments = [], submitted = [], activeCycles = [] } = opts
+
+  return {
+    reviewCycle: {
+      findUnique: vi.fn().mockResolvedValue(cycle),
+      findMany: vi.fn().mockResolvedValue(activeCycles),
+    },
+    reviewAssignment: {
+      findMany: vi.fn().mockResolvedValue(assignments),
+    },
+    evaluationResponse: {
+      findMany: vi.fn().mockResolvedValue(submitted),
+    },
+  }
+}
+
+function makeEmitter() {
+  return { emit: vi.fn().mockResolvedValue(undefined) }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// getCycleProgress
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('EvaluationProgressService.getCycleProgress', () => {
+  it('サイクルが存在しない場合に EvaluationProgressCycleNotFoundError をスローする', async () => {
+    const db = makePrisma({ cycle: null })
+    const svc = createEvaluationProgressService(db as never)
+    await expect(svc.getCycleProgress('no-such')).rejects.toBeInstanceOf(
+      EvaluationProgressCycleNotFoundError,
+    )
+  })
+
+  it('割り当てが0件の場合は evaluators が空配列を返す', async () => {
+    const db = makePrisma({ assignments: [], submitted: [] })
+    const svc = createEvaluationProgressService(db as never)
+    const result = await svc.getCycleProgress('cycle-1')
+    expect(result).toEqual({
+      cycleId: 'cycle-1',
+      totalEvaluators: 0,
+      fullySubmittedCount: 0,
+      evaluators: [],
+    })
+  })
+
+  it('全員提出済みの場合 fullySubmittedCount が totalEvaluators と一致する', async () => {
+    const db = makePrisma({
+      assignments: [
+        { evaluatorId: 'u1', targetUserId: 't1' },
+        { evaluatorId: 'u2', targetUserId: 't2' },
+      ],
+      submitted: [
+        { evaluatorId: 'u1', targetUserId: 't1' },
+        { evaluatorId: 'u2', targetUserId: 't2' },
+      ],
+    })
+    const svc = createEvaluationProgressService(db as never)
+    const result = await svc.getCycleProgress('cycle-1')
+    expect(result.totalEvaluators).toBe(2)
+    expect(result.fullySubmittedCount).toBe(2)
+    expect(result.evaluators.every((e) => e.pendingCount === 0)).toBe(true)
+  })
+
+  it('一部未提出の場合に pendingCount が正しく計算される', async () => {
+    const db = makePrisma({
+      assignments: [
+        { evaluatorId: 'u1', targetUserId: 't1' },
+        { evaluatorId: 'u1', targetUserId: 't2' },
+      ],
+      submitted: [{ evaluatorId: 'u1', targetUserId: 't1' }],
+    })
+    const svc = createEvaluationProgressService(db as never)
+    const result = await svc.getCycleProgress('cycle-1')
+    expect(result.totalEvaluators).toBe(1)
+    expect(result.fullySubmittedCount).toBe(0)
+    const u1 = result.evaluators.find((e) => e.evaluatorId === 'u1')
+    expect(u1?.submittedCount).toBe(1)
+    expect(u1?.pendingCount).toBe(1)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// getEvaluatorProgress
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('EvaluationProgressService.getEvaluatorProgress', () => {
+  it('サイクルが存在しない場合に EvaluationProgressCycleNotFoundError をスローする', async () => {
+    const db = makePrisma({ cycle: null })
+    const svc = createEvaluationProgressService(db as never)
+    await expect(svc.getEvaluatorProgress('no-such', 'u1')).rejects.toBeInstanceOf(
+      EvaluationProgressCycleNotFoundError,
+    )
+  })
+
+  it('割り当てが0件の場合は全カウントが0', async () => {
+    const db = makePrisma({ assignments: [], submitted: [] })
+    const svc = createEvaluationProgressService(db as never)
+    const result = await svc.getEvaluatorProgress('cycle-1', 'u1')
+    expect(result).toEqual({
+      evaluatorId: 'u1',
+      totalAssignments: 0,
+      submittedCount: 0,
+      pendingCount: 0,
+    })
+  })
+
+  it('提出済みと未提出を正しくカウントする', async () => {
+    const db = makePrisma({
+      assignments: [{ targetUserId: 't1' }, { targetUserId: 't2' }] as never,
+      submitted: [{ evaluatorId: 'u1', targetUserId: 't1' }],
+    })
+    const svc = createEvaluationProgressService(db as never)
+    const result = await svc.getEvaluatorProgress('cycle-1', 'u1')
+    expect(result.totalAssignments).toBe(2)
+    expect(result.submittedCount).toBe(1)
+    expect(result.pendingCount).toBe(1)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// scanAndSendReminders
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('EvaluationProgressService.scanAndSendReminders', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('対象サイクルがない場合は notified=0, skipped=0 を返す', async () => {
+    const db = makePrisma({ activeCycles: [] })
+    const svc = createEvaluationProgressService(db as never)
+    const result = await svc.scanAndSendReminders(new Date('2026-04-20T00:00:00Z'))
+    expect(result).toEqual({ notified: 0, skipped: 0 })
+  })
+
+  it('未提出の評価者に通知を送り notified をカウントする', async () => {
+    const emitter = makeEmitter()
+    const db = {
+      reviewCycle: {
+        findUnique: vi.fn().mockResolvedValue({ id: 'cycle-1' }),
+        findMany: vi.fn().mockResolvedValue([{ id: 'cycle-1', name: 'テストサイクル' }]),
+      },
+      reviewAssignment: {
+        findMany: vi.fn().mockResolvedValue([
+          { evaluatorId: 'u1', targetUserId: 't1' },
+          { evaluatorId: 'u2', targetUserId: 't2' },
+        ]),
+      },
+      evaluationResponse: {
+        findMany: vi.fn().mockResolvedValue([{ evaluatorId: 'u1', targetUserId: 't1' }]),
+      },
+    }
+    const svc = createEvaluationProgressService(db as never, emitter as never)
+    const result = await svc.scanAndSendReminders(new Date('2026-04-20T00:00:00Z'))
+    expect(result.notified).toBe(1)
+    expect(result.skipped).toBe(0)
+    expect(emitter.emit).toHaveBeenCalledTimes(1)
+    expect(emitter.emit).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: 'u2', category: 'EVAL_REMINDER' }),
+    )
+  })
+
+  it('notificationEmitter が null の場合は skipped をカウントする', async () => {
+    const db = {
+      reviewCycle: {
+        findUnique: vi.fn().mockResolvedValue({ id: 'cycle-1' }),
+        findMany: vi.fn().mockResolvedValue([{ id: 'cycle-1', name: 'テストサイクル' }]),
+      },
+      reviewAssignment: {
+        findMany: vi.fn().mockResolvedValue([{ evaluatorId: 'u1', targetUserId: 't1' }]),
+      },
+      evaluationResponse: {
+        findMany: vi.fn().mockResolvedValue([]),
+      },
+    }
+    const svc = createEvaluationProgressService(db as never, null)
+    const result = await svc.scanAndSendReminders(new Date('2026-04-20T00:00:00Z'))
+    expect(result.notified).toBe(0)
+    expect(result.skipped).toBe(1)
+  })
+
+  it('全員提出済みの場合は notified=0 を返す', async () => {
+    const emitter = makeEmitter()
+    const db = {
+      reviewCycle: {
+        findUnique: vi.fn().mockResolvedValue({ id: 'cycle-1' }),
+        findMany: vi.fn().mockResolvedValue([{ id: 'cycle-1', name: 'テストサイクル' }]),
+      },
+      reviewAssignment: {
+        findMany: vi.fn().mockResolvedValue([{ evaluatorId: 'u1', targetUserId: 't1' }]),
+      },
+      evaluationResponse: {
+        findMany: vi.fn().mockResolvedValue([{ evaluatorId: 'u1', targetUserId: 't1' }]),
+      },
+    }
+    const svc = createEvaluationProgressService(db as never, emitter as never)
+    const result = await svc.scanAndSendReminders(new Date('2026-04-20T00:00:00Z'))
+    expect(result.notified).toBe(0)
+    expect(result.skipped).toBe(0)
+    expect(emitter.emit).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## 概要

issue #55「進捗表示とリマインダー」を実装します。

## 実装内容

### 新規ファイル

| ファイル | 説明 |
|---|---|
| `src/lib/evaluation/evaluation-progress-types.ts` | 型定義（EvaluatorProgressRecord, CycleProgressRecord, ReminderScanResult） |
| `src/lib/evaluation/evaluation-progress-service.ts` | サービス実装（getCycleProgress / getEvaluatorProgress / scanAndSendReminders） |
| `src/lib/evaluation/evaluation-progress-service-di.ts` | DIコンテナ |
| `src/app/api/evaluation/cycles/[id]/progress/route.ts` | GET /api/evaluation/cycles/[id]/progress（HR_MANAGER/ADMIN向け全体進捗） |
| `src/app/api/evaluation/cycles/[id]/progress/me/route.ts` | GET /api/evaluation/cycles/[id]/progress/me（個人進捗） |
| `src/app/api/evaluation/reminder/scan/route.ts` | POST /api/evaluation/reminder/scan（ADMINのみ、リマインダースキャン） |
| `src/tests/evaluation/evaluation-progress-service.test.ts` | 単体テスト 11件 |

### 要件対応

- **Req 8.8**: `While 評価期間中` — `getCycleProgress` / `getEvaluatorProgress` で評価した人数と未提出数をリアルタイム取得
- **Req 8.9**: `If 評価締め切り3日前` — `scanAndSendReminders` で未送信の評価者に `EVAL_REMINDER` 通知を自動送信

## テスト計画

- [x] `pnpm test -- src/tests/evaluation/evaluation-progress-service.test.ts` — 11テスト全パス
- [x] TypeScript型チェック — 実装ファイルにエラーなし
- [ ] `GET /api/evaluation/cycles/[id]/progress` に HR_MANAGER でアクセスし進捗が返ることを確認
- [ ] `GET /api/evaluation/cycles/[id]/progress/me` に一般ユーザーでアクセスし自分の進捗が返ることを確認
- [ ] `POST /api/evaluation/reminder/scan` に ADMIN でアクセスし `{ notified, skipped }` が返ることを確認
- [ ] ADMIN 以外で reminder/scan を叩き 403 が返ることを確認
- [ ] HR_MANAGER 以外で cycles/[id]/progress を叩き 403 が返ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)