### PR TITLE
feat: add role-based KPI dashboard

### DIFF
--- a/src/app/api/dashboard/kpi/route.ts
+++ b/src/app/api/dashboard/kpi/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from 'next/server'
+import { getAppSession } from '@/lib/auth/app-session'
+import { getDashboardService } from '@/lib/dashboard/dashboard-service-di'
+import type { UserRole } from '@/lib/notification/notification-types'
+
+function isUserRole(value: unknown): value is UserRole {
+  return value === 'ADMIN' || value === 'HR_MANAGER' || value === 'MANAGER' || value === 'EMPLOYEE'
+}
+
+export async function GET(): Promise<NextResponse> {
+  const session = await getAppSession()
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const sess = session as Record<string, unknown>
+  const userId = typeof sess.userId === 'string' ? sess.userId : undefined
+  const role = sess.role
+  if (!userId || !isUserRole(role)) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  let service: ReturnType<typeof getDashboardService>
+  try {
+    service = getDashboardService()
+  } catch {
+    return NextResponse.json({ error: 'Dashboard service not initialized' }, { status: 503 })
+  }
+
+  const result = await service.getKpiSummary(role, userId)
+  return NextResponse.json({ success: true, data: result }, { status: 200 })
+}

--- a/src/lib/dashboard/dashboard-service-di.ts
+++ b/src/lib/dashboard/dashboard-service-di.ts
@@ -1,0 +1,26 @@
+import type { DashboardService } from './dashboard-types'
+
+let service: DashboardService | null = null
+
+export function setDashboardServiceForTesting(svc: DashboardService): void {
+  service = svc
+}
+
+export function clearDashboardServiceForTesting(): void {
+  service = null
+}
+
+export function initDashboardService(svc: DashboardService): void {
+  service = svc
+}
+
+export function getDashboardService(): DashboardService {
+  if (!service) {
+    throw new Error(
+      'DashboardService is not initialized. ' +
+        'テストでは setDashboardServiceForTesting() を呼んでください。' +
+        'プロダクションでは initDashboardService() を呼んでください。',
+    )
+  }
+  return service
+}

--- a/src/lib/dashboard/dashboard-service.ts
+++ b/src/lib/dashboard/dashboard-service.ts
@@ -1,0 +1,139 @@
+import type { UserRole } from '@/lib/notification/notification-types'
+import type {
+  DashboardAggregateRow,
+  DashboardRepository,
+  DashboardService,
+  DashboardSummary,
+  EmployeeDashboardRow,
+  KpiMetric,
+} from './dashboard-types'
+
+function toPercent(numerator: number, denominator: number): number {
+  if (denominator <= 0) return 0
+  return Math.round((numerator / denominator) * 10000) / 100
+}
+
+function buildCommonMetrics(
+  aggregate: DashboardAggregateRow,
+  employeeCount: number,
+): readonly KpiMetric[] {
+  return [
+    {
+      key: 'employeeCount',
+      label: '社員数',
+      value: employeeCount,
+      unit: 'count',
+    },
+    {
+      key: 'evaluationCompletionRate',
+      label: '評価完了率',
+      value: toPercent(aggregate.completedEvaluations, aggregate.totalEvaluations),
+      unit: 'percent',
+    },
+    {
+      key: 'goalAchievementRate',
+      label: '目標達成率',
+      value: toPercent(aggregate.completedGoals, aggregate.totalGoals),
+      unit: 'percent',
+    },
+    {
+      key: 'skillCoverageRate',
+      label: 'スキルカバレッジ',
+      value: toPercent(aggregate.coveredSkills, aggregate.totalSkills),
+      unit: 'percent',
+    },
+  ]
+}
+
+function buildEmployeeMetrics(aggregate: EmployeeDashboardRow): readonly KpiMetric[] {
+  return [
+    {
+      key: 'myFinalScore',
+      label: '自分の評価',
+      value: aggregate.latestFinalScore ?? 0,
+      unit: 'score',
+    },
+    {
+      key: 'myGoalProgressRate',
+      label: '自分の目標達成率',
+      value: toPercent(aggregate.completedGoals, aggregate.totalGoals),
+      unit: 'percent',
+    },
+    {
+      key: 'skillCoverageRate',
+      label: '自分のスキルカバレッジ',
+      value: toPercent(aggregate.coveredSkills, aggregate.totalSkills),
+      unit: 'percent',
+    },
+    {
+      key: 'myIncentiveScore',
+      label: '自分のインセンティブ',
+      value: aggregate.latestIncentiveScore ?? 0,
+      unit: 'score',
+    },
+  ]
+}
+
+function buildEmptyStateMessage(metrics: readonly KpiMetric[]): string | null {
+  const hasPositiveMetric = metrics.some((metric) => metric.value > 0)
+  return hasPositiveMetric
+    ? null
+    : 'まだ表示できるデータがありません。評価、目標、スキル登録が進むとここにKPIが表示されます。'
+}
+
+class DashboardServiceImpl implements DashboardService {
+  constructor(private readonly repository: DashboardRepository) {}
+
+  async getKpiSummary(role: UserRole, userId: string): Promise<DashboardSummary> {
+    if (role === 'ADMIN' || role === 'HR_MANAGER') {
+      const [employeeCount, aggregate] = await Promise.all([
+        this.repository.countEmployees(),
+        this.repository.getCompanyAggregate(),
+      ])
+      const metrics = buildCommonMetrics(aggregate, employeeCount)
+      return {
+        role,
+        scopeUserId: userId,
+        metrics,
+        emptyStateMessage: buildEmptyStateMessage(metrics),
+      }
+    }
+
+    if (role === 'MANAGER') {
+      const [teamMemberCount, aggregate] = await Promise.all([
+        this.repository.countManagedMembers(userId),
+        this.repository.getManagerAggregate(userId),
+      ])
+      const metrics: readonly KpiMetric[] = [
+        {
+          key: 'teamMemberCount',
+          label: '担当メンバー数',
+          value: teamMemberCount,
+          unit: 'count',
+        },
+        ...buildCommonMetrics(aggregate, teamMemberCount).filter(
+          (metric) => metric.key !== 'employeeCount',
+        ),
+      ]
+      return {
+        role,
+        scopeUserId: userId,
+        metrics,
+        emptyStateMessage: buildEmptyStateMessage(metrics),
+      }
+    }
+
+    const aggregate = await this.repository.getEmployeeAggregate(userId)
+    const metrics = buildEmployeeMetrics(aggregate)
+    return {
+      role,
+      scopeUserId: userId,
+      metrics,
+      emptyStateMessage: buildEmptyStateMessage(metrics),
+    }
+  }
+}
+
+export function createDashboardService(repository: DashboardRepository): DashboardService {
+  return new DashboardServiceImpl(repository)
+}

