### PR TITLE
feat: add appeal acceptance recalculation

### DIFF
--- a/src/lib/appeal/appeal-service.ts
+++ b/src/lib/appeal/appeal-service.ts
@@ -1,7 +1,9 @@
 import type {
+  AppealAuditLogger,
   Appeal,
   AppealInput,
   AppealNotificationPort,
+  AppealRecalculationPort,
   AppealRepository,
   AppealReviewInput,
   AppealService,
@@ -35,11 +37,19 @@ const ALLOWED_REVIEW_TRANSITIONS: Record<AppealStatus, readonly AppealReviewInpu
 export interface AppealServiceDeps {
   readonly repository: AppealRepository
   readonly notificationEmitter?: AppealNotificationPort
+  readonly recalculationPort?: AppealRecalculationPort
+  readonly auditLogger?: AppealAuditLogger
   readonly clock?: () => Date
 }
 
 function computeDeadline(publishedAt: Date): Date {
   return new Date(publishedAt.getTime() + APPEAL_WINDOW_DAYS * MS_PER_DAY)
+}
+
+function computeRetentionUntil(submittedAt: Date): Date {
+  const retention = new Date(submittedAt)
+  retention.setFullYear(retention.getFullYear() + 7)
+  return retention
 }
 
 function assertWithinDeadline(target: AppealableTarget, now: Date): void {
@@ -65,11 +75,15 @@ function sortAppealsForReview(left: Appeal, right: Appeal): number {
 class AppealServiceImpl implements AppealService {
   private readonly repository: AppealRepository
   private readonly notificationEmitter?: AppealNotificationPort
+  private readonly recalculationPort?: AppealRecalculationPort
+  private readonly auditLogger?: AppealAuditLogger
   private readonly clock: () => Date
 
   constructor(deps: AppealServiceDeps) {
     this.repository = deps.repository
     this.notificationEmitter = deps.notificationEmitter
+    this.recalculationPort = deps.recalculationPort
+    this.auditLogger = deps.auditLogger
     this.clock = deps.clock ?? (() => new Date())
   }
 
@@ -83,6 +97,7 @@ class AppealServiceImpl implements AppealService {
       throw new AppealTargetNotFoundError(input.targetType, input.targetId)
     }
 
+    const now = this.clock()
     assertWithinDeadline(target, this.clock())
 
     const appeal = await this.repository.createAppeal({
@@ -93,6 +108,7 @@ class AppealServiceImpl implements AppealService {
       targetId: input.targetId,
       reason: input.reason,
       desiredOutcome: input.desiredOutcome?.trim() || null,
+      retainedUntil: computeRetentionUntil(now),
     })
 
     const hrManagerIds = await this.repository.listHrManagerIds()
@@ -132,12 +148,46 @@ class AppealServiceImpl implements AppealService {
 
     assertReviewTransition(appeal.status, input.status)
 
+    const reviewTime = this.clock()
+    const recalculationRequestedAt =
+      input.status === 'ACCEPTED' ? reviewTime : appeal.recalculationRequestedAt
+
     const reviewedAppeal = await this.repository.updateAppealReview(appealId, {
       status: input.status,
       reviewerId: hrManagerId,
       reviewComment: input.reviewComment.trim(),
-      reviewedAt: this.clock(),
+      reviewedAt: reviewTime,
+      recalculationRequestedAt,
     })
+
+    if (input.status === 'ACCEPTED' && this.recalculationPort) {
+      await this.recalculationPort.recalculate({
+        appealId: reviewedAppeal.id,
+        cycleId: reviewedAppeal.cycleId,
+        subjectId: reviewedAppeal.subjectId,
+        triggeredBy: hrManagerId,
+      })
+    }
+
+    if (input.status === 'ACCEPTED' && this.auditLogger) {
+      await this.auditLogger.emit({
+        userId: hrManagerId,
+        action: 'RECORD_UPDATE',
+        resourceType: 'EVALUATION',
+        resourceId: reviewedAppeal.subjectId,
+        before: {
+          appealId: appeal.id,
+          status: appeal.status,
+          recalculationRequestedAt: appeal.recalculationRequestedAt?.toISOString() ?? null,
+        },
+        after: {
+          appealId: reviewedAppeal.id,
+          status: reviewedAppeal.status,
+          recalculationRequestedAt: reviewedAppeal.recalculationRequestedAt?.toISOString() ?? null,
+          retainedUntil: reviewedAppeal.retainedUntil.toISOString(),
+        },
+      })
+    }
 
     if (this.notificationEmitter) {
       await this.notificationEmitter.emit({

--- a/src/lib/appeal/appeal-types.ts
+++ b/src/lib/appeal/appeal-types.ts
@@ -26,6 +26,8 @@ export interface Appeal {
   readonly reviewComment: string | null
   readonly reviewedAt: Date | null
   readonly submittedAt: Date
+  readonly retainedUntil: Date
+  readonly recalculationRequestedAt: Date | null
 }
 
 export interface AppealReviewInput {
@@ -44,7 +46,13 @@ export interface AppealRepository {
   createAppeal(
     input: Omit<
       Appeal,
-      'id' | 'status' | 'reviewerId' | 'reviewComment' | 'reviewedAt' | 'submittedAt'
+      | 'id'
+      | 'status'
+      | 'reviewerId'
+      | 'reviewComment'
+      | 'reviewedAt'
+      | 'submittedAt'
+      | 'recalculationRequestedAt'
     >,
   ): Promise<Appeal>
   findPublishedFeedbackTarget(
@@ -65,6 +73,7 @@ export interface AppealRepository {
       reviewerId: string
       reviewComment: string
       reviewedAt: Date
+      recalculationRequestedAt?: Date | null
     },
   ): Promise<Appeal>
 }
@@ -76,6 +85,26 @@ export interface AppealNotificationPort {
     title: string
     body: string
     payload?: Record<string, unknown>
+  }): Promise<void>
+}
+
+export interface AppealRecalculationPort {
+  recalculate(input: {
+    appealId: string
+    cycleId: string
+    subjectId: string
+    triggeredBy: string
+  }): Promise<void>
+}
+
+export interface AppealAuditLogger {
+  emit(entry: {
+    userId: string | null
+    action: 'RECORD_UPDATE'
+    resourceType: 'EVALUATION'
+    resourceId: string | null
+    before: Record<string, unknown> | null
+    after: Record<string, unknown> | null
   }): Promise<void>
 }
 

--- a/src/tests/appeal/appeal-service.test.ts
+++ b/src/tests/appeal/appeal-service.test.ts
@@ -1,8 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createAppealService } from '@/lib/appeal/appeal-service'
 import type {
+  AppealAuditLogger,
   Appeal,
   AppealNotificationPort,
+  AppealRecalculationPort,
   AppealRepository,
   AppealableTarget,
 } from '@/lib/appeal/appeal-types'
@@ -38,6 +40,8 @@ function makeAppeal(overrides: Partial<Appeal> = {}): Appeal {
     reviewComment: null,
     reviewedAt: null,
     submittedAt: new Date('2026-04-12T00:00:00.000Z'),
+    retainedUntil: new Date('2033-04-12T00:00:00.000Z'),
+    recalculationRequestedAt: null,
     ...overrides,
   }
 }
@@ -104,6 +108,7 @@ describe('AppealService.submitAppeal', () => {
       targetId: 'feedback-1',
       reason: '評価内容に差異があります',
       desiredOutcome: '再確認してほしい',
+      retainedUntil: new Date('2033-04-20T00:00:00.000Z'),
     })
     expect(notificationEmitter.emit).toHaveBeenCalledTimes(2)
     expect(result).toEqual(
@@ -214,6 +219,7 @@ describe('AppealService.review', () => {
       reviewerId: 'hr-1',
       reviewComment: '確認を開始しました',
       reviewedAt: new Date('2026-04-21T00:00:00.000Z'),
+      recalculationRequestedAt: null,
     })
     expect(notificationEmitter.emit).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -222,6 +228,63 @@ describe('AppealService.review', () => {
       }),
     )
     expect(result.status).toBe('UNDER_REVIEW')
+  })
+
+  it('ACCEPTED のとき再計算と監査ログを起動する', async () => {
+    const repository = makeRepository()
+    repository.findAppealById = vi.fn().mockResolvedValue(
+      makeAppeal({
+        id: 'appeal-accepted',
+        status: 'UNDER_REVIEW',
+        targetType: 'TOTAL_EVALUATION',
+        targetId: 'result-1',
+      }),
+    )
+    repository.updateAppealReview = vi.fn().mockImplementation(async (appealId, input) =>
+      makeAppeal({
+        id: appealId,
+        status: input.status,
+        reviewerId: input.reviewerId,
+        reviewComment: input.reviewComment,
+        reviewedAt: input.reviewedAt,
+        recalculationRequestedAt: input.recalculationRequestedAt ?? null,
+        targetType: 'TOTAL_EVALUATION',
+        targetId: 'result-1',
+      }),
+    )
+    const recalculationPort: AppealRecalculationPort = {
+      recalculate: vi.fn().mockResolvedValue(undefined),
+    }
+    const auditLogger: AppealAuditLogger = {
+      emit: vi.fn().mockResolvedValue(undefined),
+    }
+    const service = createAppealService({
+      repository,
+      recalculationPort,
+      auditLogger,
+      clock: () => new Date('2026-04-21T00:00:00.000Z'),
+    })
+
+    const result = await service.review('hr-1', 'appeal-accepted', {
+      status: 'ACCEPTED',
+      reviewComment: '認容して再計算します',
+    })
+
+    expect(recalculationPort.recalculate).toHaveBeenCalledWith({
+      appealId: 'appeal-accepted',
+      cycleId: 'cycle-1',
+      subjectId: 'emp-1',
+      triggeredBy: 'hr-1',
+    })
+    expect(auditLogger.emit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'hr-1',
+        action: 'RECORD_UPDATE',
+        resourceType: 'EVALUATION',
+        resourceId: 'emp-1',
+      }),
+    )
+    expect(result.recalculationRequestedAt).toEqual(new Date('2026-04-21T00:00:00.000Z'))
   })
 
   it('存在しない異議申立ては not found', async () => {


### PR DESCRIPTION
## Summary
- add 7-year retention metadata to appeals and persist recalculation request timestamps
- trigger recalculation and audit logging automatically when an appeal is accepted
- extend appeal service tests to cover retention, recalculation, and audit behavior

## Issue
- Addresses #71

## Verification
- pnpm vitest run src/tests/appeal/appeal-service.test.ts src/tests/appeal/appeal-routes.test.ts
- pnpm type-check
- pnpm build
- pnpm test