### PR TITLE
[codex] Add total evaluation weighted preview calculation

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -28,6 +28,12 @@ enum EmployeeStatus {
   PENDING_JOIN
 }
 
+enum TotalEvalStatus {
+  CALCULATED
+  PENDING_FINALIZATION
+  FINALIZED
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // 監査ログ Enums (Requirement 17)
 // ─────────────────────────────────────────────────────────────────────────────
@@ -729,4 +735,58 @@ model EvaluationResponse {
   @@index([cycleId, evaluatorId])
   @@index([cycleId, targetUserId])
   @@map("evaluation_responses")
+}
+
+// 総合評価 (Requirement 12.1, 12.2, 12.4)
+model TotalEvaluationResult {
+  id                  String          @id @default(cuid())
+  cycleId             String
+  subjectId           String
+  gradeId             String
+  gradeLabel          String
+  performanceScore    Float
+  goalScore           Float
+  feedbackScore       Float
+  incentiveAdjustment Float           @default(0)
+  performanceWeight   Float
+  goalWeight          Float
+  feedbackWeight      Float
+  finalScore          Float
+  status              TotalEvalStatus @default(CALCULATED)
+  calculatedAt        DateTime        @default(now())
+  finalizedAt         DateTime?
+
+  @@unique([cycleId, subjectId])
+  @@index([cycleId, status])
+  @@index([subjectId])
+  @@map("total_evaluation_results")
+}
+
+model TotalEvaluationOverride {
+  id         String   @id @default(cuid())
+  cycleId    String
+  subjectId  String
+  w1Override Float
+  w2Override Float
+  w3Override Float
+  reason     String
+  adjustedBy String
+  adjustedAt DateTime @default(now())
+
+  @@index([cycleId, subjectId])
+  @@map("total_evaluation_overrides")
+}
+
+model TotalEvaluationCorrection {
+  id          String   @id @default(cuid())
+  cycleId     String
+  subjectId   String
+  beforeJson  Json
+  afterJson   Json
+  correctedBy String
+  reason      String
+  correctedAt DateTime @default(now())
+
+  @@index([cycleId, subjectId])
+  @@map("total_evaluation_corrections")
 }

--- a/src/app/api/feedback/archive-scan/route.ts
+++ b/src/app/api/feedback/archive-scan/route.ts
@@ -8,11 +8,6 @@ import { type NextRequest, NextResponse } from 'next/server'
 import { requireAuthenticated } from '@/lib/skill/skill-route-helpers'
 import { getFeedbackService } from '@/lib/feedback/feedback-service-di'
 
-export {
-  setFeedbackServiceForTesting,
-  clearFeedbackServiceForTesting,
-} from '@/lib/feedback/feedback-service-di'
-
 export async function POST(_request: NextRequest): Promise<NextResponse> {
   const guard = await requireAuthenticated()
   if (!guard.ok) return guard.response

--- a/src/app/api/feedback/view/route.ts
+++ b/src/app/api/feedback/view/route.ts
@@ -10,11 +10,6 @@ import { requireAuthenticated } from '@/lib/skill/skill-route-helpers'
 import { getFeedbackService } from '@/lib/feedback/feedback-service-di'
 import { FeedbackNotFoundError, FeedbackInvalidStatusError } from '@/lib/feedback/feedback-service'
 
-export {
-  setFeedbackServiceForTesting,
-  clearFeedbackServiceForTesting,
-} from '@/lib/feedback/feedback-service-di'
-
 const bodySchema = z.object({
   cycleId: z.string().min(1),
   subjectId: z.string().min(1),

--- a/src/app/api/incentive/score/route.ts
+++ b/src/app/api/incentive/score/route.ts
@@ -7,11 +7,6 @@ import { type NextRequest, NextResponse } from 'next/server'
 import { requireAuthenticated } from '@/lib/skill/skill-route-helpers'
 import { getIncentiveService } from '@/lib/incentive/incentive-service-di'
 
-export {
-  setIncentiveServiceForTesting,
-  clearIncentiveServiceForTesting,
-} from '@/lib/incentive/incentive-service-di'
-
 export async function GET(request: NextRequest): Promise<NextResponse> {
   const guard = await requireAuthenticated()
   if (!guard.ok) return guard.response

--- a/src/app/api/total-evaluation/preview/route.ts
+++ b/src/app/api/total-evaluation/preview/route.ts
@@ -1,0 +1,39 @@
+/**
+ * Issue #66 / Task 19.1: Total evaluation preview API (Req 12.4)
+ *
+ * - GET /api/total-evaluation/preview?cycleId=X
+ * - HR_MANAGER / ADMIN only
+ */
+import { type NextRequest, NextResponse } from 'next/server'
+import { getAppSession } from '@/lib/auth/app-session'
+import { getTotalEvaluationService } from '@/lib/total-evaluation/total-evaluation-service-di'
+
+const HR_OR_ADMIN_ROLES = ['HR_MANAGER', 'ADMIN'] as const
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const session = await getAppSession()
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const sess = session as Record<string, unknown>
+  const role = typeof sess.role === 'string' ? sess.role : undefined
+  if (!role || !HR_OR_ADMIN_ROLES.includes(role as (typeof HR_OR_ADMIN_ROLES)[number])) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const cycleId = request.nextUrl.searchParams.get('cycleId')
+  if (!cycleId) {
+    return NextResponse.json({ error: 'cycleId is required' }, { status: 400 })
+  }
+
+  let service: ReturnType<typeof getTotalEvaluationService>
+  try {
+    service = getTotalEvaluationService()
+  } catch {
+    return NextResponse.json({ error: 'Total evaluation service not initialized' }, { status: 503 })
+  }
+
+  const preview = await service.previewBeforeFinalize(cycleId)
+  return NextResponse.json({ success: true, data: preview }, { status: 200 })
+}

--- a/src/lib/jobs/job-types.ts
+++ b/src/lib/jobs/job-types.ts
@@ -3,6 +3,7 @@ import { exportRequestSchema } from '@/lib/export/export-types'
 import { importRequestSchema } from '@/lib/import/import-types'
 import { NOTIFICATION_CATEGORIES } from '@/lib/notification/notification-types'
 import { feedbackTransformPayloadSchema } from '@/lib/feedback/feedback-types'
+import { totalEvaluationCalculationPayloadSchema } from '@/lib/total-evaluation/total-evaluation-types'
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Job 名一覧
@@ -15,6 +16,7 @@ export const JOB_NAMES = [
   'anonymize-user',
   'ai-feedback-generation',
   'feedback-transform',
+  'total-evaluation-calculate',
   'goal-deadline-alert',
   'one-on-one-reminder',
 ] as const
@@ -58,6 +60,8 @@ export const jobPayloadSchema = {
   }),
 
   'feedback-transform': feedbackTransformPayloadSchema,
+
+  'total-evaluation-calculate': totalEvaluationCalculationPayloadSchema,
 
   'goal-deadline-alert': z.object({
     triggeredAt: z.string().datetime(),

--- a/src/lib/total-evaluation/total-evaluation-service-di.ts
+++ b/src/lib/total-evaluation/total-evaluation-service-di.ts
@@ -1,0 +1,26 @@
+import type { TotalEvaluationService } from './total-evaluation-types'
+
+let service: TotalEvaluationService | null = null
+
+export function setTotalEvaluationServiceForTesting(svc: TotalEvaluationService): void {
+  service = svc
+}
+
+export function clearTotalEvaluationServiceForTesting(): void {
+  service = null
+}
+
+export function initTotalEvaluationService(svc: TotalEvaluationService): void {
+  service = svc
+}
+
+export function getTotalEvaluationService(): TotalEvaluationService {
+  if (!service) {
+    throw new Error(
+      'TotalEvaluationService is not initialized. ' +
+        'テストでは setTotalEvaluationServiceForTesting() を呼んでください。' +
+        'プロダクションでは initTotalEvaluationService() を呼んでください。',
+    )
+  }
+  return service
+}

--- a/src/lib/total-evaluation/total-evaluation-service.ts
+++ b/src/lib/total-evaluation/total-evaluation-service.ts
@@ -1,0 +1,142 @@
+import type {
+  GradeWeights,
+  GradeWeightProvider,
+  IncentiveAdjustmentProvider,
+  TotalEvaluationCalculationInput,
+  TotalEvaluationJobQueue,
+  TotalEvaluationRepository,
+  TotalEvaluationResult,
+  TotalEvaluationScheduleResult,
+  TotalEvaluationService,
+  TotalEvaluationPreview,
+} from './total-evaluation-types'
+import {
+  TotalEvaluationGradeNotFoundError,
+  TotalEvaluationInputNotFoundError,
+  TotalEvaluationJobQueueNotConfiguredError,
+} from './total-evaluation-types'
+
+export interface TotalEvaluationServiceDeps {
+  readonly repository: TotalEvaluationRepository
+  readonly gradeWeightProvider: GradeWeightProvider
+  readonly incentiveAdjustmentProvider: IncentiveAdjustmentProvider
+  readonly jobQueue?: TotalEvaluationJobQueue
+  readonly clock?: () => Date
+}
+
+function roundScore(value: number): number {
+  return Math.round(value * 100) / 100
+}
+
+function buildResult(params: {
+  readonly input: TotalEvaluationCalculationInput
+  readonly weights: GradeWeights
+  readonly incentiveAdjustment: number
+  readonly calculatedAt: Date
+}): TotalEvaluationResult {
+  const feedbackScore = params.input.feedbackScore + params.incentiveAdjustment
+  const finalScore =
+    params.input.performanceScore * params.weights.performanceWeight +
+    params.input.goalScore * params.weights.goalWeight +
+    feedbackScore * params.weights.feedbackWeight
+
+  return {
+    cycleId: params.input.cycleId,
+    subjectId: params.input.subjectId,
+    gradeId: params.weights.gradeId,
+    gradeLabel: params.weights.label,
+    performanceScore: params.input.performanceScore,
+    goalScore: params.input.goalScore,
+    feedbackScore: roundScore(feedbackScore),
+    incentiveAdjustment: params.incentiveAdjustment,
+    performanceWeight: params.weights.performanceWeight,
+    goalWeight: params.weights.goalWeight,
+    feedbackWeight: params.weights.feedbackWeight,
+    finalScore: roundScore(finalScore),
+    status: 'CALCULATED',
+    calculatedAt: params.calculatedAt,
+  }
+}
+
+class TotalEvaluationServiceImpl implements TotalEvaluationService {
+  private readonly repository: TotalEvaluationRepository
+  private readonly gradeWeightProvider: GradeWeightProvider
+  private readonly incentiveAdjustmentProvider: IncentiveAdjustmentProvider
+  private readonly jobQueue?: TotalEvaluationJobQueue
+  private readonly clock: () => Date
+
+  constructor(deps: TotalEvaluationServiceDeps) {
+    this.repository = deps.repository
+    this.gradeWeightProvider = deps.gradeWeightProvider
+    this.incentiveAdjustmentProvider = deps.incentiveAdjustmentProvider
+    this.jobQueue = deps.jobQueue
+    this.clock = deps.clock ?? (() => new Date())
+  }
+
+  async calculateAll(cycleId: string): Promise<TotalEvaluationResult[]> {
+    const inputs = await this.repository.listCalculationInputs(cycleId)
+    const adjustments =
+      await this.incentiveAdjustmentProvider.getAdjustmentForTotalEvaluation(cycleId)
+
+    const results = await Promise.all(
+      inputs.map((input) => this.calculateInput(input, adjustments.get(input.subjectId) ?? 0)),
+    )
+
+    await this.repository.upsertCalculatedResults(results)
+    return results
+  }
+
+  async calculateSubject(cycleId: string, subjectId: string): Promise<TotalEvaluationResult> {
+    const input = await this.repository.findCalculationInput(cycleId, subjectId)
+    if (!input) throw new TotalEvaluationInputNotFoundError(cycleId, subjectId)
+
+    const adjustments =
+      await this.incentiveAdjustmentProvider.getAdjustmentForTotalEvaluation(cycleId)
+    const result = await this.calculateInput(input, adjustments.get(subjectId) ?? 0)
+
+    await this.repository.upsertCalculatedResults([result])
+    return result
+  }
+
+  async scheduleCalculateAll(cycleId: string): Promise<TotalEvaluationScheduleResult> {
+    if (!this.jobQueue) throw new TotalEvaluationJobQueueNotConfiguredError()
+
+    const inputs = await this.repository.listCalculationInputs(cycleId)
+    const jobIds = await Promise.all(
+      inputs.map((input) =>
+        this.jobQueue!.enqueue('total-evaluation-calculate', {
+          cycleId,
+          subjectId: input.subjectId,
+        }),
+      ),
+    )
+
+    return { enqueued: jobIds.length, jobIds }
+  }
+
+  async previewBeforeFinalize(cycleId: string): Promise<TotalEvaluationPreview> {
+    const results = await this.repository.listPreviewResults(cycleId)
+    return { cycleId, results }
+  }
+
+  private async calculateInput(
+    input: TotalEvaluationCalculationInput,
+    incentiveAdjustment: number,
+  ): Promise<TotalEvaluationResult> {
+    const weights = await this.gradeWeightProvider.findGradeWeights(input.gradeId)
+    if (!weights) throw new TotalEvaluationGradeNotFoundError(input.gradeId)
+
+    return buildResult({
+      input,
+      weights,
+      incentiveAdjustment,
+      calculatedAt: this.clock(),
+    })
+  }
+}
+
+export function createTotalEvaluationService(
+  deps: TotalEvaluationServiceDeps,
+): TotalEvaluationService {
+  return new TotalEvaluationServiceImpl(deps)
+}

--- a/src/lib/total-evaluation/total-evaluation-types.ts
+++ b/src/lib/total-evaluation/total-evaluation-types.ts
@@ -1,0 +1,116 @@
+import { z } from 'zod'
+
+export const TOTAL_EVALUATION_STATUSES = [
+  'CALCULATED',
+  'PENDING_FINALIZATION',
+  'FINALIZED',
+] as const
+
+export type TotalEvaluationStatus = (typeof TOTAL_EVALUATION_STATUSES)[number]
+
+export interface TotalEvaluationCalculationInput {
+  readonly cycleId: string
+  readonly subjectId: string
+  readonly gradeId: string
+  readonly performanceScore: number
+  readonly goalScore: number
+  readonly feedbackScore: number
+}
+
+export interface GradeWeights {
+  readonly gradeId: string
+  readonly label: string
+  readonly performanceWeight: number
+  readonly goalWeight: number
+  readonly feedbackWeight: number
+}
+
+export interface TotalEvaluationResult {
+  readonly id?: string
+  readonly cycleId: string
+  readonly subjectId: string
+  readonly gradeId: string
+  readonly gradeLabel: string
+  readonly performanceScore: number
+  readonly goalScore: number
+  readonly feedbackScore: number
+  readonly incentiveAdjustment: number
+  readonly performanceWeight: number
+  readonly goalWeight: number
+  readonly feedbackWeight: number
+  readonly finalScore: number
+  readonly status: TotalEvaluationStatus
+  readonly calculatedAt: Date
+}
+
+export interface TotalEvaluationPreview {
+  readonly cycleId: string
+  readonly results: TotalEvaluationResult[]
+}
+
+export interface TotalEvaluationScheduleResult {
+  readonly enqueued: number
+  readonly jobIds: string[]
+}
+
+export interface TotalEvaluationRepository {
+  listCalculationInputs(cycleId: string): Promise<TotalEvaluationCalculationInput[]>
+  findCalculationInput(
+    cycleId: string,
+    subjectId: string,
+  ): Promise<TotalEvaluationCalculationInput | null>
+  upsertCalculatedResults(results: TotalEvaluationResult[]): Promise<void>
+  listPreviewResults(cycleId: string): Promise<TotalEvaluationResult[]>
+}
+
+export interface GradeWeightProvider {
+  findGradeWeights(gradeId: string): Promise<GradeWeights | null>
+}
+
+export interface IncentiveAdjustmentProvider {
+  getAdjustmentForTotalEvaluation(cycleId: string): Promise<Map<string, number>>
+}
+
+export const totalEvaluationCalculationPayloadSchema = z.object({
+  cycleId: z.string().min(1),
+  subjectId: z.string().min(1),
+})
+
+export type TotalEvaluationCalculationPayload = z.infer<
+  typeof totalEvaluationCalculationPayloadSchema
+>
+
+export interface TotalEvaluationJobQueue {
+  enqueue(
+    name: 'total-evaluation-calculate',
+    payload: TotalEvaluationCalculationPayload,
+  ): Promise<string>
+}
+
+export interface TotalEvaluationService {
+  calculateAll(cycleId: string): Promise<TotalEvaluationResult[]>
+  calculateSubject(cycleId: string, subjectId: string): Promise<TotalEvaluationResult>
+  scheduleCalculateAll(cycleId: string): Promise<TotalEvaluationScheduleResult>
+  previewBeforeFinalize(cycleId: string): Promise<TotalEvaluationPreview>
+}
+
+export class TotalEvaluationInputNotFoundError extends Error {
+  constructor(cycleId: string, subjectId: string) {
+    super(`Total evaluation input not found: cycleId="${cycleId}", subjectId="${subjectId}"`)
+    this.name = 'TotalEvaluationInputNotFoundError'
+  }
+}
+
+export class TotalEvaluationGradeNotFoundError extends Error {
+  constructor(gradeId: string) {
+    super(`Grade weights not found: gradeId="${gradeId}"`)
+    this.name = 'TotalEvaluationGradeNotFoundError'
+  }
+}
+
+export class TotalEvaluationJobQueueNotConfiguredError extends Error {
+  constructor() {
+    super('Total evaluation job queue is not configured')
+    this.name = 'TotalEvaluationJobQueueNotConfiguredError'
+  }
+}

--- a/src/lib/total-evaluation/total-evaluation-worker.ts
+++ b/src/lib/total-evaluation/total-evaluation-worker.ts
@@ -1,0 +1,36 @@
+import type { Job } from 'bullmq'
+import { createBaseWorker } from '@/lib/jobs/base-worker'
+import type {
+  TotalEvaluationCalculationPayload,
+  TotalEvaluationResult,
+  TotalEvaluationService,
+} from './total-evaluation-types'
+import { totalEvaluationCalculationPayloadSchema } from './total-evaluation-types'
+
+export interface TotalEvaluationWorkerDeps {
+  readonly service: TotalEvaluationService
+}
+
+function parsePayload(value: unknown): TotalEvaluationCalculationPayload | null {
+  const parsed = totalEvaluationCalculationPayloadSchema.safeParse(value)
+  return parsed.success ? parsed.data : null
+}
+
+export async function processTotalEvaluationCalculationJob(
+  job: Job,
+  deps: TotalEvaluationWorkerDeps,
+): Promise<TotalEvaluationResult> {
+  const payload = parsePayload(job.data)
+
+  if (!payload) {
+    throw new Error(`TotalEvaluationWorker: invalid payload for job "${job.id ?? 'unknown'}"`)
+  }
+
+  return deps.service.calculateSubject(payload.cycleId, payload.subjectId)
+}
+
+export function createTotalEvaluationWorker(deps: TotalEvaluationWorkerDeps) {
+  return createBaseWorker('total-evaluation-calculate', (job) =>
+    processTotalEvaluationCalculationJob(job, deps),
+  )
+}

--- a/src/tests/feedback/feedback-routes.test.ts
+++ b/src/tests/feedback/feedback-routes.test.ts
@@ -13,7 +13,11 @@ import {
   setFeedbackServiceForTesting,
   clearFeedbackServiceForTesting,
 } from '@/lib/feedback/feedback-service-di'
-import type { FeedbackService, FeedbackPreview, PublishedFeedback } from '@/lib/feedback/feedback-types'
+import type {
+  FeedbackService,
+  FeedbackPreview,
+  PublishedFeedback,
+} from '@/lib/feedback/feedback-types'
 import { FeedbackNotFoundError, FeedbackInvalidStatusError } from '@/lib/feedback/feedback-service'
 
 vi.mock('next-auth', () => ({
@@ -53,6 +57,8 @@ function makeMockFeedbackService(overrides?: Partial<FeedbackService>): Feedback
     previewTransformed: vi.fn().mockResolvedValue(null),
     approveAndPublish: vi.fn().mockResolvedValue(undefined),
     getPublishedFor: vi.fn().mockResolvedValue([]),
+    recordView: vi.fn().mockResolvedValue(undefined),
+    archiveExpired: vi.fn().mockResolvedValue({ archived: 0 }),
     ...overrides,
   }
 }
@@ -119,7 +125,9 @@ describe('GET /api/feedback/preview', () => {
 
   it('結果が存在しない場合 404', async () => {
     mockedGetServerSession.mockResolvedValue(makeHrManagerSession())
-    setFeedbackServiceForTesting(makeMockFeedbackService({ previewTransformed: vi.fn().mockResolvedValue(null) }))
+    setFeedbackServiceForTesting(
+      makeMockFeedbackService({ previewTransformed: vi.fn().mockResolvedValue(null) }),
+    )
 
     const req = new NextRequest('http://localhost/api/feedback/preview?cycleId=c1&subjectId=s1')
     const res = await previewGET(req)
@@ -129,9 +137,13 @@ describe('GET /api/feedback/preview', () => {
   it('HR_MANAGER がプレビューを取得できる', async () => {
     mockedGetServerSession.mockResolvedValue(makeHrManagerSession())
     const preview = makeSamplePreview()
-    setFeedbackServiceForTesting(makeMockFeedbackService({ previewTransformed: vi.fn().mockResolvedValue(preview) }))
+    setFeedbackServiceForTesting(
+      makeMockFeedbackService({ previewTransformed: vi.fn().mockResolvedValue(preview) }),
+    )
 
-    const req = new NextRequest('http://localhost/api/feedback/preview?cycleId=cycle-1&subjectId=user-1')
+    const req = new NextRequest(
+      'http://localhost/api/feedback/preview?cycleId=cycle-1&subjectId=user-1',
+    )
     const res = await previewGET(req)
 
     expect(res.status).toBe(200)
@@ -214,7 +226,9 @@ describe('POST /api/feedback/approve', () => {
     mockedGetServerSession.mockResolvedValue(makeHrManagerSession())
     setFeedbackServiceForTesting(
       makeMockFeedbackService({
-        approveAndPublish: vi.fn().mockRejectedValue(new FeedbackInvalidStatusError('PENDING_HR_APPROVAL', 'PUBLISHED')),
+        approveAndPublish: vi
+          .fn()
+          .mockRejectedValue(new FeedbackInvalidStatusError('PENDING_HR_APPROVAL', 'PUBLISHED')),
       }),
     )
 
@@ -261,7 +275,9 @@ describe('GET /api/feedback/published', () => {
   it('認証済みユーザーの公開フィードバックを取得できる（匿名）', async () => {
     mockedGetServerSession.mockResolvedValue(makeEmployeeSession('emp-1'))
     const published = makeSamplePublished()
-    setFeedbackServiceForTesting(makeMockFeedbackService({ getPublishedFor: vi.fn().mockResolvedValue([published]) }))
+    setFeedbackServiceForTesting(
+      makeMockFeedbackService({ getPublishedFor: vi.fn().mockResolvedValue([published]) }),
+    )
 
     const res = await publishedGET()
 

--- a/src/tests/feedback/feedback-service.test.ts
+++ b/src/tests/feedback/feedback-service.test.ts
@@ -6,8 +6,16 @@
  * - HR_MANAGER プレビュー・承認・公開
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { createFeedbackService, FeedbackNotFoundError, FeedbackInvalidStatusError } from '@/lib/feedback/feedback-service'
-import type { FeedbackRepository, FeedbackResultRepository, FeedbackTransformResult } from '@/lib/feedback/feedback-types'
+import {
+  createFeedbackService,
+  FeedbackNotFoundError,
+  FeedbackInvalidStatusError,
+} from '@/lib/feedback/feedback-service'
+import type {
+  FeedbackRepository,
+  FeedbackResultRepository,
+  FeedbackTransformResult,
+} from '@/lib/feedback/feedback-types'
 import type { JobQueue } from '@/lib/jobs/job-queue'
 import { InMemoryEvaluationEventBus } from '@/lib/evaluation/evaluation-event-bus'
 
@@ -49,13 +57,18 @@ function makeMockFeedbackResultRepository(
         store.filter((r) => r.subjectId === subjectId && r.status === 'PUBLISHED'),
       )
     }),
-    updateStatus: vi.fn().mockImplementation((cycleId: string, subjectId: string, update: Partial<FeedbackTransformResult>) => {
-      const idx = store.findIndex((r) => r.cycleId === cycleId && r.subjectId === subjectId)
-      if (idx >= 0) {
-        store[idx] = { ...store[idx]!, ...update }
-      }
-      return Promise.resolve()
-    }),
+    findPublishedBefore: vi.fn().mockResolvedValue([]),
+    updateStatus: vi
+      .fn()
+      .mockImplementation(
+        (cycleId: string, subjectId: string, update: Partial<FeedbackTransformResult>) => {
+          const idx = store.findIndex((r) => r.cycleId === cycleId && r.subjectId === subjectId)
+          if (idx >= 0) {
+            store[idx] = { ...store[idx]!, ...update }
+          }
+          return Promise.resolve()
+        },
+      ),
   }
 }
 
@@ -89,7 +102,11 @@ describe('FeedbackService.scheduleTransform', () => {
     const jobQueue = makeMockJobQueue()
     const repo = makeMockFeedbackRepository(['user-1', 'user-2', 'user-3'])
     const resultRepo = makeMockFeedbackResultRepository()
-    const svc = createFeedbackService({ jobQueue, feedbackRepository: repo, feedbackResultRepository: resultRepo })
+    const svc = createFeedbackService({
+      jobQueue,
+      feedbackRepository: repo,
+      feedbackResultRepository: resultRepo,
+    })
 
     await svc.scheduleTransform('cycle-1')
 
@@ -113,7 +130,11 @@ describe('FeedbackService.scheduleTransform', () => {
     const jobQueue = makeMockJobQueue()
     const repo = makeMockFeedbackRepository([])
     const resultRepo = makeMockFeedbackResultRepository()
-    const svc = createFeedbackService({ jobQueue, feedbackRepository: repo, feedbackResultRepository: resultRepo })
+    const svc = createFeedbackService({
+      jobQueue,
+      feedbackRepository: repo,
+      feedbackResultRepository: resultRepo,
+    })
 
     await svc.scheduleTransform('cycle-1')
 
@@ -132,7 +153,12 @@ describe('FeedbackService CycleFinalized 購読', () => {
     const resultRepo = makeMockFeedbackResultRepository()
     const eventBus = new InMemoryEvaluationEventBus()
 
-    createFeedbackService({ jobQueue, feedbackRepository: repo, feedbackResultRepository: resultRepo, eventBus })
+    createFeedbackService({
+      jobQueue,
+      feedbackRepository: repo,
+      feedbackResultRepository: resultRepo,
+      eventBus,
+    })
 
     // Act: CycleFinalized イベントを publish
     await eventBus.publish('CycleFinalized', {
@@ -158,7 +184,11 @@ describe('FeedbackService CycleFinalized 購読', () => {
     const jobQueue = makeMockJobQueue()
     const repo = makeMockFeedbackRepository(['user-x'])
     const resultRepo = makeMockFeedbackResultRepository()
-    const svc = createFeedbackService({ jobQueue, feedbackRepository: repo, feedbackResultRepository: resultRepo })
+    const svc = createFeedbackService({
+      jobQueue,
+      feedbackRepository: repo,
+      feedbackResultRepository: resultRepo,
+    })
 
     await svc.scheduleTransform('cycle-5')
 
@@ -179,7 +209,11 @@ describe('FeedbackService.previewTransformed', () => {
     const repo = makeMockFeedbackRepository()
     const sample = makeSampleTransformResult()
     const resultRepo = makeMockFeedbackResultRepository([sample])
-    const svc = createFeedbackService({ jobQueue, feedbackRepository: repo, feedbackResultRepository: resultRepo })
+    const svc = createFeedbackService({
+      jobQueue,
+      feedbackRepository: repo,
+      feedbackResultRepository: resultRepo,
+    })
 
     const preview = await svc.previewTransformed('cycle-1', 'user-1')
 
@@ -196,7 +230,11 @@ describe('FeedbackService.previewTransformed', () => {
     const jobQueue = makeMockJobQueue()
     const repo = makeMockFeedbackRepository()
     const resultRepo = makeMockFeedbackResultRepository()
-    const svc = createFeedbackService({ jobQueue, feedbackRepository: repo, feedbackResultRepository: resultRepo })
+    const svc = createFeedbackService({
+      jobQueue,
+      feedbackRepository: repo,
+      feedbackResultRepository: resultRepo,
+    })
 
     const preview = await svc.previewTransformed('cycle-1', 'user-1')
 
@@ -235,7 +273,11 @@ describe('FeedbackService.approveAndPublish', () => {
     const jobQueue = makeMockJobQueue()
     const repo = makeMockFeedbackRepository()
     const resultRepo = makeMockFeedbackResultRepository()
-    const svc = createFeedbackService({ jobQueue, feedbackRepository: repo, feedbackResultRepository: resultRepo })
+    const svc = createFeedbackService({
+      jobQueue,
+      feedbackRepository: repo,
+      feedbackResultRepository: resultRepo,
+    })
 
     await expect(svc.approveAndPublish('cycle-1', 'user-1', 'hr-mgr-1')).rejects.toThrow(
       FeedbackNotFoundError,
@@ -247,7 +289,11 @@ describe('FeedbackService.approveAndPublish', () => {
     const repo = makeMockFeedbackRepository()
     const sample = makeSampleTransformResult({ status: 'PUBLISHED' })
     const resultRepo = makeMockFeedbackResultRepository([sample])
-    const svc = createFeedbackService({ jobQueue, feedbackRepository: repo, feedbackResultRepository: resultRepo })
+    const svc = createFeedbackService({
+      jobQueue,
+      feedbackRepository: repo,
+      feedbackResultRepository: resultRepo,
+    })
 
     await expect(svc.approveAndPublish('cycle-1', 'user-1', 'hr-mgr-1')).rejects.toThrow(
       FeedbackInvalidStatusError,
@@ -268,7 +314,11 @@ describe('FeedbackService.getPublishedFor', () => {
       publishedAt: '2025-01-15T10:00:00.000Z',
     })
     const resultRepo = makeMockFeedbackResultRepository([published])
-    const svc = createFeedbackService({ jobQueue, feedbackRepository: repo, feedbackResultRepository: resultRepo })
+    const svc = createFeedbackService({
+      jobQueue,
+      feedbackRepository: repo,
+      feedbackResultRepository: resultRepo,
+    })
 
     const results = await svc.getPublishedFor('user-1')
 
@@ -290,7 +340,11 @@ describe('FeedbackService.getPublishedFor', () => {
     const jobQueue = makeMockJobQueue()
     const repo = makeMockFeedbackRepository()
     const resultRepo = makeMockFeedbackResultRepository()
-    const svc = createFeedbackService({ jobQueue, feedbackRepository: repo, feedbackResultRepository: resultRepo })
+    const svc = createFeedbackService({
+      jobQueue,
+      feedbackRepository: repo,
+      feedbackResultRepository: resultRepo,
+    })
 
     const results = await svc.getPublishedFor('user-1')
 

--- a/src/tests/feedback/feedback-view-archive.test.ts
+++ b/src/tests/feedback/feedback-view-archive.test.ts
@@ -46,7 +46,11 @@ function makeDeps(opts: {
   }
 
   return {
-    jobQueue: { enqueue: vi.fn() },
+    jobQueue: {
+      enqueue: vi.fn(),
+      getJobStatus: vi.fn().mockResolvedValue(null),
+      close: vi.fn().mockResolvedValue(undefined),
+    },
     feedbackRepository: {
       findSubjectsByCycleId: vi.fn().mockResolvedValue([]),
       findRawComments: vi.fn().mockResolvedValue([]),

--- a/src/tests/feedback/feedback-worker.test.ts
+++ b/src/tests/feedback/feedback-worker.test.ts
@@ -26,7 +26,8 @@ function makeMockAIGateway(
   mildifyResponse = '["transformed1"]',
   summaryResponse = 'この被評価者は丁寧なコミュニケーションが強みです。一方で、タスクの優先順位付けにおいて改善の余地があります。全体として成長意欲が高く、フィードバックを前向きに受け止める姿勢が評価されています。今後は計画的な業務遂行を意識することで、さらなる成長が期待できます。',
 ): AIGateway {
-  const chatFn = vi.fn()
+  const chatFn = vi
+    .fn()
     .mockResolvedValueOnce({
       content: mildifyResponse,
       provider: 'claude',
@@ -59,17 +60,17 @@ function makeMockFeedbackResultRepository(): FeedbackResultRepository {
     findByCycleAndSubject: vi.fn().mockResolvedValue(null),
     findByCycleId: vi.fn().mockResolvedValue([]),
     findPublishedBySubject: vi.fn().mockResolvedValue([]),
+    findPublishedBefore: vi.fn().mockResolvedValue([]),
     updateStatus: vi.fn().mockResolvedValue(undefined),
   }
 }
 
-function makeDeps(
-  overrides: Partial<FeedbackWorkerDeps> = {},
-): FeedbackWorkerDeps {
+function makeDeps(overrides: Partial<FeedbackWorkerDeps> = {}): FeedbackWorkerDeps {
   return {
     aiGateway: overrides.aiGateway ?? makeMockAIGateway(),
     feedbackRepository: overrides.feedbackRepository ?? makeMockFeedbackRepository(),
-    feedbackResultRepository: overrides.feedbackResultRepository ?? makeMockFeedbackResultRepository(),
+    feedbackResultRepository:
+      overrides.feedbackResultRepository ?? makeMockFeedbackResultRepository(),
     generateId: overrides.generateId ?? (() => 'test-id-1'),
   }
 }
@@ -85,12 +86,18 @@ beforeEach(() => {
 describe('processFeedbackTransformJob', () => {
   it('有効なペイロードで AIGateway を呼び出しマイルド化変換と要約生成を行う', async () => {
     const comments = ['彼の仕事は雑すぎる', 'やる気が全くない']
-    const transformedResponse = '["丁寧さを意識するとさらに良くなります", "モチベーション向上のサポートが有効かもしれません"]'
-    const summaryResponse = '強みとして誠実な取り組み姿勢が見られます。改善点として、作業の丁寧さとモチベーション管理に課題があります。'
+    const transformedResponse =
+      '["丁寧さを意識するとさらに良くなります", "モチベーション向上のサポートが有効かもしれません"]'
+    const summaryResponse =
+      '強みとして誠実な取り組み姿勢が見られます。改善点として、作業の丁寧さとモチベーション管理に課題があります。'
     const aiGateway = makeMockAIGateway(transformedResponse, summaryResponse)
     const repo = makeMockFeedbackRepository(comments)
     const resultRepo = makeMockFeedbackResultRepository()
-    const deps = makeDeps({ aiGateway, feedbackRepository: repo, feedbackResultRepository: resultRepo })
+    const deps = makeDeps({
+      aiGateway,
+      feedbackRepository: repo,
+      feedbackResultRepository: resultRepo,
+    })
     const job = makeJob({ cycleId: 'cycle-1', subjectId: 'user-1' })
 
     const result = await processFeedbackTransformJob(job, deps)
@@ -111,11 +118,16 @@ describe('processFeedbackTransformJob', () => {
   it('要約生成後に FeedbackResultRepository に保存される', async () => {
     const comments = ['良い仕事をしている']
     const transformedResponse = '["引き続き良い仕事を続けてください"]'
-    const summaryResponse = '丁寧な業務遂行が強みとして評価されています。今後も継続的な成長が期待されます。'
+    const summaryResponse =
+      '丁寧な業務遂行が強みとして評価されています。今後も継続的な成長が期待されます。'
     const aiGateway = makeMockAIGateway(transformedResponse, summaryResponse)
     const repo = makeMockFeedbackRepository(comments)
     const resultRepo = makeMockFeedbackResultRepository()
-    const deps = makeDeps({ aiGateway, feedbackRepository: repo, feedbackResultRepository: resultRepo })
+    const deps = makeDeps({
+      aiGateway,
+      feedbackRepository: repo,
+      feedbackResultRepository: resultRepo,
+    })
     const job = makeJob({ cycleId: 'cycle-1', subjectId: 'user-1' })
 
     await processFeedbackTransformJob(job, deps)
@@ -138,7 +150,11 @@ describe('processFeedbackTransformJob', () => {
     const aiGateway = makeMockAIGateway()
     const repo = makeMockFeedbackRepository([])
     const resultRepo = makeMockFeedbackResultRepository()
-    const deps = makeDeps({ aiGateway, feedbackRepository: repo, feedbackResultRepository: resultRepo })
+    const deps = makeDeps({
+      aiGateway,
+      feedbackRepository: repo,
+      feedbackResultRepository: resultRepo,
+    })
     const job = makeJob({ cycleId: 'cycle-1', subjectId: 'user-1' })
 
     const result = await processFeedbackTransformJob(job, deps)
@@ -192,9 +208,7 @@ describe('processFeedbackTransformJob', () => {
     const deps = makeDeps({ aiGateway, feedbackRepository: repo })
     const job = makeJob({ cycleId: 'cycle-1', subjectId: 'user-1' })
 
-    await expect(processFeedbackTransformJob(job, deps)).rejects.toThrow(
-      'AI response mismatch',
-    )
+    await expect(processFeedbackTransformJob(job, deps)).rejects.toThrow('AI response mismatch')
   })
 
   it('AI レスポンスが不正なJSONの場合はエラーをスローする', async () => {
@@ -204,9 +218,7 @@ describe('processFeedbackTransformJob', () => {
     const deps = makeDeps({ aiGateway, feedbackRepository: repo })
     const job = makeJob({ cycleId: 'cycle-1', subjectId: 'user-1' })
 
-    await expect(processFeedbackTransformJob(job, deps)).rejects.toThrow(
-      'AI response mismatch',
-    )
+    await expect(processFeedbackTransformJob(job, deps)).rejects.toThrow('AI response mismatch')
   })
 
   it('要約生成が失敗した場合はエラーをスローする', async () => {

--- a/src/tests/incentive/incentive-score-route.test.ts
+++ b/src/tests/incentive/incentive-score-route.test.ts
@@ -4,6 +4,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { NextRequest } from 'next/server'
 import type { IncentiveScore, IncentiveService } from '@/lib/incentive/incentive-types'
+import {
+  setIncentiveServiceForTesting,
+  clearIncentiveServiceForTesting,
+} from '@/lib/incentive/incentive-service-di'
 
 vi.mock('next-auth', () => ({
   getServerSession: vi.fn(),
@@ -12,11 +16,7 @@ vi.mock('next-auth', () => ({
 const { getServerSession } = await import('next-auth')
 const mockedGetServerSession = vi.mocked(getServerSession)
 
-const {
-  GET,
-  setIncentiveServiceForTesting,
-  clearIncentiveServiceForTesting,
-} = await import('@/app/api/incentive/score/route')
+const { GET } = await import('@/app/api/incentive/score/route')
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Helpers

--- a/src/tests/total-evaluation/total-evaluation-job-types.test.ts
+++ b/src/tests/total-evaluation/total-evaluation-job-types.test.ts
@@ -1,0 +1,23 @@
+/**
+ * Issue #66 / Task 19.1: total-evaluation job payload schema tests.
+ */
+import { describe, it, expect } from 'vitest'
+import { isJobName, jobPayloadSchema } from '@/lib/jobs/job-types'
+
+describe('total-evaluation-calculate job type', () => {
+  it('JobNameとして登録され、cycleId/subjectIdを検証する', () => {
+    expect(isJobName('total-evaluation-calculate')).toBe(true)
+
+    expect(() =>
+      jobPayloadSchema['total-evaluation-calculate'].parse({
+        cycleId: 'cycle-1',
+        subjectId: 'user-1',
+      }),
+    ).not.toThrow()
+    expect(() =>
+      jobPayloadSchema['total-evaluation-calculate'].parse({
+        cycleId: 'cycle-1',
+      }),
+    ).toThrow()
+  })
+})

--- a/src/tests/total-evaluation/total-evaluation-routes.test.ts
+++ b/src/tests/total-evaluation/total-evaluation-routes.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Issue #66 / Task 19.1: Total evaluation preview API tests.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import {
+  setTotalEvaluationServiceForTesting,
+  clearTotalEvaluationServiceForTesting,
+} from '@/lib/total-evaluation/total-evaluation-service-di'
+import type { TotalEvaluationService } from '@/lib/total-evaluation/total-evaluation-types'
+
+vi.mock('next-auth', () => ({
+  getServerSession: vi.fn(),
+}))
+
+const { getServerSession } = await import('next-auth')
+const mockedGetServerSession = vi.mocked(getServerSession)
+
+const { GET: previewGET } = await import('@/app/api/total-evaluation/preview/route')
+
+function makeSession(role: string) {
+  return {
+    user: { email: 'user@example.com' },
+    userId: 'user-1',
+    role,
+  }
+}
+
+function makeService(overrides?: Partial<TotalEvaluationService>): TotalEvaluationService {
+  return {
+    calculateAll: vi.fn(),
+    calculateSubject: vi.fn(),
+    scheduleCalculateAll: vi.fn(),
+    previewBeforeFinalize: vi.fn().mockResolvedValue({
+      cycleId: 'cycle-1',
+      results: [{ subjectId: 'user-1', finalScore: 80 }],
+    }),
+    ...overrides,
+  } as TotalEvaluationService
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+afterEach(() => {
+  clearTotalEvaluationServiceForTesting()
+})
+
+describe('GET /api/total-evaluation/preview', () => {
+  it('未認証は401', async () => {
+    mockedGetServerSession.mockResolvedValue(null)
+
+    const res = await previewGET(
+      new NextRequest('http://localhost/api/total-evaluation/preview?cycleId=cycle-1'),
+    )
+
+    expect(res.status).toBe(401)
+  })
+
+  it('EMPLOYEEは403', async () => {
+    mockedGetServerSession.mockResolvedValue(makeSession('EMPLOYEE'))
+    setTotalEvaluationServiceForTesting(makeService())
+
+    const res = await previewGET(
+      new NextRequest('http://localhost/api/total-evaluation/preview?cycleId=cycle-1'),
+    )
+
+    expect(res.status).toBe(403)
+  })
+
+  it('cycleId未指定は400', async () => {
+    mockedGetServerSession.mockResolvedValue(makeSession('HR_MANAGER'))
+    setTotalEvaluationServiceForTesting(makeService())
+
+    const res = await previewGET(new NextRequest('http://localhost/api/total-evaluation/preview'))
+
+    expect(res.status).toBe(400)
+  })
+
+  it('HR_MANAGERが確定前プレビューを取得できる', async () => {
+    mockedGetServerSession.mockResolvedValue(makeSession('HR_MANAGER'))
+    const service = makeService()
+    setTotalEvaluationServiceForTesting(service)
+
+    const res = await previewGET(
+      new NextRequest('http://localhost/api/total-evaluation/preview?cycleId=cycle-1'),
+    )
+
+    expect(res.status).toBe(200)
+    expect(service.previewBeforeFinalize).toHaveBeenCalledWith('cycle-1')
+    await expect(res.json()).resolves.toEqual({
+      success: true,
+      data: {
+        cycleId: 'cycle-1',
+        results: [{ subjectId: 'user-1', finalScore: 80 }],
+      },
+    })
+  })
+})

--- a/src/tests/total-evaluation/total-evaluation-service.test.ts
+++ b/src/tests/total-evaluation/total-evaluation-service.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Issue #66 / Task 19.1: TotalEvaluationService tests (Req 12.1, 12.2, 12.4)
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { createTotalEvaluationService } from '@/lib/total-evaluation/total-evaluation-service'
+import type {
+  TotalEvaluationCalculationInput,
+  TotalEvaluationRepository,
+  GradeWeightProvider,
+  IncentiveAdjustmentProvider,
+  TotalEvaluationJobQueue,
+} from '@/lib/total-evaluation/total-evaluation-types'
+
+function makeInput(
+  overrides: Partial<TotalEvaluationCalculationInput> = {},
+): TotalEvaluationCalculationInput {
+  return {
+    cycleId: 'cycle-1',
+    subjectId: 'user-1',
+    gradeId: 'grade-a',
+    performanceScore: 80,
+    goalScore: 70,
+    feedbackScore: 90,
+    ...overrides,
+  }
+}
+
+function makeRepo(
+  inputs: TotalEvaluationCalculationInput[] = [makeInput()],
+): TotalEvaluationRepository {
+  return {
+    listCalculationInputs: vi.fn().mockResolvedValue(inputs),
+    findCalculationInput: vi
+      .fn()
+      .mockImplementation(
+        async (cycleId: string, subjectId: string) =>
+          inputs.find((input) => input.cycleId === cycleId && input.subjectId === subjectId) ??
+          null,
+      ),
+    upsertCalculatedResults: vi.fn().mockResolvedValue(undefined),
+    listPreviewResults: vi.fn().mockResolvedValue([]),
+  }
+}
+
+function makeGradeProvider(overrides?: Partial<GradeWeightProvider>): GradeWeightProvider {
+  return {
+    findGradeWeights: vi.fn().mockResolvedValue({
+      gradeId: 'grade-a',
+      label: 'G3',
+      performanceWeight: 0.5,
+      goalWeight: 0.3,
+      feedbackWeight: 0.2,
+    }),
+    ...overrides,
+  }
+}
+
+function makeIncentives(adjustments = new Map<string, number>()): IncentiveAdjustmentProvider {
+  return {
+    getAdjustmentForTotalEvaluation: vi.fn().mockResolvedValue(adjustments),
+  }
+}
+
+describe('TotalEvaluationService.calculateAll', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('業績・目標・インセンティブ加算後360度点を等級ウェイトで加重平均する', async () => {
+    const repo = makeRepo([makeInput()])
+    const svc = createTotalEvaluationService({
+      repository: repo,
+      gradeWeightProvider: makeGradeProvider(),
+      incentiveAdjustmentProvider: makeIncentives(new Map([['user-1', 5]])),
+    })
+
+    const results = await svc.calculateAll('cycle-1')
+
+    expect(results).toEqual([
+      expect.objectContaining({
+        cycleId: 'cycle-1',
+        subjectId: 'user-1',
+        gradeId: 'grade-a',
+        gradeLabel: 'G3',
+        performanceScore: 80,
+        goalScore: 70,
+        feedbackScore: 95,
+        incentiveAdjustment: 5,
+        performanceWeight: 0.5,
+        goalWeight: 0.3,
+        feedbackWeight: 0.2,
+        finalScore: 80,
+        status: 'CALCULATED',
+      }),
+    ])
+    expect(repo.upsertCalculatedResults).toHaveBeenCalledWith(results)
+  })
+
+  it('対象社員ごとに等級マスタのデフォルトウェイトを適用する', async () => {
+    const repo = makeRepo([
+      makeInput({ subjectId: 'user-1', gradeId: 'grade-a' }),
+      makeInput({
+        subjectId: 'user-2',
+        gradeId: 'grade-b',
+        performanceScore: 60,
+        goalScore: 100,
+        feedbackScore: 80,
+      }),
+    ])
+    const gradeWeightProvider = makeGradeProvider({
+      findGradeWeights: vi.fn().mockImplementation(async (gradeId: string) =>
+        gradeId === 'grade-b'
+          ? {
+              gradeId,
+              label: 'G4',
+              performanceWeight: 0.2,
+              goalWeight: 0.5,
+              feedbackWeight: 0.3,
+            }
+          : {
+              gradeId,
+              label: 'G3',
+              performanceWeight: 0.5,
+              goalWeight: 0.3,
+              feedbackWeight: 0.2,
+            },
+      ),
+    })
+    const svc = createTotalEvaluationService({
+      repository: repo,
+      gradeWeightProvider,
+      incentiveAdjustmentProvider: makeIncentives(),
+    })
+
+    const results = await svc.calculateAll('cycle-1')
+
+    expect(results.map((r) => ({ subjectId: r.subjectId, finalScore: r.finalScore }))).toEqual([
+      { subjectId: 'user-1', finalScore: 79 },
+      { subjectId: 'user-2', finalScore: 86 },
+    ])
+    expect(gradeWeightProvider.findGradeWeights).toHaveBeenCalledWith('grade-a')
+    expect(gradeWeightProvider.findGradeWeights).toHaveBeenCalledWith('grade-b')
+  })
+})
+
+describe('TotalEvaluationService.previewBeforeFinalize', () => {
+  it('確定前プレビューとして各社員の内訳を返す', async () => {
+    const previewRows = [
+      {
+        id: 'ter-1',
+        cycleId: 'cycle-1',
+        subjectId: 'user-1',
+        gradeId: 'grade-a',
+        gradeLabel: 'G3',
+        performanceScore: 80,
+        goalScore: 70,
+        feedbackScore: 95,
+        incentiveAdjustment: 5,
+        performanceWeight: 0.5,
+        goalWeight: 0.3,
+        feedbackWeight: 0.2,
+        finalScore: 80,
+        status: 'CALCULATED' as const,
+        calculatedAt: new Date('2026-04-01T00:00:00.000Z'),
+      },
+    ]
+    const repo = makeRepo([])
+    repo.listPreviewResults = vi.fn().mockResolvedValue(previewRows)
+    const svc = createTotalEvaluationService({
+      repository: repo,
+      gradeWeightProvider: makeGradeProvider(),
+      incentiveAdjustmentProvider: makeIncentives(),
+    })
+
+    await expect(svc.previewBeforeFinalize('cycle-1')).resolves.toEqual({
+      cycleId: 'cycle-1',
+      results: previewRows,
+    })
+  })
+})
+
+describe('TotalEvaluationService.scheduleCalculateAll', () => {
+  it('全社員分の計算ジョブを社員単位で投入する', async () => {
+    const repo = makeRepo([makeInput({ subjectId: 'user-1' }), makeInput({ subjectId: 'user-2' })])
+    const jobQueue: TotalEvaluationJobQueue = {
+      enqueue: vi.fn().mockResolvedValue('job-1'),
+    }
+    const svc = createTotalEvaluationService({
+      repository: repo,
+      gradeWeightProvider: makeGradeProvider(),
+      incentiveAdjustmentProvider: makeIncentives(),
+      jobQueue,
+    })
+
+    const result = await svc.scheduleCalculateAll('cycle-1')
+
+    expect(result).toEqual({ enqueued: 2, jobIds: ['job-1', 'job-1'] })
+    expect(jobQueue.enqueue).toHaveBeenNthCalledWith(1, 'total-evaluation-calculate', {
+      cycleId: 'cycle-1',
+      subjectId: 'user-1',
+    })
+    expect(jobQueue.enqueue).toHaveBeenNthCalledWith(2, 'total-evaluation-calculate', {
+      cycleId: 'cycle-1',
+      subjectId: 'user-2',
+    })
+  })
+})

--- a/src/tests/total-evaluation/total-evaluation-worker.test.ts
+++ b/src/tests/total-evaluation/total-evaluation-worker.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Issue #66 / Task 19.1: Total evaluation BullMQ worker tests.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { processTotalEvaluationCalculationJob } from '@/lib/total-evaluation/total-evaluation-worker'
+import type { TotalEvaluationService } from '@/lib/total-evaluation/total-evaluation-types'
+
+function makeJob(data: unknown) {
+  return {
+    id: 'job-1',
+    data,
+  }
+}
+
+describe('processTotalEvaluationCalculationJob', () => {
+  it('payloadのcycleId/subjectIdを使って社員単位の再計算を行う', async () => {
+    const service: Pick<TotalEvaluationService, 'calculateSubject'> = {
+      calculateSubject: vi.fn().mockResolvedValue({
+        cycleId: 'cycle-1',
+        subjectId: 'user-1',
+        finalScore: 80,
+      }),
+    }
+
+    const result = await processTotalEvaluationCalculationJob(
+      makeJob({ cycleId: 'cycle-1', subjectId: 'user-1' }) as never,
+      { service: service as TotalEvaluationService },
+    )
+
+    expect(service.calculateSubject).toHaveBeenCalledWith('cycle-1', 'user-1')
+    expect(result).toEqual({ cycleId: 'cycle-1', subjectId: 'user-1', finalScore: 80 })
+  })
+
+  it('不正payloadはエラーにする', async () => {
+    const service: Pick<TotalEvaluationService, 'calculateSubject'> = {
+      calculateSubject: vi.fn(),
+    }
+
+    await expect(
+      processTotalEvaluationCalculationJob(makeJob({ cycleId: 'cycle-1' }) as never, {
+        service: service as TotalEvaluationService,
+      }),
+    ).rejects.toThrow('TotalEvaluationWorker: invalid payload')
+    expect(service.calculateSubject).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- Closes #66
- Add the total-evaluation domain service for weighted final score calculation using grade default weights
- Include incentive adjustments in the 360-degree score before applying the feedback weight
- Register a BullMQ job payload for employee-level total evaluation calculation and add the worker processor
- Add the HR_MANAGER/ADMIN preview API for pre-finalization score breakdowns
- Add Prisma schema models for total evaluation results, overrides, and corrections
- Remove test-only route re-exports from existing route modules so `next build` accepts the route files

## Validation
- `pnpm vitest run src/tests/total-evaluation`
- `pnpm vitest run src/tests/jobs/job-types.test.ts src/tests/jobs/job-queue.test.ts src/tests/prisma/schema.test.ts src/tests/total-evaluation`
- `pnpm type-check`
- `pnpm build`
- `pnpm test` (135 files / 1520 tests)

## Notes
- `pnpm build` passes with an existing Next.js warning about multiple lockfiles and inferred workspace root.