### PR TITLE
feat: [#56] サイクル途中の入退社扱いと集計の実装

### DIFF
--- a/src/app/api/evaluation/cycles/[id]/invalidate-resigned/route.ts
+++ b/src/app/api/evaluation/cycles/[id]/invalidate-resigned/route.ts
@@ -1,0 +1,43 @@
+/**
+ * Issue #56 / Task 15.7: 退職者評価依頼無効化 API (Req 8.19)
+ *
+ * - POST /api/evaluation/cycles/[id]/invalidate-resigned — HR_MANAGER/ADMIN のみ
+ *   退職日が設定された被評価者の ACTIVE な割り当てを無効化（DECLINED）する
+ */
+import { type NextRequest, NextResponse } from 'next/server'
+import { requireAuthenticated } from '@/lib/skill/skill-route-helpers'
+import { getCycleAggregationService } from '@/lib/evaluation/cycle-aggregation-service-di'
+import { CycleAggregationNotFoundError } from '@/lib/evaluation/cycle-aggregation-types'
+
+const HR_OR_ADMIN_ROLES = ['HR_MANAGER', 'ADMIN'] as const
+
+export async function POST(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const guard = await requireAuthenticated()
+  if (!guard.ok) return guard.response
+
+  if (!HR_OR_ADMIN_ROLES.includes(guard.session.role as (typeof HR_OR_ADMIN_ROLES)[number])) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const { id } = await params
+
+  let svc: ReturnType<typeof getCycleAggregationService>
+  try {
+    svc = getCycleAggregationService()
+  } catch {
+    return NextResponse.json({ error: 'CycleAggregation service not initialized' }, { status: 503 })
+  }
+
+  try {
+    const result = await svc.invalidateResignedAssignments(id)
+    return NextResponse.json({ success: true, data: result })
+  } catch (err) {
+    if (err instanceof CycleAggregationNotFoundError) {
+      return NextResponse.json({ error: 'ReviewCycle not found' }, { status: 404 })
+    }
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/api/evaluation/cycles/[id]/run-aggregation/route.ts
+++ b/src/app/api/evaluation/cycles/[id]/run-aggregation/route.ts
@@ -1,0 +1,54 @@
+/**
+ * Issue #56 / Task 15.7: 評価サイクル集計実行 API (Req 8.13, 8.14, 8.15)
+ *
+ * - POST /api/evaluation/cycles/[id]/run-aggregation — HR_MANAGER/ADMIN のみ
+ *   AGGREGATING 状態のサイクルの全回答を集計してスコアと匿名コメントを返す
+ */
+import { type NextRequest, NextResponse } from 'next/server'
+import { requireAuthenticated } from '@/lib/skill/skill-route-helpers'
+import { getCycleAggregationService } from '@/lib/evaluation/cycle-aggregation-service-di'
+import {
+  CycleAggregationNotFoundError,
+  CycleAggregationInvalidStatusError,
+} from '@/lib/evaluation/cycle-aggregation-types'
+
+export {
+  setCycleAggregationServiceForTesting,
+  clearCycleAggregationServiceForTesting,
+} from '@/lib/evaluation/cycle-aggregation-service-di'
+
+const HR_OR_ADMIN_ROLES = ['HR_MANAGER', 'ADMIN'] as const
+
+export async function POST(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<NextResponse> {
+  const guard = await requireAuthenticated()
+  if (!guard.ok) return guard.response
+
+  if (!HR_OR_ADMIN_ROLES.includes(guard.session.role as (typeof HR_OR_ADMIN_ROLES)[number])) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const { id } = await params
+
+  let svc: ReturnType<typeof getCycleAggregationService>
+  try {
+    svc = getCycleAggregationService()
+  } catch {
+    return NextResponse.json({ error: 'CycleAggregation service not initialized' }, { status: 503 })
+  }
+
+  try {
+    const result = await svc.aggregateCycle(id)
+    return NextResponse.json({ success: true, data: result })
+  } catch (err) {
+    if (err instanceof CycleAggregationNotFoundError) {
+      return NextResponse.json({ error: 'ReviewCycle not found' }, { status: 404 })
+    }
+    if (err instanceof CycleAggregationInvalidStatusError) {
+      return NextResponse.json({ error: err.message }, { status: 409 })
+    }
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/lib/evaluation/cycle-aggregation-service-di.ts
+++ b/src/lib/evaluation/cycle-aggregation-service-di.ts
@@ -1,0 +1,26 @@
+/**
+ * Issue #56 / Task 15.7: CycleAggregationService DI コンテナ
+ */
+import type { CycleAggregationService } from './cycle-aggregation-service'
+
+let _service: CycleAggregationService | null = null
+
+export function setCycleAggregationServiceForTesting(svc: CycleAggregationService): void {
+  _service = svc
+}
+
+export function clearCycleAggregationServiceForTesting(): void {
+  _service = null
+}
+
+export function getCycleAggregationService(): CycleAggregationService {
+  if (_service) return _service
+  throw new Error(
+    'CycleAggregationService is not initialized. ' +
+      'テストでは setCycleAggregationServiceForTesting() を呼んでください。',
+  )
+}
+
+export function initCycleAggregationService(svc: CycleAggregationService): void {
+  _service = svc
+}

--- a/src/lib/evaluation/cycle-aggregation-service.ts
+++ b/src/lib/evaluation/cycle-aggregation-service.ts
@@ -1,0 +1,228 @@
+/**
+ * Issue #56 / Task 15.7: サイクル途中の入退社扱いと集計 サービス
+ * (Req 8.13, 8.14, 8.15, 8.18, 8.19)
+ *
+ * - aggregateCycle: 全回答を集計してスコアと匿名コメントを生成 (Req 8.13, 8.14, 8.15)
+ * - checkEligibility: 在籍期間50%未満の入社者を除外チェック (Req 8.18)
+ * - invalidateResignedAssignments: 退職日以降の評価依頼を無効化 (Req 8.19)
+ */
+import type { PrismaClient } from '@prisma/client'
+import {
+  CycleAggregationNotFoundError,
+  CycleAggregationInvalidStatusError,
+  type AggregatedUserResult,
+  type CycleAggregationResult,
+  type EligibilityCheckResult,
+  type InvalidateResignedResult,
+} from './cycle-aggregation-types'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Constants
+// ─────────────────────────────────────────────────────────────────────────────
+
+const MIN_TENURE_RATIO = 0.5
+
+const AGGREGATABLE_STATUSES = ['AGGREGATING', 'PENDING_FEEDBACK_APPROVAL', 'FINALIZED'] as const
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Service interface
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface CycleAggregationService {
+  /**
+   * 全回答を集計してスコアと匿名コメントを生成 (Req 8.13, 8.14, 8.15)
+   * - peerScore = Σpeer_scores / peer_evaluator_count
+   * - peerEvaluatorCount < minReviewers → minimumNotMet = true
+   */
+  aggregateCycle(cycleId: string): Promise<CycleAggregationResult>
+
+  /**
+   * 在籍期間チェック (Req 8.18)
+   * hireDate が設定されており在籍期間がサイクル期間の50%未満の場合は除外対象
+   */
+  checkEligibility(cycleId: string, userIds: string[]): Promise<EligibilityCheckResult[]>
+
+  /**
+   * 退職日以降の評価依頼を無効化 (Req 8.19)
+   * resignDate が設定されている target の ACTIVE な割り当てを DECLINED に変更
+   */
+  invalidateResignedAssignments(cycleId: string): Promise<InvalidateResignedResult>
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Implementation
+// ─────────────────────────────────────────────────────────────────────────────
+
+class CycleAggregationServiceImpl implements CycleAggregationService {
+  constructor(private readonly db: PrismaClient) {}
+
+  async aggregateCycle(cycleId: string): Promise<CycleAggregationResult> {
+    const cycle = await this.db.reviewCycle.findUnique({
+      where: { id: cycleId },
+      select: { id: true, status: true, minReviewers: true },
+    })
+    if (!cycle) throw new CycleAggregationNotFoundError(cycleId)
+
+    if (!AGGREGATABLE_STATUSES.includes(cycle.status as (typeof AGGREGATABLE_STATUSES)[number])) {
+      throw new CycleAggregationInvalidStatusError(cycle.status)
+    }
+
+    const responses = await this.db.evaluationResponse.findMany({
+      where: { cycleId, isDraft: false },
+      select: {
+        targetUserId: true,
+        responseType: true,
+        score: true,
+        comment: true,
+      },
+    })
+
+    const targetMap = new Map<
+      string,
+      {
+        peerScores: number[]
+        selfScore: number | null
+        topDownScore: number | null
+        comments: string[]
+      }
+    >()
+
+    for (const r of responses) {
+      if (!targetMap.has(r.targetUserId)) {
+        targetMap.set(r.targetUserId, {
+          peerScores: [],
+          selfScore: null,
+          topDownScore: null,
+          comments: [],
+        })
+      }
+      const entry = targetMap.get(r.targetUserId)!
+
+      if (r.comment && r.responseType !== 'SELF') {
+        entry.comments.push(r.comment)
+      }
+
+      if (r.responseType === 'PEER') {
+        entry.peerScores.push(r.score)
+      } else if (r.responseType === 'SELF') {
+        entry.selfScore = r.score
+      } else if (r.responseType === 'TOP_DOWN') {
+        entry.topDownScore = r.score
+      }
+    }
+
+    const results: AggregatedUserResult[] = Array.from(targetMap.entries()).map(
+      ([targetUserId, { peerScores, selfScore, topDownScore, comments }]) => {
+        const peerEvaluatorCount = peerScores.length
+        const peerScore =
+          peerEvaluatorCount > 0
+            ? peerScores.reduce((sum, s) => sum + s, 0) / peerEvaluatorCount
+            : null
+
+        return {
+          targetUserId,
+          peerScore,
+          peerEvaluatorCount,
+          selfScore,
+          topDownScore,
+          minimumNotMet: peerEvaluatorCount < cycle.minReviewers,
+          anonymousComments: comments,
+        }
+      },
+    )
+
+    return {
+      cycleId,
+      totalTargets: results.length,
+      minimumNotMetCount: results.filter((r) => r.minimumNotMet).length,
+      results,
+    }
+  }
+
+  async checkEligibility(cycleId: string, userIds: string[]): Promise<EligibilityCheckResult[]> {
+    const cycle = await this.db.reviewCycle.findUnique({
+      where: { id: cycleId },
+      select: { startDate: true, endDate: true },
+    })
+    if (!cycle) throw new CycleAggregationNotFoundError(cycleId)
+
+    const cycleDurationMs = cycle.endDate.getTime() - cycle.startDate.getTime()
+    if (cycleDurationMs <= 0) {
+      return userIds.map((userId) => ({ userId, eligible: true, tenureRatio: null }))
+    }
+
+    const users = await this.db.user.findMany({
+      where: { id: { in: userIds } },
+      select: { id: true, hireDate: true },
+    })
+
+    const userMap = new Map(users.map((u) => [u.id, u]))
+
+    return userIds.map((userId) => {
+      const user = userMap.get(userId)
+      if (!user?.hireDate) {
+        return { userId, eligible: true, tenureRatio: null }
+      }
+
+      const hireDateMs = user.hireDate.getTime()
+      const cycleStartMs = cycle.startDate.getTime()
+      const cycleEndMs = cycle.endDate.getTime()
+
+      if (hireDateMs <= cycleStartMs) {
+        return { userId, eligible: true, tenureRatio: 1 }
+      }
+      if (hireDateMs >= cycleEndMs) {
+        return { userId, eligible: false, tenureRatio: 0 }
+      }
+
+      const tenureRatio = (cycleEndMs - hireDateMs) / cycleDurationMs
+      return { userId, eligible: tenureRatio >= MIN_TENURE_RATIO, tenureRatio }
+    })
+  }
+
+  async invalidateResignedAssignments(cycleId: string): Promise<InvalidateResignedResult> {
+    const cycle = await this.db.reviewCycle.findUnique({
+      where: { id: cycleId },
+      select: { id: true },
+    })
+    if (!cycle) throw new CycleAggregationNotFoundError(cycleId)
+
+    const assignments = await this.db.reviewAssignment.findMany({
+      where: {
+        cycleId,
+        status: 'ACTIVE',
+        target: { resignDate: { not: null } },
+      },
+      select: { id: true },
+    })
+
+    if (assignments.length === 0) return { invalidated: 0 }
+
+    await this.db.$transaction(
+      assignments.map(({ id }) =>
+        this.db.reviewAssignment.update({
+          where: { id },
+          data: {
+            status: 'DECLINED',
+            decline: {
+              create: {
+                reason: '退職による自動無効化',
+                replacementEvaluatorId: null,
+              },
+            },
+          },
+        }),
+      ),
+    )
+
+    return { invalidated: assignments.length }
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Factory
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function createCycleAggregationService(db: PrismaClient): CycleAggregationService {
+  return new CycleAggregationServiceImpl(db)
+}

--- a/src/lib/evaluation/cycle-aggregation-types.ts
+++ b/src/lib/evaluation/cycle-aggregation-types.ts
@@ -1,0 +1,72 @@
+/**
+ * Issue #56 / Task 15.7: サイクル途中の入退社扱いと集計 型定義
+ * (Req 8.13, 8.14, 8.15, 8.18, 8.19)
+ */
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Domain types
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** 被評価者ごとの集計結果 (Req 8.13, 8.14) */
+export interface AggregatedUserResult {
+  targetUserId: string
+  /** 他者評価スコア合計 / 他者評価者数 (Req 8.13) */
+  peerScore: number | null
+  /** 有効なピア評価者数 */
+  peerEvaluatorCount: number
+  /** 自己評価スコア */
+  selfScore: number | null
+  /** 上司評価スコア */
+  topDownScore: number | null
+  /**
+   * 評価者数が最低評価者数を下回る場合 true → 公開保留 (Req 8.14)
+   * peerEvaluatorCount < cycle.minReviewers のとき true
+   */
+  minimumNotMet: boolean
+  /** 匿名コメント群（送信済みのみ） */
+  anonymousComments: string[]
+}
+
+/** サイクル全体の集計結果 (Req 8.15) */
+export interface CycleAggregationResult {
+  cycleId: string
+  /** 集計対象の被評価者数 */
+  totalTargets: number
+  /** MinimumNotMet フラグが立った被評価者数 */
+  minimumNotMetCount: number
+  /** 被評価者ごとの集計結果 */
+  results: AggregatedUserResult[]
+}
+
+/** 退職者割り当て無効化結果 (Req 8.19) */
+export interface InvalidateResignedResult {
+  /** 無効化した割り当て数 */
+  invalidated: number
+}
+
+/** 在籍期間チェック結果 (Req 8.18) */
+export interface EligibilityCheckResult {
+  userId: string
+  /** 在籍期間が評価対象期間の50%以上 → 被評価者として有効 */
+  eligible: boolean
+  /** 在籍割合（0〜1）。hireDate が null の場合は null */
+  tenureRatio: number | null
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Domain errors
+// ─────────────────────────────────────────────────────────────────────────────
+
+export class CycleAggregationNotFoundError extends Error {
+  constructor(cycleId: string) {
+    super(`ReviewCycle not found: ${cycleId}`)
+    this.name = 'CycleAggregationNotFoundError'
+  }
+}
+
+export class CycleAggregationInvalidStatusError extends Error {
+  constructor(status: string) {
+    super(`Cannot aggregate cycle in status: ${status}`)
+    this.name = 'CycleAggregationInvalidStatusError'
+  }
+}

--- a/src/tests/evaluation/cycle-aggregation-service.test.ts
+++ b/src/tests/evaluation/cycle-aggregation-service.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Issue #56 / Task 15.7: CycleAggregationService 単体テスト
+ * (Req 8.13, 8.14, 8.15, 8.18, 8.19)
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { createCycleAggregationService } from '@/lib/evaluation/cycle-aggregation-service'
+import {
+  CycleAggregationNotFoundError,
+  CycleAggregationInvalidStatusError,
+} from '@/lib/evaluation/cycle-aggregation-types'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+const BASE_CYCLE = {
+  id: 'cycle-1',
+  status: 'AGGREGATING',
+  minReviewers: 3,
+  startDate: new Date('2026-01-01T00:00:00Z'),
+  endDate: new Date('2026-03-31T00:00:00Z'),
+}
+
+function makePrisma(opts: {
+  cycle?: object | null
+  responses?: object[]
+  assignments?: object[]
+  users?: object[]
+  transactionFn?: () => Promise<object[]>
+}) {
+  const {
+    cycle = BASE_CYCLE,
+    responses = [],
+    assignments = [],
+    users = [],
+    transactionFn = async () => [],
+  } = opts
+
+  return {
+    reviewCycle: { findUnique: vi.fn().mockResolvedValue(cycle) },
+    evaluationResponse: { findMany: vi.fn().mockResolvedValue(responses) },
+    reviewAssignment: { findMany: vi.fn().mockResolvedValue(assignments) },
+    user: { findMany: vi.fn().mockResolvedValue(users) },
+    $transaction: vi.fn().mockImplementation(transactionFn),
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// aggregateCycle (Req 8.13, 8.14, 8.15)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('CycleAggregationService.aggregateCycle', () => {
+  it('サイクルが存在しない場合 CycleAggregationNotFoundError をスローする', async () => {
+    const db = makePrisma({ cycle: null })
+    const svc = createCycleAggregationService(db as never)
+    await expect(svc.aggregateCycle('no-such')).rejects.toBeInstanceOf(
+      CycleAggregationNotFoundError,
+    )
+  })
+
+  it('DRAFT ステータスでは CycleAggregationInvalidStatusError をスローする', async () => {
+    const db = makePrisma({ cycle: { ...BASE_CYCLE, status: 'DRAFT' } })
+    const svc = createCycleAggregationService(db as never)
+    await expect(svc.aggregateCycle('cycle-1')).rejects.toBeInstanceOf(
+      CycleAggregationInvalidStatusError,
+    )
+  })
+
+  it('回答が0件の場合は空の results を返す', async () => {
+    const db = makePrisma({ responses: [] })
+    const svc = createCycleAggregationService(db as never)
+    const result = await svc.aggregateCycle('cycle-1')
+    expect(result.totalTargets).toBe(0)
+    expect(result.results).toEqual([])
+  })
+
+  it('peerScore = Σpeer_scores / peer_count で計算される (Req 8.13)', async () => {
+    const db = makePrisma({
+      responses: [
+        { targetUserId: 't1', responseType: 'PEER', score: 80, comment: null },
+        { targetUserId: 't1', responseType: 'PEER', score: 60, comment: null },
+        { targetUserId: 't1', responseType: 'PEER', score: 70, comment: null },
+      ],
+    })
+    const svc = createCycleAggregationService(db as never)
+    const result = await svc.aggregateCycle('cycle-1')
+    const t1 = result.results.find((r) => r.targetUserId === 't1')
+    expect(t1?.peerScore).toBeCloseTo((80 + 60 + 70) / 3)
+    expect(t1?.peerEvaluatorCount).toBe(3)
+  })
+
+  it('peerEvaluatorCount < minReviewers のとき minimumNotMet = true (Req 8.14)', async () => {
+    const db = makePrisma({
+      responses: [
+        { targetUserId: 't1', responseType: 'PEER', score: 80, comment: null },
+        { targetUserId: 't1', responseType: 'PEER', score: 70, comment: null },
+      ],
+    })
+    const svc = createCycleAggregationService(db as never)
+    const result = await svc.aggregateCycle('cycle-1')
+    const t1 = result.results.find((r) => r.targetUserId === 't1')
+    expect(t1?.minimumNotMet).toBe(true)
+    expect(result.minimumNotMetCount).toBe(1)
+  })
+
+  it('peerEvaluatorCount >= minReviewers のとき minimumNotMet = false', async () => {
+    const db = makePrisma({
+      responses: [
+        { targetUserId: 't1', responseType: 'PEER', score: 80, comment: null },
+        { targetUserId: 't1', responseType: 'PEER', score: 70, comment: null },
+        { targetUserId: 't1', responseType: 'PEER', score: 90, comment: null },
+      ],
+    })
+    const svc = createCycleAggregationService(db as never)
+    const result = await svc.aggregateCycle('cycle-1')
+    const t1 = result.results.find((r) => r.targetUserId === 't1')
+    expect(t1?.minimumNotMet).toBe(false)
+  })
+
+  it('自己評価・上司評価スコアと匿名コメントを正しく集計する (Req 8.15)', async () => {
+    const db = makePrisma({
+      responses: [
+        { targetUserId: 't1', responseType: 'SELF', score: 80, comment: '自己コメント' },
+        { targetUserId: 't1', responseType: 'TOP_DOWN', score: 75, comment: 'good' },
+        { targetUserId: 't1', responseType: 'PEER', score: 85, comment: 'great' },
+        { targetUserId: 't1', responseType: 'PEER', score: 90, comment: null },
+        { targetUserId: 't1', responseType: 'PEER', score: 70, comment: 'ok' },
+      ],
+    })
+    const svc = createCycleAggregationService(db as never)
+    const result = await svc.aggregateCycle('cycle-1')
+    const t1 = result.results.find((r) => r.targetUserId === 't1')
+    expect(t1?.selfScore).toBe(80)
+    expect(t1?.topDownScore).toBe(75)
+    expect(t1?.anonymousComments).toContain('good')
+    expect(t1?.anonymousComments).toContain('great')
+    expect(t1?.anonymousComments).toContain('ok')
+    expect(t1?.anonymousComments).not.toContain('自己コメント')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// checkEligibility (Req 8.18)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('CycleAggregationService.checkEligibility', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('サイクルが存在しない場合 CycleAggregationNotFoundError をスローする', async () => {
+    const db = makePrisma({ cycle: null })
+    const svc = createCycleAggregationService(db as never)
+    await expect(svc.checkEligibility('no-such', ['u1'])).rejects.toBeInstanceOf(
+      CycleAggregationNotFoundError,
+    )
+  })
+
+  it('hireDate が null のユーザーは eligible=true', async () => {
+    const db = makePrisma({ users: [{ id: 'u1', hireDate: null }] })
+    const svc = createCycleAggregationService(db as never)
+    const result = await svc.checkEligibility('cycle-1', ['u1'])
+    expect(result[0].eligible).toBe(true)
+    expect(result[0].tenureRatio).toBeNull()
+  })
+
+  it('サイクル開始前に入社したユーザーは eligible=true (tenureRatio=1)', async () => {
+    const db = makePrisma({ users: [{ id: 'u1', hireDate: new Date('2025-12-01') }] })
+    const svc = createCycleAggregationService(db as never)
+    const result = await svc.checkEligibility('cycle-1', ['u1'])
+    expect(result[0].eligible).toBe(true)
+    expect(result[0].tenureRatio).toBe(1)
+  })
+
+  it('在籍期間50%以上のユーザーは eligible=true (Req 8.18)', async () => {
+    // cycle: 2026-01-01〜2026-03-31 (89日)、hireDate: 2026-02-14 → 残り45日/89日≈0.506
+    const db = makePrisma({ users: [{ id: 'u1', hireDate: new Date('2026-02-14') }] })
+    const svc = createCycleAggregationService(db as never)
+    const result = await svc.checkEligibility('cycle-1', ['u1'])
+    expect(result[0].eligible).toBe(true)
+    expect(result[0].tenureRatio).toBeGreaterThanOrEqual(0.5)
+  })
+
+  it('在籍期間50%未満のユーザーは eligible=false (Req 8.18)', async () => {
+    // hireDate: 2026-03-01 → 残り30日/89日≈0.337
+    const db = makePrisma({ users: [{ id: 'u1', hireDate: new Date('2026-03-01') }] })
+    const svc = createCycleAggregationService(db as never)
+    const result = await svc.checkEligibility('cycle-1', ['u1'])
+    expect(result[0].eligible).toBe(false)
+    expect(result[0].tenureRatio).toBeLessThan(0.5)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// invalidateResignedAssignments (Req 8.19)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('CycleAggregationService.invalidateResignedAssignments', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('サイクルが存在しない場合 CycleAggregationNotFoundError をスローする', async () => {
+    const db = makePrisma({ cycle: null })
+    const svc = createCycleAggregationService(db as never)
+    await expect(svc.invalidateResignedAssignments('no-such')).rejects.toBeInstanceOf(
+      CycleAggregationNotFoundError,
+    )
+  })
+
+  it('退職者の割り当てがない場合は invalidated=0 を返す', async () => {
+    const db = makePrisma({ assignments: [] })
+    const svc = createCycleAggregationService(db as never)
+    const result = await svc.invalidateResignedAssignments('cycle-1')
+    expect(result).toEqual({ invalidated: 0 })
+  })
+
+  it('退職者の ACTIVE な割り当てを無効化して件数を返す (Req 8.19)', async () => {
+    const updated = { id: 'a1', status: 'DECLINED' }
+    const db = {
+      reviewCycle: { findUnique: vi.fn().mockResolvedValue(BASE_CYCLE) },
+      reviewAssignment: {
+        findMany: vi.fn().mockResolvedValue([{ id: 'a1' }, { id: 'a2' }]),
+        update: vi.fn().mockResolvedValue(updated),
+      },
+      evaluationResponse: { findMany: vi.fn() },
+      user: { findMany: vi.fn() },
+      $transaction: vi.fn().mockResolvedValue([updated, updated]),
+    }
+    const svc = createCycleAggregationService(db as never)
+    const result = await svc.invalidateResignedAssignments('cycle-1')
+    expect(result.invalidated).toBe(2)
+    expect(db.$transaction).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## 概要

issue #56「サイクル途中の入退社扱いと集計」を実装します。

## 実装内容

### 新規ファイル

| ファイル | 説明 |
|---|---|
| `src/lib/evaluation/cycle-aggregation-types.ts` | 型定義（AggregatedUserResult, CycleAggregationResult, EligibilityCheckResult, InvalidateResignedResult） |
| `src/lib/evaluation/cycle-aggregation-service.ts` | サービス実装（aggregateCycle / checkEligibility / invalidateResignedAssignments） |
| `src/lib/evaluation/cycle-aggregation-service-di.ts` | DIコンテナ |
| `src/app/api/evaluation/cycles/[id]/run-aggregation/route.ts` | POST — 集計実行（HR_MANAGER/ADMIN） |
| `src/app/api/evaluation/cycles/[id]/invalidate-resigned/route.ts` | POST — 退職者割り当て無効化（HR_MANAGER/ADMIN） |
| `src/tests/evaluation/cycle-aggregation-service.test.ts` | 単体テスト 15件 |

### 要件対応

| 要件 | 実装 |
|---|---|
| **Req 8.13** 被評価点 = Σpeer_scores / peer_count | `aggregateCycle` で計算 |
| **Req 8.14** 評価者数 < minReviewers → MinimumNotMetFlag | `minimumNotMet: true` でフラグ付与、公開保留判定用 |
| **Req 8.15** 全回答集計・スコア生成・匿名コメント群 | `aggregateCycle` で一括集計（selfScore / topDownScore / peerScore / anonymousComments） |
| **Req 8.18** 在籍期間50%未満の入社者を除外 | `checkEligibility(cycleId, userIds)` — hireDate から tenureRatio を算出 |
| **Req 8.19** 退職日以降の評価依頼を無効化 | `invalidateResignedAssignments(cycleId)` — resignDate あり target の ACTIVE 割り当てを DECLINED に変更 |

## テスト計画

- [x] `pnpm test -- src/tests/evaluation/cycle-aggregation-service.test.ts` — 15テスト全パス
- [ ] `POST /api/evaluation/cycles/[id]/run-aggregation` に HR_MANAGER でアクセスし集計結果が返ることを確認
- [ ] DRAFT 状態のサイクルで run-aggregation を叩き 409 が返ることを確認
- [ ] `POST /api/evaluation/cycles/[id]/invalidate-resigned` に HR_MANAGER でアクセスし `{ invalidated: N }` が返ることを確認
- [ ] HR_MANAGER 以外で叩き 403 が返ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)