### PR TITLE
feat: support total evaluation weight overrides

### DIFF
--- a/src/app/api/total-evaluation/override/route.ts
+++ b/src/app/api/total-evaluation/override/route.ts
@@ -1,0 +1,99 @@
+import { type NextRequest, NextResponse } from 'next/server'
+import { ZodError } from 'zod'
+import { getAppSession } from '@/lib/auth/app-session'
+import { getTotalEvaluationService } from '@/lib/total-evaluation/total-evaluation-service-di'
+import { totalEvaluationWeightOverrideSchema } from '@/lib/total-evaluation/total-evaluation-types'
+
+const HR_OR_ADMIN_ROLES = ['HR_MANAGER', 'ADMIN'] as const
+
+function isAllowedRole(role: string | undefined): boolean {
+  return !!role && HR_OR_ADMIN_ROLES.includes(role as (typeof HR_OR_ADMIN_ROLES)[number])
+}
+
+function getSessionRole(session: unknown): string | undefined {
+  const sess = session as Record<string, unknown>
+  return typeof sess.role === 'string' ? sess.role : undefined
+}
+
+function getSessionUserId(session: unknown): string | undefined {
+  const sess = session as Record<string, unknown>
+  return typeof sess.userId === 'string' ? sess.userId : undefined
+}
+
+function getRequestMetadata(request: NextRequest): { ipAddress: string; userAgent: string } {
+  return {
+    ipAddress: request.headers.get('x-forwarded-for') ?? '127.0.0.1',
+    userAgent: request.headers.get('user-agent') ?? 'unknown',
+  }
+}
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const session = await getAppSession()
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const role = getSessionRole(session)
+  if (!isAllowedRole(role)) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const cycleId = request.nextUrl.searchParams.get('cycleId')
+  const subjectId = request.nextUrl.searchParams.get('subjectId')
+  if (!cycleId || !subjectId) {
+    return NextResponse.json({ error: 'cycleId and subjectId are required' }, { status: 400 })
+  }
+
+  let service: ReturnType<typeof getTotalEvaluationService>
+  try {
+    service = getTotalEvaluationService()
+  } catch {
+    return NextResponse.json({ error: 'Total evaluation service not initialized' }, { status: 503 })
+  }
+
+  const override = await service.getWeightOverride(cycleId, subjectId)
+  return NextResponse.json({ success: true, data: override }, { status: 200 })
+}
+
+export async function PUT(request: NextRequest): Promise<NextResponse> {
+  const session = await getAppSession()
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const role = getSessionRole(session)
+  if (!isAllowedRole(role)) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const adjustedBy = getSessionUserId(session)
+  if (!adjustedBy) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  let service: ReturnType<typeof getTotalEvaluationService>
+  try {
+    service = getTotalEvaluationService()
+  } catch {
+    return NextResponse.json({ error: 'Total evaluation service not initialized' }, { status: 503 })
+  }
+
+  try {
+    const payload = totalEvaluationWeightOverrideSchema.parse(await request.json())
+    const metadata = getRequestMetadata(request)
+    const result = await service.overrideWeight({
+      ...payload,
+      adjustedBy,
+      ...metadata,
+    })
+    return NextResponse.json({ success: true, data: result }, { status: 200 })
+  } catch (error) {
+    if (error instanceof ZodError) {
+      return NextResponse.json(
+        { error: 'Validation failed', details: error.flatten() },
+        { status: 422 },
+      )
+    }
+    throw error
+  }
+}

