### PR TITLE
feat: add appeal submission flow

### DIFF
--- a/src/app/api/appeals/route.ts
+++ b/src/app/api/appeals/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { ZodError } from 'zod'
+import { getAppSession } from '@/lib/auth/app-session'
+import { getAppealService } from '@/lib/appeal/appeal-service-di'
+import {
+  AppealDeadlineExceededError,
+  AppealTargetNotFoundError,
+  appealInputSchema,
+} from '@/lib/appeal/appeal-types'
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const session = await getAppSession()
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const sess = session as Record<string, unknown>
+  const role = typeof sess.role === 'string' ? sess.role : undefined
+  const userId = typeof sess.userId === 'string' ? sess.userId : undefined
+  if (!userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  if (role !== 'EMPLOYEE') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  let service: ReturnType<typeof getAppealService>
+  try {
+    service = getAppealService()
+  } catch {
+    return NextResponse.json({ error: 'Appeal service not initialized' }, { status: 503 })
+  }
+
+  try {
+    const payload = appealInputSchema.parse(await request.json())
+    const result = await service.submitAppeal(userId, payload)
+    return NextResponse.json({ success: true, data: result }, { status: 201 })
+  } catch (error) {
+    if (error instanceof ZodError) {
+      return NextResponse.json(
+        { error: 'Validation failed', details: error.flatten() },
+        { status: 422 },
+      )
+    }
+    if (error instanceof AppealTargetNotFoundError) {
+      return NextResponse.json({ error: 'Appeal target not found' }, { status: 404 })
+    }
+    if (error instanceof AppealDeadlineExceededError) {
+      return NextResponse.json(
+        { error: 'Appeal deadline exceeded', deadline: error.deadline.toISOString() },
+        { status: 422 },
+      )
+    }
+    throw error
+  }
+}

--- a/src/lib/appeal/appeal-service-di.ts
+++ b/src/lib/appeal/appeal-service-di.ts
@@ -1,0 +1,26 @@
+import type { AppealService } from './appeal-types'
+
+let service: AppealService | null = null
+
+export function setAppealServiceForTesting(svc: AppealService): void {
+  service = svc
+}
+
+export function clearAppealServiceForTesting(): void {
+  service = null
+}
+
+export function initAppealService(svc: AppealService): void {
+  service = svc
+}
+
+export function getAppealService(): AppealService {
+  if (!service) {
+    throw new Error(
+      'AppealService is not initialized. ' +
+        'テストでは setAppealServiceForTesting() を呼んでください。' +
+        'プロダクションでは initAppealService() を呼んでください。',
+    )
+  }
+  return service
+}

