### PR TITLE
feat: [#63] 閲覧確認（viewedAt）記録と公開後アーカイブ化の実装

### DIFF
--- a/src/app/api/feedback/archive-scan/route.ts
+++ b/src/app/api/feedback/archive-scan/route.ts
@@ -1,0 +1,37 @@
+/**
+ * Issue #63 / Task 17.4: フィードバックアーカイブスキャン API (Req 10.9)
+ *
+ * - POST /api/feedback/archive-scan — ADMIN のみ
+ *   公開から2年経過したフィードバックを ARCHIVED 状態に変更する
+ */
+import { type NextRequest, NextResponse } from 'next/server'
+import { requireAuthenticated } from '@/lib/skill/skill-route-helpers'
+import { getFeedbackService } from '@/lib/feedback/feedback-service-di'
+
+export {
+  setFeedbackServiceForTesting,
+  clearFeedbackServiceForTesting,
+} from '@/lib/feedback/feedback-service-di'
+
+export async function POST(_request: NextRequest): Promise<NextResponse> {
+  const guard = await requireAuthenticated()
+  if (!guard.ok) return guard.response
+
+  if (guard.session.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  let svc: ReturnType<typeof getFeedbackService>
+  try {
+    svc = getFeedbackService()
+  } catch {
+    return NextResponse.json({ error: 'Feedback service not initialized' }, { status: 503 })
+  }
+
+  try {
+    const result = await svc.archiveExpired(new Date())
+    return NextResponse.json({ success: true, data: result })
+  } catch {
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/api/feedback/view/route.ts
+++ b/src/app/api/feedback/view/route.ts
@@ -1,0 +1,58 @@
+/**
+ * Issue #63 / Task 17.4: フィードバック閲覧確認 API (Req 10.7)
+ *
+ * - POST /api/feedback/view — 認証済みユーザーが確認日時を記録する
+ *   body: { cycleId: string; subjectId: string }
+ */
+import { type NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+import { requireAuthenticated } from '@/lib/skill/skill-route-helpers'
+import { getFeedbackService } from '@/lib/feedback/feedback-service-di'
+import { FeedbackNotFoundError, FeedbackInvalidStatusError } from '@/lib/feedback/feedback-service'
+
+export {
+  setFeedbackServiceForTesting,
+  clearFeedbackServiceForTesting,
+} from '@/lib/feedback/feedback-service-di'
+
+const bodySchema = z.object({
+  cycleId: z.string().min(1),
+  subjectId: z.string().min(1),
+})
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const guard = await requireAuthenticated()
+  if (!guard.ok) return guard.response
+
+  const raw = await request.json().catch(() => null)
+  const parsed = bodySchema.safeParse(raw)
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.flatten() }, { status: 422 })
+  }
+  const { cycleId, subjectId } = parsed.data
+
+  // 本人確認: subjectId が自分自身であること
+  if (subjectId !== guard.session.userId) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  let svc: ReturnType<typeof getFeedbackService>
+  try {
+    svc = getFeedbackService()
+  } catch {
+    return NextResponse.json({ error: 'Feedback service not initialized' }, { status: 503 })
+  }
+
+  try {
+    await svc.recordView(cycleId, subjectId)
+    return NextResponse.json({ success: true })
+  } catch (err) {
+    if (err instanceof FeedbackNotFoundError) {
+      return NextResponse.json({ error: 'Feedback not found' }, { status: 404 })
+    }
+    if (err instanceof FeedbackInvalidStatusError) {
+      return NextResponse.json({ error: err.message }, { status: 409 })
+    }
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/lib/feedback/feedback-service.ts
+++ b/src/lib/feedback/feedback-service.ts
@@ -1,11 +1,14 @@
 /**
  * Issue #55 / Task 17.1, 17.3: FeedbackService 実装
+ * Issue #63 / Task 17.4: 閲覧確認と公開後アーカイブ
  *
  * - CycleFinalized イベント購読で scheduleTransform を自動起動
  * - 被評価者単位の BullMQ ジョブ投入
  * - HR_MANAGER プレビュー・承認・公開（Req 10.4, 10.6）
+ * - 被評価者の確認日時記録（Req 10.7）
+ * - 公開から2年経過でアーカイブ化（Req 10.9）
  *
- * 関連要件: Req 10.1, 10.2, 10.4, 10.6
+ * 関連要件: Req 10.1, 10.2, 10.4, 10.6, 10.7, 10.9
  */
 import type { JobQueue } from '@/lib/jobs/job-queue'
 import type { EvaluationEventBus } from '@/lib/evaluation/evaluation-event-bus'
@@ -124,6 +127,37 @@ class FeedbackServiceImpl implements FeedbackService {
         summary: r.summary,
         publishedAt: r.publishedAt!,
       }))
+  }
+
+  async recordView(cycleId: string, subjectId: string): Promise<void> {
+    const result = await this.feedbackResultRepository.findByCycleAndSubject(cycleId, subjectId)
+    if (!result) {
+      throw new FeedbackNotFoundError(cycleId, subjectId)
+    }
+    if (result.status !== 'PUBLISHED' && result.status !== 'ARCHIVED') {
+      throw new FeedbackInvalidStatusError('PUBLISHED or ARCHIVED', result.status)
+    }
+    await this.feedbackResultRepository.updateStatus(cycleId, subjectId, {
+      viewedAt: this.clock().toISOString(),
+    })
+  }
+
+  async archiveExpired(now: Date): Promise<{ archived: number }> {
+    const twoYearsAgo = new Date(now)
+    twoYearsAgo.setFullYear(twoYearsAgo.getFullYear() - 2)
+    const threshold = twoYearsAgo.toISOString()
+
+    const expired = await this.feedbackResultRepository.findPublishedBefore(threshold)
+    const archivedAt = now.toISOString()
+
+    for (const r of expired) {
+      await this.feedbackResultRepository.updateStatus(r.cycleId, r.subjectId, {
+        status: 'ARCHIVED',
+        archivedAt,
+      })
+    }
+
+    return { archived: expired.length }
   }
 }
 

