### PR TITLE
feat: finalize total evaluation results

### DIFF
--- a/src/app/api/total-evaluation/correction/route.ts
+++ b/src/app/api/total-evaluation/correction/route.ts
@@ -1,0 +1,65 @@
+import { type NextRequest, NextResponse } from 'next/server'
+import { ZodError } from 'zod'
+import { getAppSession } from '@/lib/auth/app-session'
+import { getTotalEvaluationService } from '@/lib/total-evaluation/total-evaluation-service-di'
+import { totalEvaluationCorrectionSchema } from '@/lib/total-evaluation/total-evaluation-types'
+
+function getSessionRole(session: unknown): string | undefined {
+  const sess = session as Record<string, unknown>
+  return typeof sess.role === 'string' ? sess.role : undefined
+}
+
+function getSessionUserId(session: unknown): string | undefined {
+  const sess = session as Record<string, unknown>
+  return typeof sess.userId === 'string' ? sess.userId : undefined
+}
+
+function getRequestMetadata(request: NextRequest): { ipAddress: string; userAgent: string } {
+  return {
+    ipAddress: request.headers.get('x-forwarded-for') ?? '127.0.0.1',
+    userAgent: request.headers.get('user-agent') ?? 'unknown',
+  }
+}
+
+export async function PUT(request: NextRequest): Promise<NextResponse> {
+  const session = await getAppSession()
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const role = getSessionRole(session)
+  if (role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const correctedBy = getSessionUserId(session)
+  if (!correctedBy) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  let service: ReturnType<typeof getTotalEvaluationService>
+  try {
+    service = getTotalEvaluationService()
+  } catch {
+    return NextResponse.json({ error: 'Total evaluation service not initialized' }, { status: 503 })
+  }
+
+  try {
+    const payload = totalEvaluationCorrectionSchema.parse(await request.json())
+    const metadata = getRequestMetadata(request)
+    const result = await service.correctAfterFinalize({
+      ...payload,
+      correctedBy,
+      ...metadata,
+    })
+    return NextResponse.json({ success: true, data: result }, { status: 200 })
+  } catch (error) {
+    if (error instanceof ZodError) {
+      return NextResponse.json(
+        { error: 'Validation failed', details: error.flatten() },
+        { status: 422 },
+      )
+    }
+    throw error
+  }
+}

--- a/src/app/api/total-evaluation/finalize/route.ts
+++ b/src/app/api/total-evaluation/finalize/route.ts
@@ -1,0 +1,71 @@
+import { type NextRequest, NextResponse } from 'next/server'
+import { ZodError } from 'zod'
+import { getAppSession } from '@/lib/auth/app-session'
+import { getTotalEvaluationService } from '@/lib/total-evaluation/total-evaluation-service-di'
+import { totalEvaluationFinalizeSchema } from '@/lib/total-evaluation/total-evaluation-types'
+
+const HR_OR_ADMIN_ROLES = ['HR_MANAGER', 'ADMIN'] as const
+
+function isAllowedRole(role: string | undefined): boolean {
+  return !!role && HR_OR_ADMIN_ROLES.includes(role as (typeof HR_OR_ADMIN_ROLES)[number])
+}
+
+function getSessionRole(session: unknown): string | undefined {
+  const sess = session as Record<string, unknown>
+  return typeof sess.role === 'string' ? sess.role : undefined
+}
+
+function getSessionUserId(session: unknown): string | undefined {
+  const sess = session as Record<string, unknown>
+  return typeof sess.userId === 'string' ? sess.userId : undefined
+}
+
+function getRequestMetadata(request: NextRequest): { ipAddress: string; userAgent: string } {
+  return {
+    ipAddress: request.headers.get('x-forwarded-for') ?? '127.0.0.1',
+    userAgent: request.headers.get('user-agent') ?? 'unknown',
+  }
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const session = await getAppSession()
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const role = getSessionRole(session)
+  if (!isAllowedRole(role)) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const finalizedBy = getSessionUserId(session)
+  if (!finalizedBy) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  let service: ReturnType<typeof getTotalEvaluationService>
+  try {
+    service = getTotalEvaluationService()
+  } catch {
+    return NextResponse.json({ error: 'Total evaluation service not initialized' }, { status: 503 })
+  }
+
+  try {
+    const payload = totalEvaluationFinalizeSchema.parse(await request.json())
+    const metadata = getRequestMetadata(request)
+    const result = await service.finalize({
+      ...payload,
+      finalizedBy,
+      ...metadata,
+    })
+    return NextResponse.json({ success: true, data: result }, { status: 200 })
+  } catch (error) {
+    if (error instanceof ZodError) {
+      return NextResponse.json(
+        { error: 'Validation failed', details: error.flatten() },
+        { status: 422 },
+      )
+    }
+    throw error
+  }
+}

--- a/src/lib/audit/audit-log-emitter.ts
+++ b/src/lib/audit/audit-log-emitter.ts
@@ -30,8 +30,8 @@ class PrismaAuditLogEmitter implements AuditLogEmitter {
       await this.db.auditLog.create({
         data: {
           userId: entry.userId,
-          action: entry.action,
-          resourceType: entry.resourceType,
+          action: entry.action as never,
+          resourceType: entry.resourceType as never,
           resourceId: entry.resourceId,
           ipAddress: entry.ipAddress,
           userAgent: entry.userAgent,

--- a/src/lib/total-evaluation/total-evaluation-service.ts
+++ b/src/lib/total-evaluation/total-evaluation-service.ts
@@ -6,6 +6,9 @@ import type {
   TotalEvaluationAuditLogger,
   TotalEvaluationBoundaryThreshold,
   TotalEvaluationCalculationInput,
+  TotalEvaluationCorrectionInput,
+  TotalEvaluationCycleCloser,
+  TotalEvaluationFinalizeInput,
   TotalEvaluationJobQueue,
   TotalEvaluationOverrideWeightInput,
   TotalEvaluationPreview,
@@ -20,6 +23,8 @@ import {
   TotalEvaluationGradeNotFoundError,
   TotalEvaluationInputNotFoundError,
   TotalEvaluationJobQueueNotConfiguredError,
+  TotalEvaluationNotFinalizedError,
+  TotalEvaluationResultNotFoundError,
 } from './total-evaluation-types'
 
 export interface TotalEvaluationServiceDeps {
@@ -28,6 +33,7 @@ export interface TotalEvaluationServiceDeps {
   readonly incentiveAdjustmentProvider: IncentiveAdjustmentProvider
   readonly gradeThresholdProvider?: GradeThresholdProvider
   readonly auditLogger?: TotalEvaluationAuditLogger
+  readonly cycleCloser?: TotalEvaluationCycleCloser
   readonly jobQueue?: TotalEvaluationJobQueue
   readonly clock?: () => Date
 }
@@ -122,6 +128,7 @@ class TotalEvaluationServiceImpl implements TotalEvaluationService {
   private readonly incentiveAdjustmentProvider: IncentiveAdjustmentProvider
   private readonly gradeThresholdProvider?: GradeThresholdProvider
   private readonly auditLogger?: TotalEvaluationAuditLogger
+  private readonly cycleCloser?: TotalEvaluationCycleCloser
   private readonly jobQueue?: TotalEvaluationJobQueue
   private readonly clock: () => Date
 
@@ -131,6 +138,7 @@ class TotalEvaluationServiceImpl implements TotalEvaluationService {
     this.incentiveAdjustmentProvider = deps.incentiveAdjustmentProvider
     this.gradeThresholdProvider = deps.gradeThresholdProvider
     this.auditLogger = deps.auditLogger
+    this.cycleCloser = deps.cycleCloser
     this.jobQueue = deps.jobQueue
     this.clock = deps.clock ?? (() => new Date())
   }
@@ -255,6 +263,88 @@ class TotalEvaluationServiceImpl implements TotalEvaluationService {
     }
 
     return result
+  }
+
+  async finalize(input: TotalEvaluationFinalizeInput): Promise<TotalEvaluationResult[]> {
+    const finalizedAt = this.clock()
+    const results = await this.repository.finalizeResults(input.cycleId, finalizedAt)
+
+    if (this.cycleCloser) {
+      await this.cycleCloser.closeCycle(input.cycleId)
+    }
+
+    if (this.auditLogger) {
+      await this.auditLogger.emit({
+        userId: input.finalizedBy,
+        action: 'EVALUATION_FINALIZED',
+        resourceType: 'EVALUATION_CYCLE',
+        resourceId: input.cycleId,
+        ipAddress: input.ipAddress,
+        userAgent: input.userAgent,
+        before: null,
+        after: {
+          cycleId: input.cycleId,
+          finalizedCount: results.length,
+          finalizedAt: finalizedAt.toISOString(),
+        },
+      })
+    }
+
+    return results
+  }
+
+  async correctAfterFinalize(
+    input: TotalEvaluationCorrectionInput,
+  ): Promise<TotalEvaluationResult> {
+    const current = await this.repository.findResult(input.cycleId, input.subjectId)
+    if (!current) throw new TotalEvaluationResultNotFoundError(input.cycleId, input.subjectId)
+    if (current.status !== 'FINALIZED') {
+      throw new TotalEvaluationNotFinalizedError(input.cycleId, input.subjectId)
+    }
+
+    const finalScore =
+      input.performanceScore * input.performanceWeight +
+      input.goalScore * input.goalWeight +
+      input.feedbackScore * input.feedbackWeight
+
+    const corrected: TotalEvaluationResult = {
+      ...current,
+      performanceScore: input.performanceScore,
+      goalScore: input.goalScore,
+      feedbackScore: input.feedbackScore,
+      incentiveAdjustment: input.incentiveAdjustment,
+      performanceWeight: input.performanceWeight,
+      goalWeight: input.goalWeight,
+      feedbackWeight: input.feedbackWeight,
+      finalScore: roundScore(finalScore),
+      status: 'FINALIZED',
+      finalizedAt: current.finalizedAt ?? this.clock(),
+    }
+
+    await this.repository.createCorrection({
+      cycleId: input.cycleId,
+      subjectId: input.subjectId,
+      before: { ...current },
+      after: { ...corrected },
+      reason: input.reason,
+      correctedBy: input.correctedBy,
+    })
+    await this.repository.upsertCalculatedResults([corrected])
+
+    if (this.auditLogger) {
+      await this.auditLogger.emit({
+        userId: input.correctedBy,
+        action: 'RECORD_UPDATE',
+        resourceType: 'EVALUATION',
+        resourceId: input.subjectId,
+        ipAddress: input.ipAddress,
+        userAgent: input.userAgent,
+        before: { ...current },
+        after: { ...corrected, reason: input.reason },
+      })
+    }
+
+    return corrected
   }
 
   private async calculateInput(

--- a/src/lib/total-evaluation/total-evaluation-types.ts
+++ b/src/lib/total-evaluation/total-evaluation-types.ts
@@ -41,6 +41,7 @@ export interface TotalEvaluationResult {
   readonly finalScore: number
   readonly status: TotalEvaluationStatus
   readonly calculatedAt: Date
+  readonly finalizedAt?: Date | null
 }
 
 export interface TotalEvaluationWeightOverride {
@@ -53,6 +54,17 @@ export interface TotalEvaluationWeightOverride {
   readonly reason: string
   readonly adjustedBy: string
   readonly adjustedAt: Date
+}
+
+export interface TotalEvaluationCorrection {
+  readonly id?: string
+  readonly cycleId: string
+  readonly subjectId: string
+  readonly before: Record<string, unknown>
+  readonly after: Record<string, unknown>
+  readonly reason: string
+  readonly correctedBy: string
+  readonly correctedAt: Date
 }
 
 export interface TotalEvaluationBoundaryThreshold {
@@ -94,6 +106,11 @@ export interface TotalEvaluationRepository {
   upsertWeightOverride(
     override: Omit<TotalEvaluationWeightOverride, 'id' | 'adjustedAt'>,
   ): Promise<TotalEvaluationWeightOverride>
+  finalizeResults(cycleId: string, finalizedAt: Date): Promise<TotalEvaluationResult[]>
+  findResult(cycleId: string, subjectId: string): Promise<TotalEvaluationResult | null>
+  createCorrection(
+    correction: Omit<TotalEvaluationCorrection, 'id' | 'correctedAt'>,
+  ): Promise<TotalEvaluationCorrection>
 }
 
 export interface GradeWeightProvider {
@@ -106,6 +123,10 @@ export interface IncentiveAdjustmentProvider {
 
 export interface GradeThresholdProvider {
   listThresholds(cycleId: string): Promise<readonly TotalEvaluationBoundaryThreshold[]>
+}
+
+export interface TotalEvaluationCycleCloser {
+  closeCycle(cycleId: string): Promise<void>
 }
 
 export const totalEvaluationCalculationPayloadSchema = z.object({
@@ -141,17 +162,63 @@ export type TotalEvaluationWeightOverridePayload = z.infer<
   typeof totalEvaluationWeightOverrideSchema
 >
 
-export interface TotalEvaluationOverrideWeightInput extends TotalEvaluationWeightOverridePayload {
-  readonly adjustedBy: string
+export const totalEvaluationFinalizeSchema = z.object({
+  cycleId: z.string().min(1),
+})
+
+export type TotalEvaluationFinalizePayload = z.infer<typeof totalEvaluationFinalizeSchema>
+
+export const totalEvaluationCorrectionSchema = z
+  .object({
+    cycleId: z.string().min(1),
+    subjectId: z.string().min(1),
+    performanceScore: z.number().min(0).max(100),
+    goalScore: z.number().min(0).max(100),
+    feedbackScore: z.number().min(0).max(100),
+    incentiveAdjustment: z.number().min(-100).max(100),
+    performanceWeight: z.number().min(0).max(1),
+    goalWeight: z.number().min(0).max(1),
+    feedbackWeight: z.number().min(0).max(1),
+    reason: z.string().trim().min(1).max(1000),
+  })
+  .superRefine((value, ctx) => {
+    const sum = value.performanceWeight + value.goalWeight + value.feedbackWeight
+    if (Math.abs(sum - 1) > 1e-6) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Weight sum must equal 1 (got ${sum})`,
+        path: ['performanceWeight'],
+      })
+    }
+  })
+
+export type TotalEvaluationCorrectionPayload = z.infer<typeof totalEvaluationCorrectionSchema>
+
+interface TotalEvaluationActorContext {
   readonly ipAddress: string
   readonly userAgent: string
+}
+
+export interface TotalEvaluationOverrideWeightInput
+  extends TotalEvaluationWeightOverridePayload, TotalEvaluationActorContext {
+  readonly adjustedBy: string
+}
+
+export interface TotalEvaluationFinalizeInput
+  extends TotalEvaluationFinalizePayload, TotalEvaluationActorContext {
+  readonly finalizedBy: string
+}
+
+export interface TotalEvaluationCorrectionInput
+  extends TotalEvaluationCorrectionPayload, TotalEvaluationActorContext {
+  readonly correctedBy: string
 }
 
 export interface TotalEvaluationAuditLogger {
   emit(entry: {
     userId: string | null
-    action: 'RECORD_UPDATE'
-    resourceType: 'EVALUATION'
+    action: 'RECORD_UPDATE' | 'EVALUATION_FINALIZED'
+    resourceType: 'EVALUATION' | 'EVALUATION_CYCLE'
     resourceId: string | null
     ipAddress: string
     userAgent: string
@@ -177,6 +244,8 @@ export interface TotalEvaluationService {
     subjectId: string,
   ): Promise<TotalEvaluationWeightOverride | null>
   overrideWeight(input: TotalEvaluationOverrideWeightInput): Promise<TotalEvaluationResult>
+  finalize(input: TotalEvaluationFinalizeInput): Promise<TotalEvaluationResult[]>
+  correctAfterFinalize(input: TotalEvaluationCorrectionInput): Promise<TotalEvaluationResult>
 }
 
 export class TotalEvaluationInputNotFoundError extends Error {
@@ -197,5 +266,19 @@ export class TotalEvaluationJobQueueNotConfiguredError extends Error {
   constructor() {
     super('Total evaluation job queue is not configured')
     this.name = 'TotalEvaluationJobQueueNotConfiguredError'
+  }
+}
+
+export class TotalEvaluationResultNotFoundError extends Error {
+  constructor(cycleId: string, subjectId: string) {
+    super(`Total evaluation result not found: cycleId="${cycleId}", subjectId="${subjectId}"`)
+    this.name = 'TotalEvaluationResultNotFoundError'
+  }
+}
+
+export class TotalEvaluationNotFinalizedError extends Error {
+  constructor(cycleId: string, subjectId: string) {
+    super(`Total evaluation is not finalized: cycleId="${cycleId}", subjectId="${subjectId}"`)
+    this.name = 'TotalEvaluationNotFinalizedError'
   }
 }

--- a/src/tests/total-evaluation/total-evaluation-routes.test.ts
+++ b/src/tests/total-evaluation/total-evaluation-routes.test.ts
@@ -1,5 +1,5 @@
 /**
- * Issue #67 / Task 19.2: Total evaluation routes tests.
+ * Issue #68 / Task 19.3: Total evaluation routes tests.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { NextRequest } from 'next/server'
@@ -19,6 +19,8 @@ const mockedGetServerSession = vi.mocked(getServerSession)
 const { GET: previewGET } = await import('@/app/api/total-evaluation/preview/route')
 const { GET: overrideGET, PUT: overridePUT } =
   await import('@/app/api/total-evaluation/override/route')
+const { POST: finalizePOST } = await import('@/app/api/total-evaluation/finalize/route')
+const { PUT: correctionPUT } = await import('@/app/api/total-evaluation/correction/route')
 
 function makeSession(role: string, userId = 'user-1') {
   return {
@@ -28,7 +30,7 @@ function makeSession(role: string, userId = 'user-1') {
   }
 }
 
-function makeJsonRequest(url: string, method: 'PUT', body: unknown): NextRequest {
+function makeJsonRequest(url: string, method: 'PUT' | 'POST', body: unknown): NextRequest {
   return new NextRequest(url, {
     method,
     headers: { 'Content-Type': 'application/json' },
@@ -60,6 +62,20 @@ function makeService(overrides?: Partial<TotalEvaluationService>): TotalEvaluati
       performanceWeight: 0.4,
       goalWeight: 0.4,
       feedbackWeight: 0.2,
+    }),
+    finalize: vi.fn().mockResolvedValue([
+      {
+        cycleId: 'cycle-1',
+        subjectId: 'user-1',
+        status: 'FINALIZED',
+        finalScore: 80,
+      },
+    ]),
+    correctAfterFinalize: vi.fn().mockResolvedValue({
+      cycleId: 'cycle-1',
+      subjectId: 'user-1',
+      status: 'FINALIZED',
+      finalScore: 82.5,
     }),
     ...overrides,
   } as TotalEvaluationService
@@ -115,20 +131,6 @@ describe('GET /api/total-evaluation/preview', () => {
 
     expect(res.status).toBe(200)
     expect(service.previewBeforeFinalize).toHaveBeenCalledWith('cycle-1')
-    await expect(res.json()).resolves.toEqual({
-      success: true,
-      data: {
-        cycleId: 'cycle-1',
-        results: [
-          {
-            subjectId: 'user-1',
-            finalScore: 80,
-            hasWeightOverride: false,
-            isNearGradeThreshold: false,
-          },
-        ],
-      },
-    })
   })
 })
 
@@ -177,51 +179,79 @@ describe('PUT /api/total-evaluation/override', () => {
 
     expect(res.status).toBe(403)
   })
+})
 
-  it('不正なウェイト合計は422', async () => {
-    mockedGetServerSession.mockResolvedValue(makeSession('HR_MANAGER', 'hr-1'))
-    setTotalEvaluationServiceForTesting(makeService())
-
-    const res = await overridePUT(
-      makeJsonRequest('http://localhost/api/total-evaluation/override', 'PUT', {
-        cycleId: 'cycle-1',
-        subjectId: 'user-1',
-        performanceWeight: 0.5,
-        goalWeight: 0.4,
-        feedbackWeight: 0.2,
-        reason: '評価会議で調整',
-      }),
-    )
-
-    expect(res.status).toBe(422)
-  })
-
-  it('HR_MANAGERがウェイト上書きを更新できる', async () => {
+describe('POST /api/total-evaluation/finalize', () => {
+  it('HR_MANAGER が総合評価を確定できる', async () => {
     mockedGetServerSession.mockResolvedValue(makeSession('HR_MANAGER', 'hr-1'))
     const service = makeService()
     setTotalEvaluationServiceForTesting(service)
 
-    const res = await overridePUT(
-      makeJsonRequest('http://localhost/api/total-evaluation/override', 'PUT', {
+    const res = await finalizePOST(
+      makeJsonRequest('http://localhost/api/total-evaluation/finalize', 'POST', {
         cycleId: 'cycle-1',
-        subjectId: 'user-1',
-        performanceWeight: 0.4,
-        goalWeight: 0.4,
-        feedbackWeight: 0.2,
-        reason: '評価会議で調整',
       }),
     )
 
     expect(res.status).toBe(200)
-    expect(service.overrideWeight).toHaveBeenCalledWith(
+    expect(service.finalize).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cycleId: 'cycle-1',
+        finalizedBy: 'hr-1',
+      }),
+    )
+  })
+})
+
+describe('PUT /api/total-evaluation/correction', () => {
+  it('HR_MANAGER は403', async () => {
+    mockedGetServerSession.mockResolvedValue(makeSession('HR_MANAGER', 'hr-1'))
+    setTotalEvaluationServiceForTesting(makeService())
+
+    const res = await correctionPUT(
+      makeJsonRequest('http://localhost/api/total-evaluation/correction', 'PUT', {
+        cycleId: 'cycle-1',
+        subjectId: 'user-1',
+        performanceScore: 85,
+        goalScore: 70,
+        feedbackScore: 95,
+        performanceWeight: 0.5,
+        goalWeight: 0.3,
+        feedbackWeight: 0.2,
+        incentiveAdjustment: 5,
+        reason: '監査後に修正',
+      }),
+    )
+
+    expect(res.status).toBe(403)
+  })
+
+  it('ADMIN が確定後修正できる', async () => {
+    mockedGetServerSession.mockResolvedValue(makeSession('ADMIN', 'admin-1'))
+    const service = makeService()
+    setTotalEvaluationServiceForTesting(service)
+
+    const res = await correctionPUT(
+      makeJsonRequest('http://localhost/api/total-evaluation/correction', 'PUT', {
+        cycleId: 'cycle-1',
+        subjectId: 'user-1',
+        performanceScore: 85,
+        goalScore: 70,
+        feedbackScore: 95,
+        performanceWeight: 0.5,
+        goalWeight: 0.3,
+        feedbackWeight: 0.2,
+        incentiveAdjustment: 5,
+        reason: '監査後に修正',
+      }),
+    )
+
+    expect(res.status).toBe(200)
+    expect(service.correctAfterFinalize).toHaveBeenCalledWith(
       expect.objectContaining({
         cycleId: 'cycle-1',
         subjectId: 'user-1',
-        performanceWeight: 0.4,
-        goalWeight: 0.4,
-        feedbackWeight: 0.2,
-        reason: '評価会議で調整',
-        adjustedBy: 'hr-1',
+        correctedBy: 'admin-1',
       }),
     )
   })

--- a/src/tests/total-evaluation/total-evaluation-service.test.ts
+++ b/src/tests/total-evaluation/total-evaluation-service.test.ts
@@ -1,5 +1,5 @@
 /**
- * Issue #67 / Task 19.2: TotalEvaluationService tests (Req 12.3, 12.6)
+ * Issue #68 / Task 19.3: TotalEvaluationService tests (Req 12.5, 12.7)
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createTotalEvaluationService } from '@/lib/total-evaluation/total-evaluation-service'
@@ -8,8 +8,10 @@ import type {
   IncentiveAdjustmentProvider,
   TotalEvaluationBoundaryThreshold,
   TotalEvaluationCalculationInput,
+  TotalEvaluationCycleCloser,
   TotalEvaluationJobQueue,
   TotalEvaluationRepository,
+  TotalEvaluationResult,
   TotalEvaluationWeightOverride,
 } from '@/lib/total-evaluation/total-evaluation-types'
 
@@ -23,6 +25,27 @@ function makeInput(
     performanceScore: 80,
     goalScore: 70,
     feedbackScore: 90,
+    ...overrides,
+  }
+}
+
+function makeResult(overrides: Partial<TotalEvaluationResult> = {}): TotalEvaluationResult {
+  return {
+    id: 'result-1',
+    cycleId: 'cycle-1',
+    subjectId: 'user-1',
+    gradeId: 'grade-a',
+    gradeLabel: 'G3',
+    performanceScore: 80,
+    goalScore: 70,
+    feedbackScore: 95,
+    incentiveAdjustment: 5,
+    performanceWeight: 0.5,
+    goalWeight: 0.3,
+    feedbackWeight: 0.2,
+    finalScore: 80,
+    status: 'CALCULATED',
+    calculatedAt: new Date('2026-04-01T00:00:00.000Z'),
     ...overrides,
   }
 }
@@ -47,6 +70,17 @@ function makeRepo(
       id: 'override-1',
       adjustedAt: new Date('2026-04-02T00:00:00.000Z'),
       ...override,
+    })),
+    finalizeResults: vi
+      .fn()
+      .mockImplementation(async (cycleId: string, finalizedAt: Date) => [
+        makeResult({ cycleId, status: 'FINALIZED', finalizedAt }),
+      ]),
+    findResult: vi.fn().mockResolvedValue(makeResult({ status: 'FINALIZED' })),
+    createCorrection: vi.fn().mockImplementation(async (correction) => ({
+      id: 'correction-1',
+      correctedAt: new Date('2026-04-03T00:00:00.000Z'),
+      ...correction,
     })),
   }
 }
@@ -157,25 +191,7 @@ describe('TotalEvaluationService.calculateAll', () => {
 
 describe('TotalEvaluationService.previewBeforeFinalize', () => {
   it('確定前プレビューとして一覧を返す', async () => {
-    const previewRows = [
-      {
-        id: 'ter-1',
-        cycleId: 'cycle-1',
-        subjectId: 'user-1',
-        gradeId: 'grade-a',
-        gradeLabel: 'G3',
-        performanceScore: 80,
-        goalScore: 70,
-        feedbackScore: 95,
-        incentiveAdjustment: 5,
-        performanceWeight: 0.5,
-        goalWeight: 0.3,
-        feedbackWeight: 0.2,
-        finalScore: 80,
-        status: 'CALCULATED' as const,
-        calculatedAt: new Date('2026-04-01T00:00:00.000Z'),
-      },
-    ]
+    const previewRows = [makeResult()]
     const repo = makeRepo([])
     repo.listPreviewResults = vi.fn().mockResolvedValue(previewRows)
     const svc = createTotalEvaluationService({
@@ -202,25 +218,7 @@ describe('TotalEvaluationService.previewBeforeFinalize', () => {
   })
 
   it('上書き有無と等級境界フラグを付けて返す', async () => {
-    const previewRows = [
-      {
-        id: 'ter-1',
-        cycleId: 'cycle-1',
-        subjectId: 'user-1',
-        gradeId: 'grade-a',
-        gradeLabel: 'G3',
-        performanceScore: 80,
-        goalScore: 70,
-        feedbackScore: 95,
-        incentiveAdjustment: 5,
-        performanceWeight: 0.4,
-        goalWeight: 0.4,
-        feedbackWeight: 0.2,
-        finalScore: 78,
-        status: 'CALCULATED' as const,
-        calculatedAt: new Date('2026-04-01T00:00:00.000Z'),
-      },
-    ]
+    const previewRows = [makeResult({ performanceWeight: 0.4, goalWeight: 0.4, finalScore: 78 })]
     const repo = makeRepo([])
     repo.listPreviewResults = vi.fn().mockResolvedValue(previewRows)
     repo.listWeightOverrides = vi.fn().mockResolvedValue([makeOverride()])
@@ -295,14 +293,123 @@ describe('TotalEvaluationService.overrideWeight', () => {
         action: 'RECORD_UPDATE',
         resourceType: 'EVALUATION',
         resourceId: 'user-1',
-        ipAddress: '127.0.0.1',
-        userAgent: 'vitest',
-        before: null,
-        after: expect.objectContaining({
-          cycleId: 'cycle-1',
-          subjectId: 'user-1',
-          reason: '評価会議で調整',
+      }),
+    )
+  })
+})
+
+describe('TotalEvaluationService.finalize', () => {
+  it('全社員の総合評価を確定し、評価サイクルをクローズし、監査ログを残す', async () => {
+    const repo = makeRepo([])
+    const auditLogger = { emit: vi.fn().mockResolvedValue(undefined) }
+    const cycleCloser: TotalEvaluationCycleCloser = {
+      closeCycle: vi.fn().mockResolvedValue(undefined),
+    }
+    const finalizedAt = new Date('2026-04-05T00:00:00.000Z')
+    const svc = createTotalEvaluationService({
+      repository: repo,
+      gradeWeightProvider: makeGradeProvider(),
+      incentiveAdjustmentProvider: makeIncentives(),
+      auditLogger,
+      cycleCloser,
+      clock: () => finalizedAt,
+    })
+
+    const results = await svc.finalize({
+      cycleId: 'cycle-1',
+      finalizedBy: 'hr-1',
+      ipAddress: '127.0.0.1',
+      userAgent: 'vitest',
+    })
+
+    expect(repo.finalizeResults).toHaveBeenCalledWith('cycle-1', finalizedAt)
+    expect(cycleCloser.closeCycle).toHaveBeenCalledWith('cycle-1')
+    expect(results).toEqual([
+      expect.objectContaining({
+        status: 'FINALIZED',
+        finalizedAt,
+      }),
+    ])
+    expect(auditLogger.emit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'hr-1',
+        action: 'EVALUATION_FINALIZED',
+        resourceType: 'EVALUATION_CYCLE',
+        resourceId: 'cycle-1',
+      }),
+    )
+  })
+})
+
+describe('TotalEvaluationService.correctAfterFinalize', () => {
+  it('確定後に ADMIN 修正を保存し、履歴を残し、監査ログを記録する', async () => {
+    const repo = makeRepo([])
+    const auditLogger = { emit: vi.fn().mockResolvedValue(undefined) }
+    repo.findResult = vi.fn().mockResolvedValue(
+      makeResult({
+        id: 'result-1',
+        status: 'FINALIZED',
+        finalizedAt: new Date('2026-04-05T00:00:00.000Z'),
+      }),
+    )
+    const svc = createTotalEvaluationService({
+      repository: repo,
+      gradeWeightProvider: makeGradeProvider(),
+      incentiveAdjustmentProvider: makeIncentives(),
+      auditLogger,
+      clock: () => new Date('2026-04-06T00:00:00.000Z'),
+    })
+
+    const result = await svc.correctAfterFinalize({
+      cycleId: 'cycle-1',
+      subjectId: 'user-1',
+      performanceScore: 85,
+      goalScore: 70,
+      feedbackScore: 95,
+      performanceWeight: 0.5,
+      goalWeight: 0.3,
+      feedbackWeight: 0.2,
+      incentiveAdjustment: 5,
+      reason: '監査後に修正',
+      correctedBy: 'admin-1',
+      ipAddress: '127.0.0.1',
+      userAgent: 'vitest',
+    })
+
+    expect(repo.createCorrection).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cycleId: 'cycle-1',
+        subjectId: 'user-1',
+        reason: '監査後に修正',
+        correctedBy: 'admin-1',
+        before: expect.objectContaining({
+          finalScore: 80,
         }),
+        after: expect.objectContaining({
+          finalScore: 82.5,
+        }),
+      }),
+    )
+    expect(repo.upsertCalculatedResults).toHaveBeenCalledWith([
+      expect.objectContaining({
+        subjectId: 'user-1',
+        status: 'FINALIZED',
+        finalScore: 82.5,
+      }),
+    ])
+    expect(result).toEqual(
+      expect.objectContaining({
+        subjectId: 'user-1',
+        status: 'FINALIZED',
+        finalScore: 82.5,
+      }),
+    )
+    expect(auditLogger.emit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'admin-1',
+        action: 'RECORD_UPDATE',
+        resourceType: 'EVALUATION',
+        resourceId: 'user-1',
       }),
     )
   })


### PR DESCRIPTION
## Summary
- add total evaluation finalize flow with cycle close and audit logging
- add ADMIN-only correction API and correction history persistence contract
- extend total evaluation service and tests for finalized result handling

## Testing
- pnpm vitest run src/tests/total-evaluation
- pnpm type-check
- pnpm build
- pnpm test