### PR TITLE
fix: stabilize evaluation route build checks

### DIFF
--- a/src/app/api/evaluation/cycles/[id]/progress/route.ts
+++ b/src/app/api/evaluation/cycles/[id]/progress/route.ts
@@ -8,11 +8,6 @@ import { requireAuthenticated } from '@/lib/skill/skill-route-helpers'
 import { getEvaluationProgressService } from '@/lib/evaluation/evaluation-progress-service-di'
 import { EvaluationProgressCycleNotFoundError } from '@/lib/evaluation/evaluation-progress-types'
 
-export {
-  setEvaluationProgressServiceForTesting,
-  clearEvaluationProgressServiceForTesting,
-} from '@/lib/evaluation/evaluation-progress-service-di'
-
 const HR_OR_ADMIN_ROLES = ['HR_MANAGER', 'ADMIN'] as const
 
 export async function GET(

--- a/src/app/api/evaluation/cycles/[id]/run-aggregation/route.ts
+++ b/src/app/api/evaluation/cycles/[id]/run-aggregation/route.ts
@@ -12,11 +12,6 @@ import {
   CycleAggregationInvalidStatusError,
 } from '@/lib/evaluation/cycle-aggregation-types'
 
-export {
-  setCycleAggregationServiceForTesting,
-  clearCycleAggregationServiceForTesting,
-} from '@/lib/evaluation/cycle-aggregation-service-di'
-
 const HR_OR_ADMIN_ROLES = ['HR_MANAGER', 'ADMIN'] as const
 
 export async function POST(

--- a/src/app/api/evaluation/reminder/scan/route.ts
+++ b/src/app/api/evaluation/reminder/scan/route.ts
@@ -8,11 +8,6 @@ import { type NextRequest, NextResponse } from 'next/server'
 import { requireAuthenticated } from '@/lib/skill/skill-route-helpers'
 import { getEvaluationProgressService } from '@/lib/evaluation/evaluation-progress-service-di'
 
-export {
-  setEvaluationProgressServiceForTesting,
-  clearEvaluationProgressServiceForTesting,
-} from '@/lib/evaluation/evaluation-progress-service-di'
-
 export async function POST(_request: NextRequest): Promise<NextResponse> {
   const guard = await requireAuthenticated()
   if (!guard.ok) return guard.response

--- a/src/tests/evaluation/cycle-aggregation-service.test.ts
+++ b/src/tests/evaluation/cycle-aggregation-service.test.ts
@@ -158,16 +158,20 @@ describe('CycleAggregationService.checkEligibility', () => {
     const db = makePrisma({ users: [{ id: 'u1', hireDate: null }] })
     const svc = createCycleAggregationService(db as never)
     const result = await svc.checkEligibility('cycle-1', ['u1'])
-    expect(result[0].eligible).toBe(true)
-    expect(result[0].tenureRatio).toBeNull()
+    expect(result).toHaveLength(1)
+    const first = result[0]!
+    expect(first.eligible).toBe(true)
+    expect(first.tenureRatio).toBeNull()
   })
 
   it('サイクル開始前に入社したユーザーは eligible=true (tenureRatio=1)', async () => {
     const db = makePrisma({ users: [{ id: 'u1', hireDate: new Date('2025-12-01') }] })
     const svc = createCycleAggregationService(db as never)
     const result = await svc.checkEligibility('cycle-1', ['u1'])
-    expect(result[0].eligible).toBe(true)
-    expect(result[0].tenureRatio).toBe(1)
+    expect(result).toHaveLength(1)
+    const first = result[0]!
+    expect(first.eligible).toBe(true)
+    expect(first.tenureRatio).toBe(1)
   })
 
   it('在籍期間50%以上のユーザーは eligible=true (Req 8.18)', async () => {
@@ -175,8 +179,10 @@ describe('CycleAggregationService.checkEligibility', () => {
     const db = makePrisma({ users: [{ id: 'u1', hireDate: new Date('2026-02-14') }] })
     const svc = createCycleAggregationService(db as never)
     const result = await svc.checkEligibility('cycle-1', ['u1'])
-    expect(result[0].eligible).toBe(true)
-    expect(result[0].tenureRatio).toBeGreaterThanOrEqual(0.5)
+    expect(result).toHaveLength(1)
+    const first = result[0]!
+    expect(first.eligible).toBe(true)
+    expect(first.tenureRatio).toBeGreaterThanOrEqual(0.5)
   })
 
   it('在籍期間50%未満のユーザーは eligible=false (Req 8.18)', async () => {
@@ -184,8 +190,10 @@ describe('CycleAggregationService.checkEligibility', () => {
     const db = makePrisma({ users: [{ id: 'u1', hireDate: new Date('2026-03-01') }] })
     const svc = createCycleAggregationService(db as never)
     const result = await svc.checkEligibility('cycle-1', ['u1'])
-    expect(result[0].eligible).toBe(false)
-    expect(result[0].tenureRatio).toBeLessThan(0.5)
+    expect(result).toHaveLength(1)
+    const first = result[0]!
+    expect(first.eligible).toBe(false)
+    expect(first.tenureRatio).toBeLessThan(0.5)
   })
 })
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
     environment: 'node',
     globals: true,
     // E2E テスト（Playwright）は vitest の対象外
-    exclude: ['**/node_modules/**', '**/dist/**', 'e2e/**', '.claude/**'],
+    exclude: ['**/node_modules/**', '**/dist/**', 'e2e/**', '.claude/**', '.worktrees/**'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],


### PR DESCRIPTION
## Summary
- Remove test-only service setter re-exports from evaluation App Router route modules so Next.js route type validation accepts them.
- Make cycle aggregation eligibility tests explicit about the expected result length before indexing under strict array access checks.
- Exclude local `.worktrees` directories from Vitest discovery so `pnpm test` only runs the current working tree.

## Test Plan
- [x] `pnpm type-check`
- [x] `pnpm build`
- [x] `pnpm test`

Note: `pnpm build` still emits the existing Next.js warning about multiple lockfiles and inferred workspace root, but the build exits successfully.