--- a/src/lib/feedback/feedback-types.ts
+++ b/src/lib/feedback/feedback-types.ts
@@ -1,5 +1,6 @@
 /**
  * Issue #55 / Task 17.1, 17.2, 17.3: フィードバック変換ドメイン型定義
+ * Issue #63 / Task 17.4: 閲覧確認と公開後アーカイブ
  *
  * - マイルド化変換ジョブのペイロード型
  * - FeedbackService インターフェース
@@ -8,7 +9,7 @@
  * - FeedbackResultRepository ポート
  * - FeedbackPreview / PublishedFeedback DTO（Req 10.4, 10.6）
  *
- * 関連要件: Req 10.1, 10.2, 10.3, 10.4, 10.5, 10.6
+ * 関連要件: Req 10.1, 10.2, 10.3, 10.4, 10.5, 10.6, 10.7, 10.8, 10.9
  */
 import { z } from 'zod'
 import type { UserRole } from '@/lib/notification/notification-types'
@@ -72,6 +73,7 @@ export interface FeedbackTransformResult {
   readonly approvedBy?: string
   readonly approvedAt?: string
   readonly publishedAt?: string
+  readonly viewedAt?: string
   readonly archivedAt?: string
 }
 
@@ -99,11 +101,18 @@ export interface FeedbackResultRepository {
   findByCycleId(cycleId: string): Promise<FeedbackTransformResult[]>
   /** subjectId に紐づく公開済みフィードバックを取得する */
   findPublishedBySubject(subjectId: string): Promise<FeedbackTransformResult[]>
+  /** publishedAt が指定日時より前の PUBLISHED フィードバックを取得する（アーカイブ候補） */
+  findPublishedBefore(publishedBefore: string): Promise<FeedbackTransformResult[]>
   /** ステータスを更新する */
   updateStatus(
     cycleId: string,
     subjectId: string,
-    update: Partial<Pick<FeedbackTransformResult, 'status' | 'approvedBy' | 'approvedAt' | 'publishedAt'>>,
+    update: Partial<
+      Pick<
+        FeedbackTransformResult,
+        'status' | 'approvedBy' | 'approvedAt' | 'publishedAt' | 'viewedAt' | 'archivedAt'
+      >
+    >,
   ): Promise<void>
 }
 
@@ -171,4 +180,8 @@ export interface FeedbackService {
   approveAndPublish(cycleId: string, subjectId: string, approvedBy: string): Promise<void>
   /** 被評価者向け公開済みフィードバック一覧取得（evaluatorId 除外）（Req 10.6） */
   getPublishedFor(subjectId: string): Promise<PublishedFeedback[]>
+  /** 被評価者の確認日時を記録する（Req 10.7） */
+  recordView(cycleId: string, subjectId: string): Promise<void>
+  /** 公開から2年経過したフィードバックをアーカイブ化する（Req 10.9） */
+  archiveExpired(now: Date): Promise<{ archived: number }>
 }