--- a/src/lib/appeal/appeal-service.ts
+++ b/src/lib/appeal/appeal-service.ts
@@ -1,0 +1,91 @@
+import type {
+  Appeal,
+  AppealInput,
+  AppealNotificationPort,
+  AppealRepository,
+  AppealService,
+  AppealableTarget,
+} from './appeal-types'
+import { AppealDeadlineExceededError, AppealTargetNotFoundError } from './appeal-types'
+
+const APPEAL_WINDOW_DAYS = 14
+const MS_PER_DAY = 24 * 60 * 60 * 1000
+
+export interface AppealServiceDeps {
+  readonly repository: AppealRepository
+  readonly notificationEmitter?: AppealNotificationPort
+  readonly clock?: () => Date
+}
+
+function computeDeadline(publishedAt: Date): Date {
+  return new Date(publishedAt.getTime() + APPEAL_WINDOW_DAYS * MS_PER_DAY)
+}
+
+function assertWithinDeadline(target: AppealableTarget, now: Date): void {
+  const deadline = computeDeadline(target.publishedAt)
+  if (now.getTime() > deadline.getTime()) {
+    throw new AppealDeadlineExceededError(deadline)
+  }
+}
+
+class AppealServiceImpl implements AppealService {
+  private readonly repository: AppealRepository
+  private readonly notificationEmitter?: AppealNotificationPort
+  private readonly clock: () => Date
+
+  constructor(deps: AppealServiceDeps) {
+    this.repository = deps.repository
+    this.notificationEmitter = deps.notificationEmitter
+    this.clock = deps.clock ?? (() => new Date())
+  }
+
+  async submitAppeal(appellantId: string, input: AppealInput): Promise<Appeal> {
+    const target =
+      input.targetType === 'FEEDBACK'
+        ? await this.repository.findPublishedFeedbackTarget(input.targetId, appellantId)
+        : await this.repository.findFinalizedTotalEvaluationTarget(input.targetId, appellantId)
+
+    if (!target) {
+      throw new AppealTargetNotFoundError(input.targetType, input.targetId)
+    }
+
+    assertWithinDeadline(target, this.clock())
+
+    const appeal = await this.repository.createAppeal({
+      appellantId,
+      cycleId: target.cycleId,
+      subjectId: target.subjectId,
+      targetType: input.targetType,
+      targetId: input.targetId,
+      reason: input.reason,
+      desiredOutcome: input.desiredOutcome?.trim() || null,
+    })
+
+    const hrManagerIds = await this.repository.listHrManagerIds()
+    if (this.notificationEmitter) {
+      await Promise.all(
+        hrManagerIds.map((userId) =>
+          this.notificationEmitter!.emit({
+            userId,
+            category: 'SYSTEM',
+            title: '異議申立てが届きました',
+            body: `評価サイクル ${target.cycleId} の異議申立てが送信されました。`,
+            payload: {
+              appealId: appeal.id,
+              cycleId: appeal.cycleId,
+              subjectId: appeal.subjectId,
+              targetType: appeal.targetType,
+              targetId: appeal.targetId,
+            },
+          }),
+        ),
+      )
+    }
+
+    return appeal
+  }
+}
+
+export function createAppealService(deps: AppealServiceDeps): AppealService {
+  return new AppealServiceImpl(deps)
+}

--- a/src/lib/appeal/appeal-types.ts
+++ b/src/lib/appeal/appeal-types.ts
@@ -1,0 +1,94 @@
+import { z } from 'zod'
+
+export const APPEAL_TARGET_TYPES = ['FEEDBACK', 'TOTAL_EVALUATION'] as const
+export type AppealTargetType = (typeof APPEAL_TARGET_TYPES)[number]
+
+export const APPEAL_STATUSES = [
+  'SUBMITTED',
+  'UNDER_REVIEW',
+  'ACCEPTED',
+  'REJECTED',
+  'WITHDRAWN',
+] as const
+export type AppealStatus = (typeof APPEAL_STATUSES)[number]
+
+export interface Appeal {
+  readonly id: string
+  readonly appellantId: string
+  readonly cycleId: string
+  readonly subjectId: string
+  readonly targetType: AppealTargetType
+  readonly targetId: string
+  readonly reason: string
+  readonly desiredOutcome: string | null
+  readonly status: AppealStatus
+  readonly reviewerId: string | null
+  readonly reviewComment: string | null
+  readonly reviewedAt: Date | null
+  readonly submittedAt: Date
+}
+
+export interface AppealableTarget {
+  readonly cycleId: string
+  readonly subjectId: string
+  readonly targetId: string
+  readonly publishedAt: Date
+}
+
+export interface AppealRepository {
+  createAppeal(
+    input: Omit<
+      Appeal,
+      'id' | 'status' | 'reviewerId' | 'reviewComment' | 'reviewedAt' | 'submittedAt'
+    >,
+  ): Promise<Appeal>
+  findPublishedFeedbackTarget(
+    targetId: string,
+    appellantId: string,
+  ): Promise<AppealableTarget | null>
+  findFinalizedTotalEvaluationTarget(
+    targetId: string,
+    appellantId: string,
+  ): Promise<AppealableTarget | null>
+  listHrManagerIds(): Promise<string[]>
+}
+
+export interface AppealNotificationPort {
+  emit(event: {
+    userId: string
+    category: 'SYSTEM'
+    title: string
+    body: string
+    payload?: Record<string, unknown>
+  }): Promise<void>
+}
+
+export const appealInputSchema = z.object({
+  targetType: z.enum(APPEAL_TARGET_TYPES),
+  targetId: z.string().min(1),
+  reason: z.string().trim().min(1).max(2000),
+  desiredOutcome: z.string().trim().max(1000).optional(),
+})
+
+export type AppealInput = z.infer<typeof appealInputSchema>
+
+export interface AppealService {
+  submitAppeal(appellantId: string, input: AppealInput): Promise<Appeal>
+}
+
+export class AppealTargetNotFoundError extends Error {
+  constructor(targetType: AppealTargetType, targetId: string) {
+    super(`Appeal target not found: type="${targetType}", targetId="${targetId}"`)
+    this.name = 'AppealTargetNotFoundError'
+  }
+}
+
+export class AppealDeadlineExceededError extends Error {
+  readonly deadline: Date
+
+  constructor(deadline: Date) {
+    super(`Appeal deadline exceeded: deadline="${deadline.toISOString()}"`)
+    this.name = 'AppealDeadlineExceededError'
+    this.deadline = deadline
+  }
+}