--- a/src/lib/dashboard/dashboard-types.ts
+++ b/src/lib/dashboard/dashboard-types.ts
@@ -1,0 +1,52 @@
+import { z } from 'zod'
+import type { UserRole } from '@/lib/notification/notification-types'
+
+export interface KpiMetric {
+  readonly key:
+    | 'employeeCount'
+    | 'evaluationCompletionRate'
+    | 'goalAchievementRate'
+    | 'skillCoverageRate'
+    | 'teamMemberCount'
+    | 'myFinalScore'
+    | 'myGoalProgressRate'
+    | 'myIncentiveScore'
+  readonly label: string
+  readonly value: number
+  readonly unit: 'count' | 'percent' | 'score'
+}
+
+export interface DashboardSummary {
+  readonly role: UserRole
+  readonly scopeUserId: string
+  readonly metrics: readonly KpiMetric[]
+  readonly emptyStateMessage: string | null
+}
+
+export interface DashboardAggregateRow {
+  readonly completedEvaluations: number
+  readonly totalEvaluations: number
+  readonly completedGoals: number
+  readonly totalGoals: number
+  readonly coveredSkills: number
+  readonly totalSkills: number
+}
+
+export interface EmployeeDashboardRow extends DashboardAggregateRow {
+  readonly latestFinalScore: number | null
+  readonly latestIncentiveScore: number | null
+}
+
+export interface DashboardRepository {
+  countEmployees(): Promise<number>
+  countManagedMembers(managerId: string): Promise<number>
+  getCompanyAggregate(): Promise<DashboardAggregateRow>
+  getManagerAggregate(managerId: string): Promise<DashboardAggregateRow>
+  getEmployeeAggregate(userId: string): Promise<EmployeeDashboardRow>
+}
+
+export interface DashboardService {
+  getKpiSummary(role: UserRole, userId: string): Promise<DashboardSummary>
+}
+
+export const dashboardQuerySchema = z.object({})

