### PR TITLE
feat: add appeal review workflow

### DIFF
--- a/src/app/api/appeals/[appealId]/route.ts
+++ b/src/app/api/appeals/[appealId]/route.ts
@@ -1,0 +1,73 @@
+import { type NextRequest, NextResponse } from 'next/server'
+import { ZodError } from 'zod'
+import { getAppSession } from '@/lib/auth/app-session'
+import { getAppealService } from '@/lib/appeal/appeal-service-di'
+import {
+  AppealInvalidStatusTransitionError,
+  AppealNotFoundError,
+  appealReviewInputSchema,
+} from '@/lib/appeal/appeal-types'
+
+const HR_OR_ADMIN_ROLES = ['HR_MANAGER', 'ADMIN'] as const
+
+function isAllowedRole(role: string | undefined): boolean {
+  return !!role && HR_OR_ADMIN_ROLES.includes(role as (typeof HR_OR_ADMIN_ROLES)[number])
+}
+
+function getSessionRole(session: unknown): string | undefined {
+  const sess = session as Record<string, unknown>
+  return typeof sess.role === 'string' ? sess.role : undefined
+}
+
+function getSessionUserId(session: unknown): string | undefined {
+  const sess = session as Record<string, unknown>
+  return typeof sess.userId === 'string' ? sess.userId : undefined
+}
+
+export async function PATCH(
+  request: NextRequest,
+  context: { params: Promise<{ appealId: string }> },
+): Promise<NextResponse> {
+  const session = await getAppSession()
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const role = getSessionRole(session)
+  if (!isAllowedRole(role)) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const userId = getSessionUserId(session)
+  if (!userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  let service: ReturnType<typeof getAppealService>
+  try {
+    service = getAppealService()
+  } catch {
+    return NextResponse.json({ error: 'Appeal service not initialized' }, { status: 503 })
+  }
+
+  try {
+    const payload = appealReviewInputSchema.parse(await request.json())
+    const { appealId } = await context.params
+    const result = await service.review(userId, appealId, payload)
+    return NextResponse.json({ success: true, data: result }, { status: 200 })
+  } catch (error) {
+    if (error instanceof ZodError) {
+      return NextResponse.json(
+        { error: 'Validation failed', details: error.flatten() },
+        { status: 422 },
+      )
+    }
+    if (error instanceof AppealNotFoundError) {
+      return NextResponse.json({ error: 'Appeal not found' }, { status: 404 })
+    }
+    if (error instanceof AppealInvalidStatusTransitionError) {
+      return NextResponse.json({ error: error.message }, { status: 409 })
+    }
+    throw error
+  }
+}

--- a/src/app/api/appeals/route.ts
+++ b/src/app/api/appeals/route.ts
@@ -8,6 +8,8 @@ import {
   appealInputSchema,
 } from '@/lib/appeal/appeal-types'
 
+const HR_OR_ADMIN_ROLES = ['HR_MANAGER', 'ADMIN'] as const
+
 export async function POST(request: NextRequest): Promise<NextResponse> {
   const session = await getAppSession()
   if (!session?.user?.email) {
@@ -53,4 +55,31 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     }
     throw error
   }
+}
+
+export async function GET(): Promise<NextResponse> {
+  const session = await getAppSession()
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const sess = session as Record<string, unknown>
+  const role = typeof sess.role === 'string' ? sess.role : undefined
+  const userId = typeof sess.userId === 'string' ? sess.userId : undefined
+  if (!userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  if (!role || !HR_OR_ADMIN_ROLES.includes(role as (typeof HR_OR_ADMIN_ROLES)[number])) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  let service: ReturnType<typeof getAppealService>
+  try {
+    service = getAppealService()
+  } catch {
+    return NextResponse.json({ error: 'Appeal service not initialized' }, { status: 503 })
+  }
+
+  const result = await service.listPending(userId)
+  return NextResponse.json({ success: true, data: result }, { status: 200 })
 }

--- a/src/lib/appeal/appeal-service.ts
+++ b/src/lib/appeal/appeal-service.ts
@@ -3,13 +3,34 @@ import type {
   AppealInput,
   AppealNotificationPort,
   AppealRepository,
+  AppealReviewInput,
   AppealService,
+  AppealStatus,
   AppealableTarget,
 } from './appeal-types'
-import { AppealDeadlineExceededError, AppealTargetNotFoundError } from './appeal-types'
+import {
+  AppealDeadlineExceededError,
+  AppealInvalidStatusTransitionError,
+  AppealNotFoundError,
+  AppealTargetNotFoundError,
+} from './appeal-types'
 
 const APPEAL_WINDOW_DAYS = 14
 const MS_PER_DAY = 24 * 60 * 60 * 1000
+const UNRESOLVED_PRIORITY: Record<AppealStatus, number> = {
+  SUBMITTED: 0,
+  UNDER_REVIEW: 1,
+  ACCEPTED: 2,
+  REJECTED: 3,
+  WITHDRAWN: 4,
+}
+const ALLOWED_REVIEW_TRANSITIONS: Record<AppealStatus, readonly AppealReviewInput['status'][]> = {
+  SUBMITTED: ['UNDER_REVIEW'],
+  UNDER_REVIEW: ['ACCEPTED', 'REJECTED', 'WITHDRAWN'],
+  ACCEPTED: [],
+  REJECTED: [],
+  WITHDRAWN: [],
+}
 
 export interface AppealServiceDeps {
   readonly repository: AppealRepository
@@ -26,6 +47,19 @@ function assertWithinDeadline(target: AppealableTarget, now: Date): void {
   if (now.getTime() > deadline.getTime()) {
     throw new AppealDeadlineExceededError(deadline)
   }
+}
+
+function assertReviewTransition(current: AppealStatus, next: AppealReviewInput['status']): void {
+  const allowed = ALLOWED_REVIEW_TRANSITIONS[current]
+  if (!allowed.includes(next)) {
+    throw new AppealInvalidStatusTransitionError(current, next)
+  }
+}
+
+function sortAppealsForReview(left: Appeal, right: Appeal): number {
+  const priorityGap = UNRESOLVED_PRIORITY[left.status] - UNRESOLVED_PRIORITY[right.status]
+  if (priorityGap !== 0) return priorityGap
+  return right.submittedAt.getTime() - left.submittedAt.getTime()
 }
 
 class AppealServiceImpl implements AppealService {
@@ -83,6 +117,43 @@ class AppealServiceImpl implements AppealService {
     }
 
     return appeal
+  }
+
+  async listPending(_hrManagerId: string): Promise<Appeal[]> {
+    const appeals = await this.repository.listAppeals()
+    return [...appeals].sort(sortAppealsForReview)
+  }
+
+  async review(hrManagerId: string, appealId: string, input: AppealReviewInput): Promise<Appeal> {
+    const appeal = await this.repository.findAppealById(appealId)
+    if (!appeal) {
+      throw new AppealNotFoundError(appealId)
+    }
+
+    assertReviewTransition(appeal.status, input.status)
+
+    const reviewedAppeal = await this.repository.updateAppealReview(appealId, {
+      status: input.status,
+      reviewerId: hrManagerId,
+      reviewComment: input.reviewComment.trim(),
+      reviewedAt: this.clock(),
+    })
+
+    if (this.notificationEmitter) {
+      await this.notificationEmitter.emit({
+        userId: reviewedAppeal.appellantId,
+        category: 'SYSTEM',
+        title: '異議申立ての審査ステータスが更新されました',
+        body: `異議申立てのステータスが ${reviewedAppeal.status} に更新されました。`,
+        payload: {
+          appealId: reviewedAppeal.id,
+          status: reviewedAppeal.status,
+          reviewComment: reviewedAppeal.reviewComment,
+        },
+      })
+    }
+
+    return reviewedAppeal
   }
 }
 

--- a/src/lib/appeal/appeal-types.ts
+++ b/src/lib/appeal/appeal-types.ts
@@ -28,6 +28,11 @@ export interface Appeal {
   readonly submittedAt: Date
 }
 
+export interface AppealReviewInput {
+  readonly status: Extract<AppealStatus, 'UNDER_REVIEW' | 'ACCEPTED' | 'REJECTED' | 'WITHDRAWN'>
+  readonly reviewComment: string
+}
+
 export interface AppealableTarget {
   readonly cycleId: string
   readonly subjectId: string
@@ -51,6 +56,17 @@ export interface AppealRepository {
     appellantId: string,
   ): Promise<AppealableTarget | null>
   listHrManagerIds(): Promise<string[]>
+  listAppeals(): Promise<Appeal[]>
+  findAppealById(appealId: string): Promise<Appeal | null>
+  updateAppealReview(
+    appealId: string,
+    input: {
+      status: AppealStatus
+      reviewerId: string
+      reviewComment: string
+      reviewedAt: Date
+    },
+  ): Promise<Appeal>
 }
 
 export interface AppealNotificationPort {
@@ -72,8 +88,15 @@ export const appealInputSchema = z.object({
 
 export type AppealInput = z.infer<typeof appealInputSchema>
 
+export const appealReviewInputSchema = z.object({
+  status: z.enum(['UNDER_REVIEW', 'ACCEPTED', 'REJECTED', 'WITHDRAWN']),
+  reviewComment: z.string().trim().min(1).max(2000),
+})
+
 export interface AppealService {
   submitAppeal(appellantId: string, input: AppealInput): Promise<Appeal>
+  listPending(hrManagerId: string): Promise<Appeal[]>
+  review(hrManagerId: string, appealId: string, input: AppealReviewInput): Promise<Appeal>
 }
 
 export class AppealTargetNotFoundError extends Error {
@@ -90,5 +113,19 @@ export class AppealDeadlineExceededError extends Error {
     super(`Appeal deadline exceeded: deadline="${deadline.toISOString()}"`)
     this.name = 'AppealDeadlineExceededError'
     this.deadline = deadline
+  }
+}
+
+export class AppealNotFoundError extends Error {
+  constructor(appealId: string) {
+    super(`Appeal not found: appealId="${appealId}"`)
+    this.name = 'AppealNotFoundError'
+  }
+}
+
+export class AppealInvalidStatusTransitionError extends Error {
+  constructor(current: AppealStatus, next: AppealStatus) {
+    super(`Invalid appeal status transition: current="${current}", next="${next}"`)
+    this.name = 'AppealInvalidStatusTransitionError'
   }
 }

--- a/src/tests/appeal/appeal-routes.test.ts
+++ b/src/tests/appeal/appeal-routes.test.ts
@@ -5,7 +5,12 @@ import {
   setAppealServiceForTesting,
 } from '@/lib/appeal/appeal-service-di'
 import type { AppealService } from '@/lib/appeal/appeal-types'
-import { AppealDeadlineExceededError, AppealTargetNotFoundError } from '@/lib/appeal/appeal-types'
+import {
+  AppealDeadlineExceededError,
+  AppealInvalidStatusTransitionError,
+  AppealNotFoundError,
+  AppealTargetNotFoundError,
+} from '@/lib/appeal/appeal-types'
 
 vi.mock('next-auth', () => ({
   getServerSession: vi.fn(),
@@ -14,7 +19,8 @@ vi.mock('next-auth', () => ({
 const { getServerSession } = await import('next-auth')
 const mockedGetServerSession = vi.mocked(getServerSession)
 
-const { POST } = await import('@/app/api/appeals/route')
+const { GET, POST } = await import('@/app/api/appeals/route')
+const { PATCH } = await import('@/app/api/appeals/[appealId]/route')
 
 function makeSession(role: string, userId = 'user-1') {
   return {
@@ -24,9 +30,17 @@ function makeSession(role: string, userId = 'user-1') {
   }
 }
 
-function makeRequest(body: unknown): NextRequest {
+function makePostRequest(body: unknown): NextRequest {
   return new NextRequest('http://localhost/api/appeals', {
     method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+function makePatchRequest(appealId: string, body: unknown): NextRequest {
+  return new NextRequest(`http://localhost/api/appeals/${appealId}`, {
+    method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
   })
@@ -41,12 +55,44 @@ function makeService(overrides?: Partial<AppealService>): AppealService {
       subjectId: 'emp-1',
       targetType: 'FEEDBACK',
       targetId: 'feedback-1',
-      reason: '内容に事実誤認があります',
+      reason: '評価内容に差異があります',
       desiredOutcome: '再確認してほしい',
       status: 'SUBMITTED',
       reviewerId: null,
       reviewComment: null,
       reviewedAt: null,
+      submittedAt: new Date('2026-04-20T00:00:00.000Z'),
+    }),
+    listPending: vi.fn().mockResolvedValue([
+      {
+        id: 'appeal-1',
+        appellantId: 'emp-1',
+        cycleId: 'cycle-1',
+        subjectId: 'emp-1',
+        targetType: 'FEEDBACK',
+        targetId: 'feedback-1',
+        reason: '理由',
+        desiredOutcome: '再確認',
+        status: 'SUBMITTED',
+        reviewerId: null,
+        reviewComment: null,
+        reviewedAt: null,
+        submittedAt: new Date('2026-04-20T00:00:00.000Z'),
+      },
+    ]),
+    review: vi.fn().mockResolvedValue({
+      id: 'appeal-1',
+      appellantId: 'emp-1',
+      cycleId: 'cycle-1',
+      subjectId: 'emp-1',
+      targetType: 'FEEDBACK',
+      targetId: 'feedback-1',
+      reason: '理由',
+      desiredOutcome: '再確認',
+      status: 'UNDER_REVIEW',
+      reviewerId: 'hr-1',
+      reviewComment: '確認開始',
+      reviewedAt: new Date('2026-04-21T00:00:00.000Z'),
       submittedAt: new Date('2026-04-20T00:00:00.000Z'),
     }),
     ...overrides,
@@ -66,62 +112,110 @@ describe('POST /api/appeals', () => {
     mockedGetServerSession.mockResolvedValue(null)
 
     const res = await POST(
-      makeRequest({
+      makePostRequest({
         targetType: 'FEEDBACK',
         targetId: 'feedback-1',
-        reason: '内容に事実誤認があります',
+        reason: '評価内容に差異があります',
       }),
     )
 
     expect(res.status).toBe(401)
   })
 
-  it('EMPLOYEE 以外は403', async () => {
-    mockedGetServerSession.mockResolvedValue(makeSession('HR_MANAGER'))
-    setAppealServiceForTesting(makeService())
-
-    const res = await POST(
-      makeRequest({
-        targetType: 'FEEDBACK',
-        targetId: 'feedback-1',
-        reason: '内容に事実誤認があります',
-      }),
-    )
-
-    expect(res.status).toBe(403)
-  })
-
-  it('不正payloadは422', async () => {
+  it('不正 payload は422', async () => {
     mockedGetServerSession.mockResolvedValue(makeSession('EMPLOYEE', 'emp-1'))
     setAppealServiceForTesting(makeService())
 
-    const res = await POST(makeRequest({ targetType: 'FEEDBACK', targetId: '' }))
+    const res = await POST(makePostRequest({ targetType: 'FEEDBACK', targetId: '' }))
 
     expect(res.status).toBe(422)
   })
+})
 
-  it('対象が見つからない場合は404', async () => {
+describe('GET /api/appeals', () => {
+  it('HR_MANAGER が一覧を取得できる', async () => {
+    mockedGetServerSession.mockResolvedValue(makeSession('HR_MANAGER', 'hr-1'))
+    const service = makeService()
+    setAppealServiceForTesting(service)
+
+    const res = await GET()
+
+    expect(res.status).toBe(200)
+    expect(service.listPending).toHaveBeenCalledWith('hr-1')
+  })
+
+  it('EMPLOYEE は403', async () => {
     mockedGetServerSession.mockResolvedValue(makeSession('EMPLOYEE', 'emp-1'))
+    setAppealServiceForTesting(makeService())
+
+    const res = await GET()
+
+    expect(res.status).toBe(403)
+  })
+})
+
+describe('PATCH /api/appeals/[appealId]', () => {
+  it('HR_MANAGER が審査更新できる', async () => {
+    mockedGetServerSession.mockResolvedValue(makeSession('HR_MANAGER', 'hr-1'))
+    const service = makeService()
+    setAppealServiceForTesting(service)
+
+    const res = await PATCH(
+      makePatchRequest('appeal-1', {
+        status: 'UNDER_REVIEW',
+        reviewComment: '確認開始',
+      }),
+      { params: Promise.resolve({ appealId: 'appeal-1' }) },
+    )
+
+    expect(res.status).toBe(200)
+    expect(service.review).toHaveBeenCalledWith('hr-1', 'appeal-1', {
+      status: 'UNDER_REVIEW',
+      reviewComment: '確認開始',
+    })
+  })
+
+  it('存在しない appeal は404', async () => {
+    mockedGetServerSession.mockResolvedValue(makeSession('HR_MANAGER', 'hr-1'))
     setAppealServiceForTesting(
       makeService({
-        submitAppeal: vi
-          .fn()
-          .mockRejectedValue(new AppealTargetNotFoundError('FEEDBACK', 'feedback-1')),
+        review: vi.fn().mockRejectedValue(new AppealNotFoundError('appeal-404')),
       }),
     )
 
-    const res = await POST(
-      makeRequest({
-        targetType: 'FEEDBACK',
-        targetId: 'feedback-1',
-        reason: '内容に事実誤認があります',
+    const res = await PATCH(
+      makePatchRequest('appeal-404', {
+        status: 'UNDER_REVIEW',
+        reviewComment: '確認開始',
       }),
+      { params: Promise.resolve({ appealId: 'appeal-404' }) },
     )
 
     expect(res.status).toBe(404)
   })
 
-  it('期限超過は422', async () => {
+  it('不正な遷移は409', async () => {
+    mockedGetServerSession.mockResolvedValue(makeSession('HR_MANAGER', 'hr-1'))
+    setAppealServiceForTesting(
+      makeService({
+        review: vi
+          .fn()
+          .mockRejectedValue(new AppealInvalidStatusTransitionError('SUBMITTED', 'ACCEPTED')),
+      }),
+    )
+
+    const res = await PATCH(
+      makePatchRequest('appeal-1', {
+        status: 'ACCEPTED',
+        reviewComment: 'いきなり認容',
+      }),
+      { params: Promise.resolve({ appealId: 'appeal-1' }) },
+    )
+
+    expect(res.status).toBe(409)
+  })
+
+  it('期限超過エラーは submit 側で422', async () => {
     mockedGetServerSession.mockResolvedValue(makeSession('EMPLOYEE', 'emp-1'))
     setAppealServiceForTesting(
       makeService({
@@ -132,36 +226,34 @@ describe('POST /api/appeals', () => {
     )
 
     const res = await POST(
-      makeRequest({
+      makePostRequest({
         targetType: 'FEEDBACK',
         targetId: 'feedback-1',
-        reason: '期限切れ確認',
+        reason: '期限切れ',
       }),
     )
 
     expect(res.status).toBe(422)
   })
 
-  it('EMPLOYEE が異議申立てを送信できる', async () => {
+  it('対象なしは submit 側で404', async () => {
     mockedGetServerSession.mockResolvedValue(makeSession('EMPLOYEE', 'emp-1'))
-    const service = makeService()
-    setAppealServiceForTesting(service)
-
-    const res = await POST(
-      makeRequest({
-        targetType: 'TOTAL_EVALUATION',
-        targetId: 'result-1',
-        reason: '総合評価の根拠を確認したい',
-        desiredOutcome: '評価内容を見直してほしい',
+    setAppealServiceForTesting(
+      makeService({
+        submitAppeal: vi
+          .fn()
+          .mockRejectedValue(new AppealTargetNotFoundError('FEEDBACK', 'feedback-1')),
       }),
     )
 
-    expect(res.status).toBe(201)
-    expect(service.submitAppeal).toHaveBeenCalledWith('emp-1', {
-      targetType: 'TOTAL_EVALUATION',
-      targetId: 'result-1',
-      reason: '総合評価の根拠を確認したい',
-      desiredOutcome: '評価内容を見直してほしい',
-    })
+    const res = await POST(
+      makePostRequest({
+        targetType: 'FEEDBACK',
+        targetId: 'feedback-1',
+        reason: '対象なし',
+      }),
+    )
+
+    expect(res.status).toBe(404)
   })
 })

--- a/src/tests/appeal/appeal-service.test.ts
+++ b/src/tests/appeal/appeal-service.test.ts
@@ -6,7 +6,12 @@ import type {
   AppealRepository,
   AppealableTarget,
 } from '@/lib/appeal/appeal-types'
-import { AppealDeadlineExceededError, AppealTargetNotFoundError } from '@/lib/appeal/appeal-types'
+import {
+  AppealDeadlineExceededError,
+  AppealInvalidStatusTransitionError,
+  AppealNotFoundError,
+  AppealTargetNotFoundError,
+} from '@/lib/appeal/appeal-types'
 
 function makeTarget(overrides: Partial<AppealableTarget> = {}): AppealableTarget {
   return {
@@ -26,7 +31,7 @@ function makeAppeal(overrides: Partial<Appeal> = {}): Appeal {
     subjectId: 'emp-1',
     targetType: 'FEEDBACK',
     targetId: 'target-1',
-    reason: '内容に事実誤認があります',
+    reason: '評価内容に差異があります',
     desiredOutcome: '再確認してほしい',
     status: 'SUBMITTED',
     reviewerId: null,
@@ -53,6 +58,17 @@ function makeRepository(): AppealRepository {
     findPublishedFeedbackTarget: vi.fn().mockResolvedValue(makeTarget()),
     findFinalizedTotalEvaluationTarget: vi.fn().mockResolvedValue(makeTarget()),
     listHrManagerIds: vi.fn().mockResolvedValue(['hr-1', 'hr-2']),
+    listAppeals: vi.fn().mockResolvedValue([]),
+    findAppealById: vi.fn().mockResolvedValue(makeAppeal()),
+    updateAppealReview: vi.fn().mockImplementation(async (appealId, input) =>
+      makeAppeal({
+        id: appealId,
+        status: input.status,
+        reviewerId: input.reviewerId,
+        reviewComment: input.reviewComment,
+        reviewedAt: input.reviewedAt,
+      }),
+    ),
   }
 }
 
@@ -75,7 +91,7 @@ describe('AppealService.submitAppeal', () => {
     const result = await service.submitAppeal('emp-1', {
       targetType: 'FEEDBACK',
       targetId: 'feedback-1',
-      reason: '内容に事実誤認があります',
+      reason: '評価内容に差異があります',
       desiredOutcome: '再確認してほしい',
     })
 
@@ -86,7 +102,7 @@ describe('AppealService.submitAppeal', () => {
       subjectId: 'emp-1',
       targetType: 'FEEDBACK',
       targetId: 'feedback-1',
-      reason: '内容に事実誤認があります',
+      reason: '評価内容に差異があります',
       desiredOutcome: '再確認してほしい',
     })
     expect(notificationEmitter.emit).toHaveBeenCalledTimes(2)
@@ -115,7 +131,7 @@ describe('AppealService.submitAppeal', () => {
       service.submitAppeal('emp-1', {
         targetType: 'FEEDBACK',
         targetId: 'feedback-1',
-        reason: '期限切れ確認',
+        reason: '期限切れ',
       }),
     ).rejects.toBeInstanceOf(AppealDeadlineExceededError)
   })
@@ -132,8 +148,110 @@ describe('AppealService.submitAppeal', () => {
       service.submitAppeal('emp-1', {
         targetType: 'TOTAL_EVALUATION',
         targetId: 'result-1',
-        reason: '総合評価の根拠を確認したい',
+        reason: '総合評価を再確認したい',
       }),
     ).rejects.toBeInstanceOf(AppealTargetNotFoundError)
+  })
+})
+
+describe('AppealService.listPending', () => {
+  it('未対応案件を優先して返す', async () => {
+    const repository = makeRepository()
+    repository.listAppeals = vi.fn().mockResolvedValue([
+      makeAppeal({
+        id: 'appeal-accepted',
+        status: 'ACCEPTED',
+        submittedAt: new Date('2026-04-10T00:00:00.000Z'),
+      }),
+      makeAppeal({
+        id: 'appeal-review',
+        status: 'UNDER_REVIEW',
+        submittedAt: new Date('2026-04-20T00:00:00.000Z'),
+      }),
+      makeAppeal({
+        id: 'appeal-submitted',
+        status: 'SUBMITTED',
+        submittedAt: new Date('2026-04-21T00:00:00.000Z'),
+      }),
+    ])
+    const service = createAppealService({ repository })
+
+    const result = await service.listPending('hr-1')
+
+    expect(result.map((appeal) => appeal.id)).toEqual([
+      'appeal-submitted',
+      'appeal-review',
+      'appeal-accepted',
+    ])
+  })
+})
+
+describe('AppealService.review', () => {
+  it('SUBMITTED を UNDER_REVIEW に更新し申立者へ通知する', async () => {
+    const repository = makeRepository()
+    repository.findAppealById = vi.fn().mockResolvedValue(
+      makeAppeal({
+        id: 'appeal-1',
+        status: 'SUBMITTED',
+      }),
+    )
+    const notificationEmitter: AppealNotificationPort = {
+      emit: vi.fn().mockResolvedValue(undefined),
+    }
+    const service = createAppealService({
+      repository,
+      notificationEmitter,
+      clock: () => new Date('2026-04-21T00:00:00.000Z'),
+    })
+
+    const result = await service.review('hr-1', 'appeal-1', {
+      status: 'UNDER_REVIEW',
+      reviewComment: '確認を開始しました',
+    })
+
+    expect(repository.updateAppealReview).toHaveBeenCalledWith('appeal-1', {
+      status: 'UNDER_REVIEW',
+      reviewerId: 'hr-1',
+      reviewComment: '確認を開始しました',
+      reviewedAt: new Date('2026-04-21T00:00:00.000Z'),
+    })
+    expect(notificationEmitter.emit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'emp-1',
+        category: 'SYSTEM',
+      }),
+    )
+    expect(result.status).toBe('UNDER_REVIEW')
+  })
+
+  it('存在しない異議申立ては not found', async () => {
+    const repository = makeRepository()
+    repository.findAppealById = vi.fn().mockResolvedValue(null)
+    const service = createAppealService({ repository })
+
+    await expect(
+      service.review('hr-1', 'appeal-missing', {
+        status: 'UNDER_REVIEW',
+        reviewComment: '確認開始',
+      }),
+    ).rejects.toBeInstanceOf(AppealNotFoundError)
+  })
+
+  it('不正な遷移は弾く', async () => {
+    const repository = makeRepository()
+    repository.findAppealById = vi.fn().mockResolvedValue(
+      makeAppeal({
+        id: 'appeal-1',
+        status: 'SUBMITTED',
+      }),
+    )
+    const service = createAppealService({ repository })
+
+    await expect(
+      service.review('hr-1', 'appeal-1', {
+        status: 'ACCEPTED',
+        reviewComment: 'いきなり認容',
+      }),
+    ).rejects.toBeInstanceOf(AppealInvalidStatusTransitionError)
   })
 })


### PR DESCRIPTION
## Summary
- add HR-facing appeal list and review APIs for issue #70
- enforce appeal review state transitions and notify appellants when review status changes
- cover appeal review ordering, transitions, and route behavior with tests

## Issue
- Addresses #70

## Verification
- pnpm vitest run src/tests/appeal/appeal-service.test.ts src/tests/appeal/appeal-routes.test.ts
- pnpm type-check
- pnpm build
- pnpm test