--- a/src/tests/appeal/appeal-routes.test.ts
+++ b/src/tests/appeal/appeal-routes.test.ts
@@ -1,0 +1,167 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+import {
+  clearAppealServiceForTesting,
+  setAppealServiceForTesting,
+} from '@/lib/appeal/appeal-service-di'
+import type { AppealService } from '@/lib/appeal/appeal-types'
+import { AppealDeadlineExceededError, AppealTargetNotFoundError } from '@/lib/appeal/appeal-types'
+
+vi.mock('next-auth', () => ({
+  getServerSession: vi.fn(),
+}))
+
+const { getServerSession } = await import('next-auth')
+const mockedGetServerSession = vi.mocked(getServerSession)
+
+const { POST } = await import('@/app/api/appeals/route')
+
+function makeSession(role: string, userId = 'user-1') {
+  return {
+    user: { email: 'user@example.com' },
+    userId,
+    role,
+  }
+}
+
+function makeRequest(body: unknown): NextRequest {
+  return new NextRequest('http://localhost/api/appeals', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+function makeService(overrides?: Partial<AppealService>): AppealService {
+  return {
+    submitAppeal: vi.fn().mockResolvedValue({
+      id: 'appeal-1',
+      appellantId: 'emp-1',
+      cycleId: 'cycle-1',
+      subjectId: 'emp-1',
+      targetType: 'FEEDBACK',
+      targetId: 'feedback-1',
+      reason: '内容に事実誤認があります',
+      desiredOutcome: '再確認してほしい',
+      status: 'SUBMITTED',
+      reviewerId: null,
+      reviewComment: null,
+      reviewedAt: null,
+      submittedAt: new Date('2026-04-20T00:00:00.000Z'),
+    }),
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+afterEach(() => {
+  clearAppealServiceForTesting()
+})
+
+describe('POST /api/appeals', () => {
+  it('未認証は401', async () => {
+    mockedGetServerSession.mockResolvedValue(null)
+
+    const res = await POST(
+      makeRequest({
+        targetType: 'FEEDBACK',
+        targetId: 'feedback-1',
+        reason: '内容に事実誤認があります',
+      }),
+    )
+
+    expect(res.status).toBe(401)
+  })
+
+  it('EMPLOYEE 以外は403', async () => {
+    mockedGetServerSession.mockResolvedValue(makeSession('HR_MANAGER'))
+    setAppealServiceForTesting(makeService())
+
+    const res = await POST(
+      makeRequest({
+        targetType: 'FEEDBACK',
+        targetId: 'feedback-1',
+        reason: '内容に事実誤認があります',
+      }),
+    )
+
+    expect(res.status).toBe(403)
+  })
+
+  it('不正payloadは422', async () => {
+    mockedGetServerSession.mockResolvedValue(makeSession('EMPLOYEE', 'emp-1'))
+    setAppealServiceForTesting(makeService())
+
+    const res = await POST(makeRequest({ targetType: 'FEEDBACK', targetId: '' }))
+
+    expect(res.status).toBe(422)
+  })
+
+  it('対象が見つからない場合は404', async () => {
+    mockedGetServerSession.mockResolvedValue(makeSession('EMPLOYEE', 'emp-1'))
+    setAppealServiceForTesting(
+      makeService({
+        submitAppeal: vi
+          .fn()
+          .mockRejectedValue(new AppealTargetNotFoundError('FEEDBACK', 'feedback-1')),
+      }),
+    )
+
+    const res = await POST(
+      makeRequest({
+        targetType: 'FEEDBACK',
+        targetId: 'feedback-1',
+        reason: '内容に事実誤認があります',
+      }),
+    )
+
+    expect(res.status).toBe(404)
+  })
+
+  it('期限超過は422', async () => {
+    mockedGetServerSession.mockResolvedValue(makeSession('EMPLOYEE', 'emp-1'))
+    setAppealServiceForTesting(
+      makeService({
+        submitAppeal: vi
+          .fn()
+          .mockRejectedValue(new AppealDeadlineExceededError(new Date('2026-04-15T00:00:00.000Z'))),
+      }),
+    )
+
+    const res = await POST(
+      makeRequest({
+        targetType: 'FEEDBACK',
+        targetId: 'feedback-1',
+        reason: '期限切れ確認',
+      }),
+    )
+
+    expect(res.status).toBe(422)
+  })
+
+  it('EMPLOYEE が異議申立てを送信できる', async () => {
+    mockedGetServerSession.mockResolvedValue(makeSession('EMPLOYEE', 'emp-1'))
+    const service = makeService()
+    setAppealServiceForTesting(service)
+
+    const res = await POST(
+      makeRequest({
+        targetType: 'TOTAL_EVALUATION',
+        targetId: 'result-1',
+        reason: '総合評価の根拠を確認したい',
+        desiredOutcome: '評価内容を見直してほしい',
+      }),
+    )
+
+    expect(res.status).toBe(201)
+    expect(service.submitAppeal).toHaveBeenCalledWith('emp-1', {
+      targetType: 'TOTAL_EVALUATION',
+      targetId: 'result-1',
+      reason: '総合評価の根拠を確認したい',
+      desiredOutcome: '評価内容を見直してほしい',
+    })
+  })
+})

--- a/src/tests/appeal/appeal-service.test.ts
+++ b/src/tests/appeal/appeal-service.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createAppealService } from '@/lib/appeal/appeal-service'
+import type {
+  Appeal,
+  AppealNotificationPort,
+  AppealRepository,
+  AppealableTarget,
+} from '@/lib/appeal/appeal-types'
+import { AppealDeadlineExceededError, AppealTargetNotFoundError } from '@/lib/appeal/appeal-types'
+
+function makeTarget(overrides: Partial<AppealableTarget> = {}): AppealableTarget {
+  return {
+    cycleId: 'cycle-1',
+    subjectId: 'emp-1',
+    targetId: 'target-1',
+    publishedAt: new Date('2026-04-10T00:00:00.000Z'),
+    ...overrides,
+  }
+}
+
+function makeAppeal(overrides: Partial<Appeal> = {}): Appeal {
+  return {
+    id: 'appeal-1',
+    appellantId: 'emp-1',
+    cycleId: 'cycle-1',
+    subjectId: 'emp-1',
+    targetType: 'FEEDBACK',
+    targetId: 'target-1',
+    reason: '内容に事実誤認があります',
+    desiredOutcome: '再確認してほしい',
+    status: 'SUBMITTED',
+    reviewerId: null,
+    reviewComment: null,
+    reviewedAt: null,
+    submittedAt: new Date('2026-04-12T00:00:00.000Z'),
+    ...overrides,
+  }
+}
+
+function makeRepository(): AppealRepository {
+  return {
+    createAppeal: vi.fn().mockImplementation(async (input) =>
+      makeAppeal({
+        appellantId: input.appellantId,
+        cycleId: input.cycleId,
+        subjectId: input.subjectId,
+        targetType: input.targetType,
+        targetId: input.targetId,
+        reason: input.reason,
+        desiredOutcome: input.desiredOutcome,
+      }),
+    ),
+    findPublishedFeedbackTarget: vi.fn().mockResolvedValue(makeTarget()),
+    findFinalizedTotalEvaluationTarget: vi.fn().mockResolvedValue(makeTarget()),
+    listHrManagerIds: vi.fn().mockResolvedValue(['hr-1', 'hr-2']),
+  }
+}
+
+describe('AppealService.submitAppeal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('公開済みフィードバックへの異議申立てを保存し HR_MANAGER に通知する', async () => {
+    const repository = makeRepository()
+    const notificationEmitter: AppealNotificationPort = {
+      emit: vi.fn().mockResolvedValue(undefined),
+    }
+    const service = createAppealService({
+      repository,
+      notificationEmitter,
+      clock: () => new Date('2026-04-20T00:00:00.000Z'),
+    })
+
+    const result = await service.submitAppeal('emp-1', {
+      targetType: 'FEEDBACK',
+      targetId: 'feedback-1',
+      reason: '内容に事実誤認があります',
+      desiredOutcome: '再確認してほしい',
+    })
+
+    expect(repository.findPublishedFeedbackTarget).toHaveBeenCalledWith('feedback-1', 'emp-1')
+    expect(repository.createAppeal).toHaveBeenCalledWith({
+      appellantId: 'emp-1',
+      cycleId: 'cycle-1',
+      subjectId: 'emp-1',
+      targetType: 'FEEDBACK',
+      targetId: 'feedback-1',
+      reason: '内容に事実誤認があります',
+      desiredOutcome: '再確認してほしい',
+    })
+    expect(notificationEmitter.emit).toHaveBeenCalledTimes(2)
+    expect(result).toEqual(
+      expect.objectContaining({
+        appellantId: 'emp-1',
+        targetType: 'FEEDBACK',
+        targetId: 'feedback-1',
+      }),
+    )
+  })
+
+  it('公開日から14日を超えた場合は期限超過エラー', async () => {
+    const repository = makeRepository()
+    repository.findPublishedFeedbackTarget = vi.fn().mockResolvedValue(
+      makeTarget({
+        publishedAt: new Date('2026-04-01T00:00:00.000Z'),
+      }),
+    )
+    const service = createAppealService({
+      repository,
+      clock: () => new Date('2026-04-20T00:00:01.000Z'),
+    })
+
+    await expect(
+      service.submitAppeal('emp-1', {
+        targetType: 'FEEDBACK',
+        targetId: 'feedback-1',
+        reason: '期限切れ確認',
+      }),
+    ).rejects.toBeInstanceOf(AppealDeadlineExceededError)
+  })
+
+  it('対象が見つからない場合は not found エラー', async () => {
+    const repository = makeRepository()
+    repository.findFinalizedTotalEvaluationTarget = vi.fn().mockResolvedValue(null)
+    const service = createAppealService({
+      repository,
+      clock: () => new Date('2026-04-20T00:00:00.000Z'),
+    })
+
+    await expect(
+      service.submitAppeal('emp-1', {
+        targetType: 'TOTAL_EVALUATION',
+        targetId: 'result-1',
+        reason: '総合評価の根拠を確認したい',
+      }),
+    ).rejects.toBeInstanceOf(AppealTargetNotFoundError)
+  })
+})


### PR DESCRIPTION
## Summary
- add the employee appeal submission service and API for feedback and total evaluation results
- enforce the 14-day appeal deadline and return explicit 404/422 responses for invalid requests
- notify HR managers when an appeal is submitted and cover the flow with service and route tests

## Issue
- Addresses #69

## Verification
- pnpm vitest run src/tests/appeal/appeal-service.test.ts src/tests/appeal/appeal-routes.test.ts
- pnpm type-check
- pnpm build
- pnpm test