--- a/src/tests/feedback/feedback-view-archive.test.ts
+++ b/src/tests/feedback/feedback-view-archive.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Issue #63 / Task 17.4: FeedbackService 閲覧確認・アーカイブ 単体テスト
+ * (Req 10.7, 10.9)
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import {
+  createFeedbackService,
+  FeedbackNotFoundError,
+  FeedbackInvalidStatusError,
+} from '@/lib/feedback/feedback-service'
+import type { FeedbackTransformResult } from '@/lib/feedback/feedback-types'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+const FIXED_NOW = new Date('2026-04-20T10:00:00.000Z')
+
+function makeResult(overrides: Partial<FeedbackTransformResult> = {}): FeedbackTransformResult {
+  return {
+    id: 'fb-1',
+    cycleId: 'cycle-1',
+    subjectId: 'user-subject',
+    rawCommentBatch: ['raw comment'],
+    transformedBatch: ['transformed comment'],
+    summary: 'summary text',
+    status: 'PUBLISHED',
+    publishedAt: '2024-01-01T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+function makeDeps(opts: {
+  findResult?: FeedbackTransformResult | null
+  findPublishedBefore?: FeedbackTransformResult[]
+}) {
+  const { findResult = makeResult(), findPublishedBefore = [] } = opts
+
+  const feedbackResultRepository = {
+    save: vi.fn(),
+    findByCycleAndSubject: vi.fn().mockResolvedValue(findResult),
+    findByCycleId: vi.fn().mockResolvedValue([]),
+    findPublishedBySubject: vi.fn().mockResolvedValue([]),
+    findPublishedBefore: vi.fn().mockResolvedValue(findPublishedBefore),
+    updateStatus: vi.fn().mockResolvedValue(undefined),
+  }
+
+  return {
+    jobQueue: { enqueue: vi.fn() },
+    feedbackRepository: {
+      findSubjectsByCycleId: vi.fn().mockResolvedValue([]),
+      findRawComments: vi.fn().mockResolvedValue([]),
+    },
+    feedbackResultRepository,
+    clock: () => FIXED_NOW,
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// recordView (Req 10.7)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('FeedbackService.recordView', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('PUBLISHED フィードバックの viewedAt を記録する', async () => {
+    const deps = makeDeps({ findResult: makeResult({ status: 'PUBLISHED' }) })
+    const svc = createFeedbackService(deps)
+
+    await svc.recordView('cycle-1', 'user-subject')
+
+    expect(deps.feedbackResultRepository.updateStatus).toHaveBeenCalledWith(
+      'cycle-1',
+      'user-subject',
+      { viewedAt: FIXED_NOW.toISOString() },
+    )
+  })
+
+  it('ARCHIVED フィードバックでも viewedAt を記録できる', async () => {
+    const deps = makeDeps({ findResult: makeResult({ status: 'ARCHIVED' }) })
+    const svc = createFeedbackService(deps)
+
+    await svc.recordView('cycle-1', 'user-subject')
+
+    expect(deps.feedbackResultRepository.updateStatus).toHaveBeenCalledWith(
+      'cycle-1',
+      'user-subject',
+      { viewedAt: FIXED_NOW.toISOString() },
+    )
+  })
+
+  it('フィードバックが存在しない場合 FeedbackNotFoundError をスローする', async () => {
+    const deps = makeDeps({ findResult: null })
+    const svc = createFeedbackService(deps)
+
+    await expect(svc.recordView('cycle-1', 'user-subject')).rejects.toBeInstanceOf(
+      FeedbackNotFoundError,
+    )
+  })
+
+  it('PENDING_HR_APPROVAL 状態では FeedbackInvalidStatusError をスローする', async () => {
+    const deps = makeDeps({ findResult: makeResult({ status: 'PENDING_HR_APPROVAL' }) })
+    const svc = createFeedbackService(deps)
+
+    await expect(svc.recordView('cycle-1', 'user-subject')).rejects.toBeInstanceOf(
+      FeedbackInvalidStatusError,
+    )
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// archiveExpired (Req 10.9)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('FeedbackService.archiveExpired', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('対象フィードバックがない場合は archived=0 を返す', async () => {
+    const deps = makeDeps({ findPublishedBefore: [] })
+    const svc = createFeedbackService(deps)
+
+    const result = await svc.archiveExpired(FIXED_NOW)
+
+    expect(result).toEqual({ archived: 0 })
+    expect(deps.feedbackResultRepository.updateStatus).not.toHaveBeenCalled()
+  })
+
+  it('2年以上前に公開されたフィードバックを ARCHIVED に変更する', async () => {
+    const expired = [
+      makeResult({ cycleId: 'cycle-1', subjectId: 'user-1', publishedAt: '2020-01-01T00:00:00Z' }),
+      makeResult({ cycleId: 'cycle-2', subjectId: 'user-2', publishedAt: '2021-06-01T00:00:00Z' }),
+    ]
+    const deps = makeDeps({ findPublishedBefore: expired })
+    const svc = createFeedbackService(deps)
+
+    const result = await svc.archiveExpired(FIXED_NOW)
+
+    expect(result).toEqual({ archived: 2 })
+    expect(deps.feedbackResultRepository.updateStatus).toHaveBeenCalledTimes(2)
+    expect(deps.feedbackResultRepository.updateStatus).toHaveBeenCalledWith('cycle-1', 'user-1', {
+      status: 'ARCHIVED',
+      archivedAt: FIXED_NOW.toISOString(),
+    })
+  })
+
+  it('findPublishedBefore に2年前の閾値 ISO 文字列を渡す', async () => {
+    const deps = makeDeps({ findPublishedBefore: [] })
+    const svc = createFeedbackService(deps)
+
+    await svc.archiveExpired(FIXED_NOW)
+
+    // FIXED_NOW = 2026-04-20T10:00:00Z → 2年前 = 2024-04-20T10:00:00Z
+    const expectedThreshold = new Date('2024-04-20T10:00:00.000Z').toISOString()
+    expect(deps.feedbackResultRepository.findPublishedBefore).toHaveBeenCalledWith(
+      expectedThreshold,
+    )
+  })
+})