--- a/src/lib/total-evaluation/total-evaluation-service.ts
+++ b/src/lib/total-evaluation/total-evaluation-service.ts
@@ -1,14 +1,20 @@
 import type {
-  GradeWeights,
+  GradeThresholdProvider,
   GradeWeightProvider,
+  GradeWeights,
   IncentiveAdjustmentProvider,
+  TotalEvaluationAuditLogger,
+  TotalEvaluationBoundaryThreshold,
   TotalEvaluationCalculationInput,
   TotalEvaluationJobQueue,
+  TotalEvaluationOverrideWeightInput,
+  TotalEvaluationPreview,
+  TotalEvaluationPreviewResult,
   TotalEvaluationRepository,
   TotalEvaluationResult,
   TotalEvaluationScheduleResult,
   TotalEvaluationService,
-  TotalEvaluationPreview,
+  TotalEvaluationWeightOverride,
 } from './total-evaluation-types'
 import {
   TotalEvaluationGradeNotFoundError,
@@ -20,12 +26,35 @@ export interface TotalEvaluationServiceDeps {
   readonly repository: TotalEvaluationRepository
   readonly gradeWeightProvider: GradeWeightProvider
   readonly incentiveAdjustmentProvider: IncentiveAdjustmentProvider
+  readonly gradeThresholdProvider?: GradeThresholdProvider
+  readonly auditLogger?: TotalEvaluationAuditLogger
   readonly jobQueue?: TotalEvaluationJobQueue
   readonly clock?: () => Date
 }
 
 function roundScore(value: number): number {
   return Math.round(value * 100) / 100
+}
+
+function toOverrideMap(
+  overrides: readonly TotalEvaluationWeightOverride[],
+): ReadonlyMap<string, TotalEvaluationWeightOverride> {
+  return new Map(overrides.map((override) => [override.subjectId, override]))
+}
+
+function toWeights(
+  input: TotalEvaluationCalculationInput,
+  gradeWeights: GradeWeights,
+  override?: TotalEvaluationWeightOverride | null,
+): GradeWeights {
+  if (!override) return gradeWeights
+  return {
+    gradeId: input.gradeId,
+    label: gradeWeights.label,
+    performanceWeight: override.performanceWeight,
+    goalWeight: override.goalWeight,
+    feedbackWeight: override.feedbackWeight,
+  }
 }
 
 function buildResult(params: {
@@ -43,7 +72,7 @@ function buildResult(params: {
   return {
     cycleId: params.input.cycleId,
     subjectId: params.input.subjectId,
-    gradeId: params.weights.gradeId,
+    gradeId: params.input.gradeId,
     gradeLabel: params.weights.label,
     performanceScore: params.input.performanceScore,
     goalScore: params.input.goalScore,
@@ -58,10 +87,41 @@ function buildResult(params: {
   }
 }
 
+function buildPreviewResult(
+  result: TotalEvaluationResult,
+  overrideMap: ReadonlyMap<string, TotalEvaluationWeightOverride>,
+  thresholds: readonly TotalEvaluationBoundaryThreshold[],
+): TotalEvaluationPreviewResult {
+  let nearestGradeThresholdScore: number | null = null
+  let thresholdDistancePercent: number | null = null
+
+  for (const threshold of thresholds) {
+    if (threshold.score <= 0) continue
+    const distancePercent = Math.abs(result.finalScore - threshold.score) / threshold.score
+    if (thresholdDistancePercent === null || distancePercent < thresholdDistancePercent) {
+      thresholdDistancePercent = distancePercent
+      nearestGradeThresholdScore = threshold.score
+    }
+  }
+
+  return {
+    ...result,
+    hasWeightOverride: overrideMap.has(result.subjectId),
+    isNearGradeThreshold: thresholdDistancePercent !== null && thresholdDistancePercent <= 0.03,
+    nearestGradeThresholdScore,
+    thresholdDistancePercent:
+      thresholdDistancePercent === null
+        ? null
+        : roundScore(thresholdDistancePercent * 10000) / 10000,
+  }
+}
+
 class TotalEvaluationServiceImpl implements TotalEvaluationService {
   private readonly repository: TotalEvaluationRepository
   private readonly gradeWeightProvider: GradeWeightProvider
   private readonly incentiveAdjustmentProvider: IncentiveAdjustmentProvider
+  private readonly gradeThresholdProvider?: GradeThresholdProvider
+  private readonly auditLogger?: TotalEvaluationAuditLogger
   private readonly jobQueue?: TotalEvaluationJobQueue
   private readonly clock: () => Date
 
@@ -69,6 +129,8 @@ class TotalEvaluationServiceImpl implements TotalEvaluationService {
     this.repository = deps.repository
     this.gradeWeightProvider = deps.gradeWeightProvider
     this.incentiveAdjustmentProvider = deps.incentiveAdjustmentProvider
+    this.gradeThresholdProvider = deps.gradeThresholdProvider
+    this.auditLogger = deps.auditLogger
     this.jobQueue = deps.jobQueue
     this.clock = deps.clock ?? (() => new Date())
   }
@@ -77,9 +139,16 @@ class TotalEvaluationServiceImpl implements TotalEvaluationService {
     const inputs = await this.repository.listCalculationInputs(cycleId)
     const adjustments =
       await this.incentiveAdjustmentProvider.getAdjustmentForTotalEvaluation(cycleId)
+    const overrideMap = toOverrideMap(await this.repository.listWeightOverrides(cycleId))
 
     const results = await Promise.all(
-      inputs.map((input) => this.calculateInput(input, adjustments.get(input.subjectId) ?? 0)),
+      inputs.map((input) =>
+        this.calculateInput(
+          input,
+          adjustments.get(input.subjectId) ?? 0,
+          overrideMap.get(input.subjectId),
+        ),
+      ),
     )
 
     await this.repository.upsertCalculatedResults(results)
@@ -92,7 +161,8 @@ class TotalEvaluationServiceImpl implements TotalEvaluationService {
 
     const adjustments =
       await this.incentiveAdjustmentProvider.getAdjustmentForTotalEvaluation(cycleId)
-    const result = await this.calculateInput(input, adjustments.get(subjectId) ?? 0)
+    const override = await this.repository.findWeightOverride(cycleId, subjectId)
+    const result = await this.calculateInput(input, adjustments.get(subjectId) ?? 0, override)
 
     await this.repository.upsertCalculatedResults([result])
     return result
@@ -115,20 +185,89 @@ class TotalEvaluationServiceImpl implements TotalEvaluationService {
   }
 
   async previewBeforeFinalize(cycleId: string): Promise<TotalEvaluationPreview> {
-    const results = await this.repository.listPreviewResults(cycleId)
-    return { cycleId, results }
+    const [results, overrides, thresholds] = await Promise.all([
+      this.repository.listPreviewResults(cycleId),
+      this.repository.listWeightOverrides(cycleId),
+      this.gradeThresholdProvider?.listThresholds(cycleId) ?? Promise.resolve([]),
+    ])
+    const overrideMap = toOverrideMap(overrides)
+
+    return {
+      cycleId,
+      results: results.map((result) => buildPreviewResult(result, overrideMap, thresholds)),
+    }
+  }
+
+  async getWeightOverride(
+    cycleId: string,
+    subjectId: string,
+  ): Promise<TotalEvaluationWeightOverride | null> {
+    return this.repository.findWeightOverride(cycleId, subjectId)
+  }
+
+  async overrideWeight(input: TotalEvaluationOverrideWeightInput): Promise<TotalEvaluationResult> {
+    const calculationInput = await this.repository.findCalculationInput(
+      input.cycleId,
+      input.subjectId,
+    )
+    if (!calculationInput) {
+      throw new TotalEvaluationInputNotFoundError(input.cycleId, input.subjectId)
+    }
+
+    const override = await this.repository.upsertWeightOverride({
+      cycleId: input.cycleId,
+      subjectId: input.subjectId,
+      performanceWeight: input.performanceWeight,
+      goalWeight: input.goalWeight,
+      feedbackWeight: input.feedbackWeight,
+      reason: input.reason,
+      adjustedBy: input.adjustedBy,
+    })
+
+    const adjustments = await this.incentiveAdjustmentProvider.getAdjustmentForTotalEvaluation(
+      input.cycleId,
+    )
+    const result = await this.calculateInput(
+      calculationInput,
+      adjustments.get(input.subjectId) ?? 0,
+      override,
+    )
+    await this.repository.upsertCalculatedResults([result])
+
+    if (this.auditLogger) {
+      await this.auditLogger.emit({
+        userId: input.adjustedBy,
+        action: 'RECORD_UPDATE',
+        resourceType: 'EVALUATION',
+        resourceId: input.subjectId,
+        ipAddress: input.ipAddress,
+        userAgent: input.userAgent,
+        before: null,
+        after: {
+          cycleId: override.cycleId,
+          subjectId: override.subjectId,
+          performanceWeight: override.performanceWeight,
+          goalWeight: override.goalWeight,
+          feedbackWeight: override.feedbackWeight,
+          reason: override.reason,
+        },
+      })
+    }
+
+    return result
   }
 
   private async calculateInput(
     input: TotalEvaluationCalculationInput,
     incentiveAdjustment: number,
+    override?: TotalEvaluationWeightOverride | null,
   ): Promise<TotalEvaluationResult> {
-    const weights = await this.gradeWeightProvider.findGradeWeights(input.gradeId)
-    if (!weights) throw new TotalEvaluationGradeNotFoundError(input.gradeId)
+    const gradeWeights = await this.gradeWeightProvider.findGradeWeights(input.gradeId)
+    if (!gradeWeights) throw new TotalEvaluationGradeNotFoundError(input.gradeId)
 
     return buildResult({
       input,
-      weights,
+      weights: toWeights(input, gradeWeights, override),
       incentiveAdjustment,
       calculatedAt: this.clock(),
     })

--- a/src/lib/total-evaluation/total-evaluation-types.ts
+++ b/src/lib/total-evaluation/total-evaluation-types.ts
@@ -43,9 +43,34 @@ export interface TotalEvaluationResult {
   readonly calculatedAt: Date
 }
 
+export interface TotalEvaluationWeightOverride {
+  readonly id?: string
+  readonly cycleId: string
+  readonly subjectId: string
+  readonly performanceWeight: number
+  readonly goalWeight: number
+  readonly feedbackWeight: number
+  readonly reason: string
+  readonly adjustedBy: string
+  readonly adjustedAt: Date
+}
+
+export interface TotalEvaluationBoundaryThreshold {
+  readonly id: string
+  readonly label: string
+  readonly score: number
+}
+
+export interface TotalEvaluationPreviewResult extends TotalEvaluationResult {
+  readonly hasWeightOverride: boolean
+  readonly isNearGradeThreshold: boolean
+  readonly nearestGradeThresholdScore: number | null
+  readonly thresholdDistancePercent: number | null
+}
+
 export interface TotalEvaluationPreview {
   readonly cycleId: string
-  readonly results: TotalEvaluationResult[]
+  readonly results: TotalEvaluationPreviewResult[]
 }
 
 export interface TotalEvaluationScheduleResult {
@@ -61,6 +86,14 @@ export interface TotalEvaluationRepository {
   ): Promise<TotalEvaluationCalculationInput | null>
   upsertCalculatedResults(results: TotalEvaluationResult[]): Promise<void>
   listPreviewResults(cycleId: string): Promise<TotalEvaluationResult[]>
+  listWeightOverrides(cycleId: string): Promise<TotalEvaluationWeightOverride[]>
+  findWeightOverride(
+    cycleId: string,
+    subjectId: string,
+  ): Promise<TotalEvaluationWeightOverride | null>
+  upsertWeightOverride(
+    override: Omit<TotalEvaluationWeightOverride, 'id' | 'adjustedAt'>,
+  ): Promise<TotalEvaluationWeightOverride>
 }
 
 export interface GradeWeightProvider {
@@ -71,6 +104,10 @@ export interface IncentiveAdjustmentProvider {
   getAdjustmentForTotalEvaluation(cycleId: string): Promise<Map<string, number>>
 }
 
+export interface GradeThresholdProvider {
+  listThresholds(cycleId: string): Promise<readonly TotalEvaluationBoundaryThreshold[]>
+}
+
 export const totalEvaluationCalculationPayloadSchema = z.object({
   cycleId: z.string().min(1),
   subjectId: z.string().min(1),
@@ -79,6 +116,49 @@ export const totalEvaluationCalculationPayloadSchema = z.object({
 export type TotalEvaluationCalculationPayload = z.infer<
   typeof totalEvaluationCalculationPayloadSchema
 >
+
+export const totalEvaluationWeightOverrideSchema = z
+  .object({
+    cycleId: z.string().min(1),
+    subjectId: z.string().min(1),
+    performanceWeight: z.number().min(0).max(1),
+    goalWeight: z.number().min(0).max(1),
+    feedbackWeight: z.number().min(0).max(1),
+    reason: z.string().trim().min(1).max(1000),
+  })
+  .superRefine((value, ctx) => {
+    const sum = value.performanceWeight + value.goalWeight + value.feedbackWeight
+    if (Math.abs(sum - 1) > 1e-6) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Weight sum must equal 1 (got ${sum})`,
+        path: ['performanceWeight'],
+      })
+    }
+  })
+
+export type TotalEvaluationWeightOverridePayload = z.infer<
+  typeof totalEvaluationWeightOverrideSchema
+>
+
+export interface TotalEvaluationOverrideWeightInput extends TotalEvaluationWeightOverridePayload {
+  readonly adjustedBy: string
+  readonly ipAddress: string
+  readonly userAgent: string
+}
+
+export interface TotalEvaluationAuditLogger {
+  emit(entry: {
+    userId: string | null
+    action: 'RECORD_UPDATE'
+    resourceType: 'EVALUATION'
+    resourceId: string | null
+    ipAddress: string
+    userAgent: string
+    before: Record<string, unknown> | null
+    after: Record<string, unknown> | null
+  }): Promise<void>
+}
 
 export interface TotalEvaluationJobQueue {
   enqueue(
@@ -92,6 +172,11 @@ export interface TotalEvaluationService {
   calculateSubject(cycleId: string, subjectId: string): Promise<TotalEvaluationResult>
   scheduleCalculateAll(cycleId: string): Promise<TotalEvaluationScheduleResult>
   previewBeforeFinalize(cycleId: string): Promise<TotalEvaluationPreview>
+  getWeightOverride(
+    cycleId: string,
+    subjectId: string,
+  ): Promise<TotalEvaluationWeightOverride | null>
+  overrideWeight(input: TotalEvaluationOverrideWeightInput): Promise<TotalEvaluationResult>
 }
 
 export class TotalEvaluationInputNotFoundError extends Error {

--- a/src/tests/total-evaluation/total-evaluation-routes.test.ts
+++ b/src/tests/total-evaluation/total-evaluation-routes.test.ts
@@ -1,11 +1,11 @@
 /**
- * Issue #66 / Task 19.1: Total evaluation preview API tests.
+ * Issue #67 / Task 19.2: Total evaluation routes tests.
  */
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { NextRequest } from 'next/server'
 import {
-  setTotalEvaluationServiceForTesting,
   clearTotalEvaluationServiceForTesting,
+  setTotalEvaluationServiceForTesting,
 } from '@/lib/total-evaluation/total-evaluation-service-di'
 import type { TotalEvaluationService } from '@/lib/total-evaluation/total-evaluation-types'
 
@@ -17,13 +17,23 @@ const { getServerSession } = await import('next-auth')
 const mockedGetServerSession = vi.mocked(getServerSession)
 
 const { GET: previewGET } = await import('@/app/api/total-evaluation/preview/route')
+const { GET: overrideGET, PUT: overridePUT } =
+  await import('@/app/api/total-evaluation/override/route')
 
-function makeSession(role: string) {
+function makeSession(role: string, userId = 'user-1') {
   return {
     user: { email: 'user@example.com' },
-    userId: 'user-1',
+    userId,
     role,
   }
+}
+
+function makeJsonRequest(url: string, method: 'PUT', body: unknown): NextRequest {
+  return new NextRequest(url, {
+    method,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
 }
 
 function makeService(overrides?: Partial<TotalEvaluationService>): TotalEvaluationService {
@@ -33,7 +43,23 @@ function makeService(overrides?: Partial<TotalEvaluationService>): TotalEvaluati
     scheduleCalculateAll: vi.fn(),
     previewBeforeFinalize: vi.fn().mockResolvedValue({
       cycleId: 'cycle-1',
-      results: [{ subjectId: 'user-1', finalScore: 80 }],
+      results: [
+        {
+          subjectId: 'user-1',
+          finalScore: 80,
+          hasWeightOverride: false,
+          isNearGradeThreshold: false,
+        },
+      ],
+    }),
+    getWeightOverride: vi.fn().mockResolvedValue(null),
+    overrideWeight: vi.fn().mockResolvedValue({
+      cycleId: 'cycle-1',
+      subjectId: 'user-1',
+      finalScore: 79,
+      performanceWeight: 0.4,
+      goalWeight: 0.4,
+      feedbackWeight: 0.2,
     }),
     ...overrides,
   } as TotalEvaluationService
@@ -93,8 +119,110 @@ describe('GET /api/total-evaluation/preview', () => {
       success: true,
       data: {
         cycleId: 'cycle-1',
-        results: [{ subjectId: 'user-1', finalScore: 80 }],
+        results: [
+          {
+            subjectId: 'user-1',
+            finalScore: 80,
+            hasWeightOverride: false,
+            isNearGradeThreshold: false,
+          },
+        ],
       },
     })
+  })
+})
+
+describe('GET /api/total-evaluation/override', () => {
+  it('HR_MANAGERが上書き設定を取得できる', async () => {
+    mockedGetServerSession.mockResolvedValue(makeSession('HR_MANAGER', 'hr-1'))
+    const service = makeService({
+      getWeightOverride: vi.fn().mockResolvedValue({
+        cycleId: 'cycle-1',
+        subjectId: 'user-1',
+        performanceWeight: 0.4,
+        goalWeight: 0.4,
+        feedbackWeight: 0.2,
+        reason: '評価会議で調整',
+        adjustedBy: 'hr-1',
+      }),
+    })
+    setTotalEvaluationServiceForTesting(service)
+
+    const res = await overrideGET(
+      new NextRequest(
+        'http://localhost/api/total-evaluation/override?cycleId=cycle-1&subjectId=user-1',
+      ),
+    )
+
+    expect(res.status).toBe(200)
+    expect(service.getWeightOverride).toHaveBeenCalledWith('cycle-1', 'user-1')
+  })
+})
+
+describe('PUT /api/total-evaluation/override', () => {
+  it('EMPLOYEEは403', async () => {
+    mockedGetServerSession.mockResolvedValue(makeSession('EMPLOYEE'))
+    setTotalEvaluationServiceForTesting(makeService())
+
+    const res = await overridePUT(
+      makeJsonRequest('http://localhost/api/total-evaluation/override', 'PUT', {
+        cycleId: 'cycle-1',
+        subjectId: 'user-1',
+        performanceWeight: 0.4,
+        goalWeight: 0.4,
+        feedbackWeight: 0.2,
+        reason: '評価会議で調整',
+      }),
+    )
+
+    expect(res.status).toBe(403)
+  })
+
+  it('不正なウェイト合計は422', async () => {
+    mockedGetServerSession.mockResolvedValue(makeSession('HR_MANAGER', 'hr-1'))
+    setTotalEvaluationServiceForTesting(makeService())
+
+    const res = await overridePUT(
+      makeJsonRequest('http://localhost/api/total-evaluation/override', 'PUT', {
+        cycleId: 'cycle-1',
+        subjectId: 'user-1',
+        performanceWeight: 0.5,
+        goalWeight: 0.4,
+        feedbackWeight: 0.2,
+        reason: '評価会議で調整',
+      }),
+    )
+
+    expect(res.status).toBe(422)
+  })
+
+  it('HR_MANAGERがウェイト上書きを更新できる', async () => {
+    mockedGetServerSession.mockResolvedValue(makeSession('HR_MANAGER', 'hr-1'))
+    const service = makeService()
+    setTotalEvaluationServiceForTesting(service)
+
+    const res = await overridePUT(
+      makeJsonRequest('http://localhost/api/total-evaluation/override', 'PUT', {
+        cycleId: 'cycle-1',
+        subjectId: 'user-1',
+        performanceWeight: 0.4,
+        goalWeight: 0.4,
+        feedbackWeight: 0.2,
+        reason: '評価会議で調整',
+      }),
+    )
+
+    expect(res.status).toBe(200)
+    expect(service.overrideWeight).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cycleId: 'cycle-1',
+        subjectId: 'user-1',
+        performanceWeight: 0.4,
+        goalWeight: 0.4,
+        feedbackWeight: 0.2,
+        reason: '評価会議で調整',
+        adjustedBy: 'hr-1',
+      }),
+    )
   })
 })

--- a/src/tests/total-evaluation/total-evaluation-service.test.ts
+++ b/src/tests/total-evaluation/total-evaluation-service.test.ts
@@ -1,14 +1,16 @@
 /**
- * Issue #66 / Task 19.1: TotalEvaluationService tests (Req 12.1, 12.2, 12.4)
+ * Issue #67 / Task 19.2: TotalEvaluationService tests (Req 12.3, 12.6)
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createTotalEvaluationService } from '@/lib/total-evaluation/total-evaluation-service'
 import type {
-  TotalEvaluationCalculationInput,
-  TotalEvaluationRepository,
   GradeWeightProvider,
   IncentiveAdjustmentProvider,
+  TotalEvaluationBoundaryThreshold,
+  TotalEvaluationCalculationInput,
   TotalEvaluationJobQueue,
+  TotalEvaluationRepository,
+  TotalEvaluationWeightOverride,
 } from '@/lib/total-evaluation/total-evaluation-types'
 
 function makeInput(
@@ -39,6 +41,13 @@ function makeRepo(
       ),
     upsertCalculatedResults: vi.fn().mockResolvedValue(undefined),
     listPreviewResults: vi.fn().mockResolvedValue([]),
+    listWeightOverrides: vi.fn().mockResolvedValue([]),
+    findWeightOverride: vi.fn().mockResolvedValue(null),
+    upsertWeightOverride: vi.fn().mockImplementation(async (override) => ({
+      id: 'override-1',
+      adjustedAt: new Date('2026-04-02T00:00:00.000Z'),
+      ...override,
+    })),
   }
 }
 
@@ -61,12 +70,39 @@ function makeIncentives(adjustments = new Map<string, number>()): IncentiveAdjus
   }
 }
 
+function makeOverride(
+  overrides: Partial<TotalEvaluationWeightOverride> = {},
+): TotalEvaluationWeightOverride {
+  return {
+    id: 'override-1',
+    cycleId: 'cycle-1',
+    subjectId: 'user-1',
+    performanceWeight: 0.4,
+    goalWeight: 0.4,
+    feedbackWeight: 0.2,
+    reason: '評価会議で調整',
+    adjustedBy: 'hr-1',
+    adjustedAt: new Date('2026-04-02T00:00:00.000Z'),
+    ...overrides,
+  }
+}
+
+function makeBoundaryThresholds(
+  thresholds: readonly number[] = [80],
+): readonly TotalEvaluationBoundaryThreshold[] {
+  return thresholds.map((score, index) => ({
+    id: `threshold-${index + 1}`,
+    label: `T${index + 1}`,
+    score,
+  }))
+}
+
 describe('TotalEvaluationService.calculateAll', () => {
   beforeEach(() => {
     vi.clearAllMocks()
   })
 
-  it('業績・目標・インセンティブ加算後360度点を等級ウェイトで加重平均する', async () => {
+  it('等級ウェイトとインセンティブ補正で最終スコアを計算する', async () => {
     const repo = makeRepo([makeInput()])
     const svc = createTotalEvaluationService({
       repository: repo,
@@ -96,55 +132,31 @@ describe('TotalEvaluationService.calculateAll', () => {
     expect(repo.upsertCalculatedResults).toHaveBeenCalledWith(results)
   })
 
-  it('対象社員ごとに等級マスタのデフォルトウェイトを適用する', async () => {
-    const repo = makeRepo([
-      makeInput({ subjectId: 'user-1', gradeId: 'grade-a' }),
-      makeInput({
-        subjectId: 'user-2',
-        gradeId: 'grade-b',
-        performanceScore: 60,
-        goalScore: 100,
-        feedbackScore: 80,
-      }),
-    ])
-    const gradeWeightProvider = makeGradeProvider({
-      findGradeWeights: vi.fn().mockImplementation(async (gradeId: string) =>
-        gradeId === 'grade-b'
-          ? {
-              gradeId,
-              label: 'G4',
-              performanceWeight: 0.2,
-              goalWeight: 0.5,
-              feedbackWeight: 0.3,
-            }
-          : {
-              gradeId,
-              label: 'G3',
-              performanceWeight: 0.5,
-              goalWeight: 0.3,
-              feedbackWeight: 0.2,
-            },
-      ),
-    })
+  it('個別ウェイト上書きがある社員は上書きウェイトで再計算する', async () => {
+    const repo = makeRepo([makeInput()])
+    repo.listWeightOverrides = vi.fn().mockResolvedValue([makeOverride()])
     const svc = createTotalEvaluationService({
       repository: repo,
-      gradeWeightProvider,
-      incentiveAdjustmentProvider: makeIncentives(),
+      gradeWeightProvider: makeGradeProvider(),
+      incentiveAdjustmentProvider: makeIncentives(new Map([['user-1', 5]])),
     })
 
-    const results = await svc.calculateAll('cycle-1')
+    const [result] = await svc.calculateAll('cycle-1')
 
-    expect(results.map((r) => ({ subjectId: r.subjectId, finalScore: r.finalScore }))).toEqual([
-      { subjectId: 'user-1', finalScore: 79 },
-      { subjectId: 'user-2', finalScore: 86 },
-    ])
-    expect(gradeWeightProvider.findGradeWeights).toHaveBeenCalledWith('grade-a')
-    expect(gradeWeightProvider.findGradeWeights).toHaveBeenCalledWith('grade-b')
+    expect(result).toEqual(
+      expect.objectContaining({
+        performanceWeight: 0.4,
+        goalWeight: 0.4,
+        feedbackWeight: 0.2,
+        feedbackScore: 95,
+        finalScore: 79,
+      }),
+    )
   })
 })
 
 describe('TotalEvaluationService.previewBeforeFinalize', () => {
-  it('確定前プレビューとして各社員の内訳を返す', async () => {
+  it('確定前プレビューとして一覧を返す', async () => {
     const previewRows = [
       {
         id: 'ter-1',
@@ -170,12 +182,129 @@ describe('TotalEvaluationService.previewBeforeFinalize', () => {
       repository: repo,
       gradeWeightProvider: makeGradeProvider(),
       incentiveAdjustmentProvider: makeIncentives(),
+      gradeThresholdProvider: {
+        listThresholds: vi.fn().mockResolvedValue([]),
+      },
     })
 
     await expect(svc.previewBeforeFinalize('cycle-1')).resolves.toEqual({
       cycleId: 'cycle-1',
-      results: previewRows,
+      results: [
+        {
+          ...previewRows[0],
+          hasWeightOverride: false,
+          isNearGradeThreshold: false,
+          nearestGradeThresholdScore: null,
+          thresholdDistancePercent: null,
+        },
+      ],
     })
+  })
+
+  it('上書き有無と等級境界フラグを付けて返す', async () => {
+    const previewRows = [
+      {
+        id: 'ter-1',
+        cycleId: 'cycle-1',
+        subjectId: 'user-1',
+        gradeId: 'grade-a',
+        gradeLabel: 'G3',
+        performanceScore: 80,
+        goalScore: 70,
+        feedbackScore: 95,
+        incentiveAdjustment: 5,
+        performanceWeight: 0.4,
+        goalWeight: 0.4,
+        feedbackWeight: 0.2,
+        finalScore: 78,
+        status: 'CALCULATED' as const,
+        calculatedAt: new Date('2026-04-01T00:00:00.000Z'),
+      },
+    ]
+    const repo = makeRepo([])
+    repo.listPreviewResults = vi.fn().mockResolvedValue(previewRows)
+    repo.listWeightOverrides = vi.fn().mockResolvedValue([makeOverride()])
+    const svc = createTotalEvaluationService({
+      repository: repo,
+      gradeWeightProvider: makeGradeProvider(),
+      incentiveAdjustmentProvider: makeIncentives(),
+      gradeThresholdProvider: {
+        listThresholds: vi.fn().mockResolvedValue(makeBoundaryThresholds([80, 60])),
+      },
+    })
+
+    await expect(svc.previewBeforeFinalize('cycle-1')).resolves.toEqual({
+      cycleId: 'cycle-1',
+      results: [
+        {
+          ...previewRows[0],
+          hasWeightOverride: true,
+          isNearGradeThreshold: true,
+          nearestGradeThresholdScore: 80,
+          thresholdDistancePercent: 0.025,
+        },
+      ],
+    })
+  })
+})
+
+describe('TotalEvaluationService.overrideWeight', () => {
+  it('上書きウェイトを保存して再計算し、監査ログを記録する', async () => {
+    const repo = makeRepo([makeInput()])
+    const auditLogger = { emit: vi.fn().mockResolvedValue(undefined) }
+    const svc = createTotalEvaluationService({
+      repository: repo,
+      gradeWeightProvider: makeGradeProvider(),
+      incentiveAdjustmentProvider: makeIncentives(new Map([['user-1', 5]])),
+      auditLogger,
+    })
+
+    const result = await svc.overrideWeight({
+      cycleId: 'cycle-1',
+      subjectId: 'user-1',
+      performanceWeight: 0.4,
+      goalWeight: 0.4,
+      feedbackWeight: 0.2,
+      reason: '評価会議で調整',
+      adjustedBy: 'hr-1',
+      ipAddress: '127.0.0.1',
+      userAgent: 'vitest',
+    })
+
+    expect(repo.upsertWeightOverride).toHaveBeenCalledWith({
+      cycleId: 'cycle-1',
+      subjectId: 'user-1',
+      performanceWeight: 0.4,
+      goalWeight: 0.4,
+      feedbackWeight: 0.2,
+      reason: '評価会議で調整',
+      adjustedBy: 'hr-1',
+    })
+    expect(result).toEqual(
+      expect.objectContaining({
+        performanceWeight: 0.4,
+        goalWeight: 0.4,
+        feedbackWeight: 0.2,
+        feedbackScore: 95,
+        finalScore: 79,
+      }),
+    )
+    expect(auditLogger.emit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'hr-1',
+        action: 'RECORD_UPDATE',
+        resourceType: 'EVALUATION',
+        resourceId: 'user-1',
+        ipAddress: '127.0.0.1',
+        userAgent: 'vitest',
+        before: null,
+        after: expect.objectContaining({
+          cycleId: 'cycle-1',
+          subjectId: 'user-1',
+          reason: '評価会議で調整',
+        }),
+      }),
+    )
   })
 })
 


### PR DESCRIPTION
## Summary
- add HR_MANAGER weight override API for total evaluation
- recalculate total evaluation results with persisted per-user override weights and audit logging
- enrich preview results with override markers and near-threshold flags

## Testing
- pnpm vitest run src/tests/total-evaluation
- pnpm type-check
- pnpm build
- pnpm test