--- a/src/tests/dashboard/dashboard-route.test.ts
+++ b/src/tests/dashboard/dashboard-route.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  clearDashboardServiceForTesting,
+  setDashboardServiceForTesting,
+} from '@/lib/dashboard/dashboard-service-di'
+import type { DashboardService } from '@/lib/dashboard/dashboard-types'
+
+vi.mock('next-auth', () => ({
+  getServerSession: vi.fn(),
+}))
+
+const { getServerSession } = await import('next-auth')
+const mockedGetServerSession = vi.mocked(getServerSession)
+
+const { GET } = await import('@/app/api/dashboard/kpi/route')
+
+function makeSession(role: string, userId = 'user-1') {
+  return {
+    user: { email: 'user@example.com' },
+    userId,
+    role,
+  }
+}
+
+function makeService(overrides?: Partial<DashboardService>): DashboardService {
+  return {
+    getKpiSummary: vi.fn().mockResolvedValue({
+      role: 'EMPLOYEE',
+      scopeUserId: 'user-1',
+      metrics: [],
+      emptyStateMessage:
+        'まだ表示できるデータがありません。評価、目標、スキル登録が進むとここにKPIが表示されます。',
+    }),
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+afterEach(() => {
+  clearDashboardServiceForTesting()
+})
+
+describe('GET /api/dashboard/kpi', () => {
+  it('未認証は401', async () => {
+    mockedGetServerSession.mockResolvedValue(null)
+
+    const res = await GET()
+
+    expect(res.status).toBe(401)
+  })
+
+  it('role と userId があれば KPI を返す', async () => {
+    mockedGetServerSession.mockResolvedValue(makeSession('MANAGER', 'manager-1'))
+    const service = makeService()
+    setDashboardServiceForTesting(service)
+
+    const res = await GET()
+
+    expect(res.status).toBe(200)
+    expect(service.getKpiSummary).toHaveBeenCalledWith('MANAGER', 'manager-1')
+  })
+
+  it('role 不正は403', async () => {
+    mockedGetServerSession.mockResolvedValue(makeSession('UNKNOWN', 'user-1'))
+    setDashboardServiceForTesting(makeService())
+
+    const res = await GET()
+
+    expect(res.status).toBe(403)
+  })
+})

--- a/src/tests/dashboard/dashboard-service.test.ts
+++ b/src/tests/dashboard/dashboard-service.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest'
+import { createDashboardService } from '@/lib/dashboard/dashboard-service'
+import type { DashboardRepository } from '@/lib/dashboard/dashboard-types'
+
+function makeRepository(overrides: Partial<DashboardRepository> = {}): DashboardRepository {
+  return {
+    countEmployees: async () => 10,
+    countManagedMembers: async () => 3,
+    getCompanyAggregate: async () => ({
+      completedEvaluations: 8,
+      totalEvaluations: 10,
+      completedGoals: 6,
+      totalGoals: 10,
+      coveredSkills: 45,
+      totalSkills: 60,
+    }),
+    getManagerAggregate: async () => ({
+      completedEvaluations: 2,
+      totalEvaluations: 3,
+      completedGoals: 1,
+      totalGoals: 3,
+      coveredSkills: 9,
+      totalSkills: 12,
+    }),
+    getEmployeeAggregate: async () => ({
+      completedEvaluations: 1,
+      totalEvaluations: 1,
+      completedGoals: 2,
+      totalGoals: 4,
+      coveredSkills: 7,
+      totalSkills: 10,
+      latestFinalScore: 82.5,
+      latestIncentiveScore: 12,
+    }),
+    ...overrides,
+  }
+}
+
+describe('DashboardService.getKpiSummary', () => {
+  it('ADMIN は全社 KPI を返す', async () => {
+    const service = createDashboardService(makeRepository())
+
+    const result = await service.getKpiSummary('ADMIN', 'admin-1')
+
+    expect(result.role).toBe('ADMIN')
+    expect(result.metrics.map((metric) => metric.key)).toEqual([
+      'employeeCount',
+      'evaluationCompletionRate',
+      'goalAchievementRate',
+      'skillCoverageRate',
+    ])
+    expect(result.emptyStateMessage).toBeNull()
+  })
+
+  it('MANAGER は担当メンバー限定 KPI を返す', async () => {
+    const service = createDashboardService(makeRepository())
+
+    const result = await service.getKpiSummary('MANAGER', 'manager-1')
+
+    expect(result.metrics.map((metric) => metric.key)).toEqual([
+      'teamMemberCount',
+      'evaluationCompletionRate',
+      'goalAchievementRate',
+      'skillCoverageRate',
+    ])
+  })
+
+  it('EMPLOYEE は自分の KPI を返す', async () => {
+    const service = createDashboardService(makeRepository())
+
+    const result = await service.getKpiSummary('EMPLOYEE', 'emp-1')
+
+    expect(result.metrics.map((metric) => metric.key)).toEqual([
+      'myFinalScore',
+      'myGoalProgressRate',
+      'skillCoverageRate',
+      'myIncentiveScore',
+    ])
+  })
+
+  it('データが空なら empty state メッセージを返す', async () => {
+    const service = createDashboardService(
+      makeRepository({
+        countEmployees: async () => 0,
+        countManagedMembers: async () => 0,
+        getCompanyAggregate: async () => ({
+          completedEvaluations: 0,
+          totalEvaluations: 0,
+          completedGoals: 0,
+          totalGoals: 0,
+          coveredSkills: 0,
+          totalSkills: 0,
+        }),
+      }),
+    )
+
+    const result = await service.getKpiSummary('HR_MANAGER', 'hr-1')
+
+    expect(result.emptyStateMessage).toContain('まだ表示できるデータがありません')
+  })
+})


### PR DESCRIPTION
## Summary
- add a role-based KPI dashboard service for admin, HR manager, manager, and employee users
- expose GET /api/dashboard/kpi with session-aware role handling and empty-state guidance
- cover the new dashboard service and route with focused tests

## Verification
- pnpm vitest run src/tests/dashboard/dashboard-service.test.ts src/tests/dashboard/dashboard-route.test.ts
- pnpm type-check
- pnpm build
- pnpm test

Addresses #72