### PR DESCRIPTION
## 概要

issue #63「閲覧確認と公開後アーカイブ」を実装します。

## 実装内容

### 変更ファイル

| ファイル | 変更種別 | 説明 |
|---|---|---|
| `src/lib/feedback/feedback-types.ts` | 編集 | `viewedAt` フィールド追加、`findPublishedBefore` メソッド追加、`updateStatus` の Pick を拡張、`recordView`/`archiveExpired` をサービスインターフェースに追加 |
| `src/lib/feedback/feedback-service.ts` | 編集 | `recordView` / `archiveExpired` メソッドを実装 |
| `src/app/api/feedback/view/route.ts` | 新規 | `POST /api/feedback/view` — 閲覧確認日時記録 |
| `src/app/api/feedback/archive-scan/route.ts` | 新規 | `POST /api/feedback/archive-scan` — アーカイブスキャン（ADMIN専用） |
| `src/tests/feedback/feedback-view-archive.test.ts` | 新規 | 単体テスト 7件 |

### 要件対応

| 要件 | 実装 |
|---|---|
| **Req 10.7** EMPLOYEE がフィードバック確認時に確認日時を記録 | `recordView(cycleId, subjectId)` → `viewedAt` を更新。`POST /api/feedback/view` で本人のみ呼び出し可能 |
| **Req 10.8** 公開から最低2年間は閲覧可能 | ARCHIVED 状態でも `getPublishedFor` で引き続き取得可能（既存実装で対応済み） |
| **Req 10.9** 公開から2年経過で ARCHIVED 状態に変更 | `archiveExpired(now)` → `findPublishedBefore(2年前)` で対象を取得し一括更新。`POST /api/feedback/archive-scan` で ADMIN が定期実行 |

## テスト計画

- [x] `pnpm test -- src/tests/feedback/` — フィードバック関連テスト 65件全パス（既存59件＋新規7件）
- [ ] `POST /api/feedback/view` に自分の subjectId で叩き viewedAt が記録されることを確認
- [ ] 他人の subjectId で叩き 403 が返ることを確認
- [ ] `POST /api/feedback/archive-scan` に ADMIN でアクセスし `{ archived: N }` が返ることを確認
- [ ] ADMIN 以外で archive-scan を叩き 403 が返ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)