### PR TITLE
feat: add dashboard trends and filters

### DIFF
--- a/src/app/api/dashboard/trends/route.ts
+++ b/src/app/api/dashboard/trends/route.ts
@@ -1,0 +1,61 @@
+import { NextResponse } from 'next/server'
+import { getAppSession } from '@/lib/auth/app-session'
+import { getDashboardService } from '@/lib/dashboard/dashboard-service-di'
+import { dashboardTrendQuerySchema } from '@/lib/dashboard/dashboard-types'
+import type { UserRole } from '@/lib/notification/notification-types'
+
+function isUserRole(value: unknown): value is UserRole {
+  return value === 'ADMIN' || value === 'HR_MANAGER' || value === 'MANAGER' || value === 'EMPLOYEE'
+}
+
+function parseCsvParam(value: string | null): string[] {
+  if (!value) return []
+  return value
+    .split(',')
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0)
+}
+
+function parseDateParam(value: string | null): Date | null {
+  if (!value) return null
+  const date = new Date(value)
+  return Number.isNaN(date.getTime()) ? new Date('invalid') : date
+}
+
+export async function GET(request: Request): Promise<NextResponse> {
+  const session = await getAppSession()
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const sess = session as Record<string, unknown>
+  const userId = typeof sess.userId === 'string' ? sess.userId : undefined
+  const role = sess.role
+  if (!userId || !isUserRole(role)) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const url = new URL(request.url)
+  const parsed = dashboardTrendQuerySchema.safeParse({
+    departmentIds: parseCsvParam(url.searchParams.get('departmentIds')),
+    cycleIds: parseCsvParam(url.searchParams.get('cycleIds')),
+    from: parseDateParam(url.searchParams.get('from')),
+    to: parseDateParam(url.searchParams.get('to')),
+  })
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'Invalid dashboard trend query', details: parsed.error.flatten() },
+      { status: 400 },
+    )
+  }
+
+  let service: ReturnType<typeof getDashboardService>
+  try {
+    service = getDashboardService()
+  } catch {
+    return NextResponse.json({ error: 'Dashboard service not initialized' }, { status: 503 })
+  }
+
+  const result = await service.getTrendSummary(role, userId, parsed.data)
+  return NextResponse.json({ success: true, data: result }, { status: 200 })
+}

--- a/src/lib/dashboard/dashboard-service-di.ts
+++ b/src/lib/dashboard/dashboard-service-di.ts
@@ -18,8 +18,8 @@ export function getDashboardService(): DashboardService {
   if (!service) {
     throw new Error(
       'DashboardService is not initialized. ' +
-        'テストでは setDashboardServiceForTesting() を呼んでください。' +
-        'プロダクションでは initDashboardService() を呼んでください。',
+        'テストでは setDashboardServiceForTesting() を呼び出してください。' +
+        'プロダクションでは initDashboardService() を呼び出してください。',
     )
   }
   return service

--- a/src/lib/dashboard/dashboard-service.ts
+++ b/src/lib/dashboard/dashboard-service.ts
@@ -4,6 +4,9 @@ import type {
   DashboardRepository,
   DashboardService,
   DashboardSummary,
+  DashboardTrendFilter,
+  DashboardTrendPoint,
+  DashboardTrendSummary,
   EmployeeDashboardRow,
   KpiMetric,
 } from './dashboard-types'
@@ -11,6 +14,19 @@ import type {
 function toPercent(numerator: number, denominator: number): number {
   if (denominator <= 0) return 0
   return Math.round((numerator / denominator) * 10000) / 100
+}
+
+function unique(values: readonly string[]): readonly string[] {
+  return [...new Set(values)]
+}
+
+function normalizeTrendFilter(filter: Partial<DashboardTrendFilter>): DashboardTrendFilter {
+  return {
+    departmentIds: unique(filter.departmentIds ?? []),
+    cycleIds: unique(filter.cycleIds ?? []),
+    from: filter.from ?? null,
+    to: filter.to ?? null,
+  }
 }
 
 function buildCommonMetrics(
@@ -49,7 +65,7 @@ function buildEmployeeMetrics(aggregate: EmployeeDashboardRow): readonly KpiMetr
   return [
     {
       key: 'myFinalScore',
-      label: '自分の評価',
+      label: '自分の総合評価',
       value: aggregate.latestFinalScore ?? 0,
       unit: 'score',
     },
@@ -74,11 +90,23 @@ function buildEmployeeMetrics(aggregate: EmployeeDashboardRow): readonly KpiMetr
   ]
 }
 
-function buildEmptyStateMessage(metrics: readonly KpiMetric[]): string | null {
+function buildKpiEmptyStateMessage(metrics: readonly KpiMetric[]): string | null {
   const hasPositiveMetric = metrics.some((metric) => metric.value > 0)
   return hasPositiveMetric
     ? null
     : 'まだ表示できるデータがありません。評価、目標、スキル登録が進むとここにKPIが表示されます。'
+}
+
+function sortAndLimitTrend(points: readonly DashboardTrendPoint[]): readonly DashboardTrendPoint[] {
+  return [...points]
+    .sort((left, right) => left.periodEnd.getTime() - right.periodEnd.getTime())
+    .slice(-3)
+}
+
+function buildTrendEmptyStateMessage(points: readonly DashboardTrendPoint[]): string | null {
+  return points.length > 0
+    ? null
+    : 'トレンドを表示できるデータがありません。フィルタ条件を見直すか、評価サイクルの確定をお待ちください。'
 }
 
 class DashboardServiceImpl implements DashboardService {
@@ -95,7 +123,7 @@ class DashboardServiceImpl implements DashboardService {
         role,
         scopeUserId: userId,
         metrics,
-        emptyStateMessage: buildEmptyStateMessage(metrics),
+        emptyStateMessage: buildKpiEmptyStateMessage(metrics),
       }
     }
 
@@ -119,7 +147,7 @@ class DashboardServiceImpl implements DashboardService {
         role,
         scopeUserId: userId,
         metrics,
-        emptyStateMessage: buildEmptyStateMessage(metrics),
+        emptyStateMessage: buildKpiEmptyStateMessage(metrics),
       }
     }
 
@@ -129,7 +157,31 @@ class DashboardServiceImpl implements DashboardService {
       role,
       scopeUserId: userId,
       metrics,
-      emptyStateMessage: buildEmptyStateMessage(metrics),
+      emptyStateMessage: buildKpiEmptyStateMessage(metrics),
+    }
+  }
+
+  async getTrendSummary(
+    role: UserRole,
+    userId: string,
+    filter: Partial<DashboardTrendFilter>,
+  ): Promise<DashboardTrendSummary> {
+    const normalizedFilter = normalizeTrendFilter(filter)
+
+    const points =
+      role === 'ADMIN' || role === 'HR_MANAGER'
+        ? await this.repository.listCompanyTrend(normalizedFilter)
+        : role === 'MANAGER'
+          ? await this.repository.listManagerTrend(userId, normalizedFilter)
+          : await this.repository.listEmployeeTrend(userId, normalizedFilter)
+
+    const normalizedPoints = sortAndLimitTrend(points)
+    return {
+      role,
+      scopeUserId: userId,
+      filters: normalizedFilter,
+      points: normalizedPoints,
+      emptyStateMessage: buildTrendEmptyStateMessage(normalizedPoints),
     }
   }
 }

--- a/src/lib/dashboard/dashboard-types.ts
+++ b/src/lib/dashboard/dashboard-types.ts
@@ -37,16 +37,69 @@ export interface EmployeeDashboardRow extends DashboardAggregateRow {
   readonly latestIncentiveScore: number | null
 }
 
+export interface DashboardTrendFilter {
+  readonly departmentIds: readonly string[]
+  readonly cycleIds: readonly string[]
+  readonly from: Date | null
+  readonly to: Date | null
+}
+
+export interface DashboardTrendPoint {
+  readonly cycleId: string
+  readonly cycleName: string
+  readonly periodStart: Date
+  readonly periodEnd: Date
+  readonly score: number
+}
+
+export interface DashboardTrendSummary {
+  readonly role: UserRole
+  readonly scopeUserId: string
+  readonly filters: DashboardTrendFilter
+  readonly points: readonly DashboardTrendPoint[]
+  readonly emptyStateMessage: string | null
+}
+
 export interface DashboardRepository {
   countEmployees(): Promise<number>
   countManagedMembers(managerId: string): Promise<number>
   getCompanyAggregate(): Promise<DashboardAggregateRow>
   getManagerAggregate(managerId: string): Promise<DashboardAggregateRow>
   getEmployeeAggregate(userId: string): Promise<EmployeeDashboardRow>
+  listCompanyTrend(filter: DashboardTrendFilter): Promise<readonly DashboardTrendPoint[]>
+  listManagerTrend(
+    managerId: string,
+    filter: DashboardTrendFilter,
+  ): Promise<readonly DashboardTrendPoint[]>
+  listEmployeeTrend(
+    userId: string,
+    filter: DashboardTrendFilter,
+  ): Promise<readonly DashboardTrendPoint[]>
 }
 
 export interface DashboardService {
   getKpiSummary(role: UserRole, userId: string): Promise<DashboardSummary>
+  getTrendSummary(
+    role: UserRole,
+    userId: string,
+    filter: Partial<DashboardTrendFilter>,
+  ): Promise<DashboardTrendSummary>
 }
 
 export const dashboardQuerySchema = z.object({})
+
+export const dashboardTrendQuerySchema = z
+  .object({
+    departmentIds: z.array(z.string().min(1)).default([]),
+    cycleIds: z.array(z.string().min(1)).default([]),
+    from: z.date().nullable().default(null),
+    to: z.date().nullable().default(null),
+  })
+  .refine(
+    (value) =>
+      value.from === null || value.to === null || value.from.getTime() <= value.to.getTime(),
+    {
+      message: 'from must be earlier than or equal to to',
+      path: ['from'],
+    },
+  )

--- a/src/tests/dashboard/dashboard-route.test.ts
+++ b/src/tests/dashboard/dashboard-route.test.ts
@@ -31,6 +31,7 @@ function makeService(overrides?: Partial<DashboardService>): DashboardService {
       emptyStateMessage:
         'まだ表示できるデータがありません。評価、目標、スキル登録が進むとここにKPIが表示されます。',
     }),
+    getTrendSummary: vi.fn(),
     ...overrides,
   }
 }

--- a/src/tests/dashboard/dashboard-service.test.ts
+++ b/src/tests/dashboard/dashboard-service.test.ts
@@ -32,6 +32,54 @@ function makeRepository(overrides: Partial<DashboardRepository> = {}): Dashboard
       latestFinalScore: 82.5,
       latestIncentiveScore: 12,
     }),
+    listCompanyTrend: async () => [
+      {
+        cycleId: 'cycle-1',
+        cycleName: '2025 Q3',
+        periodStart: new Date('2025-07-01T00:00:00.000Z'),
+        periodEnd: new Date('2025-09-30T23:59:59.999Z'),
+        score: 71.2,
+      },
+      {
+        cycleId: 'cycle-2',
+        cycleName: '2025 Q4',
+        periodStart: new Date('2025-10-01T00:00:00.000Z'),
+        periodEnd: new Date('2025-12-31T23:59:59.999Z'),
+        score: 74.8,
+      },
+      {
+        cycleId: 'cycle-3',
+        cycleName: '2026 Q1',
+        periodStart: new Date('2026-01-01T00:00:00.000Z'),
+        periodEnd: new Date('2026-03-31T23:59:59.999Z'),
+        score: 79.5,
+      },
+      {
+        cycleId: 'cycle-4',
+        cycleName: '2026 Q2',
+        periodStart: new Date('2026-04-01T00:00:00.000Z'),
+        periodEnd: new Date('2026-06-30T23:59:59.999Z'),
+        score: 81.4,
+      },
+    ],
+    listManagerTrend: async () => [
+      {
+        cycleId: 'cycle-2',
+        cycleName: '2025 Q4',
+        periodStart: new Date('2025-10-01T00:00:00.000Z'),
+        periodEnd: new Date('2025-12-31T23:59:59.999Z'),
+        score: 76.1,
+      },
+    ],
+    listEmployeeTrend: async () => [
+      {
+        cycleId: 'cycle-2',
+        cycleName: '2025 Q4',
+        periodStart: new Date('2025-10-01T00:00:00.000Z'),
+        periodEnd: new Date('2025-12-31T23:59:59.999Z'),
+        score: 80.4,
+      },
+    ],
     ...overrides,
   }
 }
@@ -97,5 +145,49 @@ describe('DashboardService.getKpiSummary', () => {
     const result = await service.getKpiSummary('HR_MANAGER', 'hr-1')
 
     expect(result.emptyStateMessage).toContain('まだ表示できるデータがありません')
+  })
+
+  it('HR_MANAGER のトレンドは新しい 3 サイクルに絞って返す', async () => {
+    const service = createDashboardService(makeRepository())
+
+    const result = await service.getTrendSummary('HR_MANAGER', 'hr-1', {})
+
+    expect(result.points.map((point) => point.cycleId)).toEqual(['cycle-2', 'cycle-3', 'cycle-4'])
+    expect(result.filters.departmentIds).toEqual([])
+    expect(result.emptyStateMessage).toBeNull()
+  })
+
+  it('トレンド取得時はフィルタを repository に渡す', async () => {
+    let received:
+      | {
+          readonly departmentIds: readonly string[]
+          readonly cycleIds: readonly string[]
+          readonly from: Date | null
+          readonly to: Date | null
+        }
+      | undefined
+    const service = createDashboardService(
+      makeRepository({
+        listCompanyTrend: async (filter) => {
+          received = filter
+          return []
+        },
+      }),
+    )
+
+    const result = await service.getTrendSummary('ADMIN', 'admin-1', {
+      departmentIds: ['dept-1'],
+      cycleIds: ['cycle-9'],
+      from: new Date('2026-01-01T00:00:00.000Z'),
+      to: new Date('2026-03-31T23:59:59.999Z'),
+    })
+
+    expect(received).toEqual({
+      departmentIds: ['dept-1'],
+      cycleIds: ['cycle-9'],
+      from: new Date('2026-01-01T00:00:00.000Z'),
+      to: new Date('2026-03-31T23:59:59.999Z'),
+    })
+    expect(result.emptyStateMessage).toContain('トレンドを表示できるデータがありません')
   })
 })

--- a/src/tests/dashboard/dashboard-trends-route.test.ts
+++ b/src/tests/dashboard/dashboard-trends-route.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  clearDashboardServiceForTesting,
+  setDashboardServiceForTesting,
+} from '@/lib/dashboard/dashboard-service-di'
+import type { DashboardService } from '@/lib/dashboard/dashboard-types'
+
+vi.mock('next-auth', () => ({
+  getServerSession: vi.fn(),
+}))
+
+const { getServerSession } = await import('next-auth')
+const mockedGetServerSession = vi.mocked(getServerSession)
+
+const { GET } = await import('@/app/api/dashboard/trends/route')
+
+function makeSession(role: string, userId = 'user-1') {
+  return {
+    user: { email: 'user@example.com' },
+    userId,
+    role,
+  }
+}
+
+function makeService(overrides?: Partial<DashboardService>): DashboardService {
+  return {
+    getKpiSummary: vi.fn(),
+    getTrendSummary: vi.fn().mockResolvedValue({
+      role: 'HR_MANAGER',
+      scopeUserId: 'user-1',
+      filters: {
+        departmentIds: ['dept-1'],
+        cycleIds: ['cycle-1'],
+        from: new Date('2026-01-01T00:00:00.000Z'),
+        to: new Date('2026-03-31T23:59:59.999Z'),
+      },
+      points: [],
+      emptyStateMessage: null,
+    }),
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+afterEach(() => {
+  clearDashboardServiceForTesting()
+})
+
+describe('GET /api/dashboard/trends', () => {
+  it('未認証は 401', async () => {
+    mockedGetServerSession.mockResolvedValue(null)
+
+    const res = await GET(new Request('http://localhost/api/dashboard/trends'))
+
+    expect(res.status).toBe(401)
+  })
+
+  it('query を parse して trend service に渡す', async () => {
+    mockedGetServerSession.mockResolvedValue(makeSession('HR_MANAGER', 'hr-1'))
+    const service = makeService()
+    setDashboardServiceForTesting(service)
+
+    const res = await GET(
+      new Request(
+        'http://localhost/api/dashboard/trends?departmentIds=dept-1,dept-2&cycleIds=cycle-1&from=2026-01-01T00:00:00.000Z&to=2026-03-31T23:59:59.999Z',
+      ),
+    )
+
+    expect(res.status).toBe(200)
+    expect(service.getTrendSummary).toHaveBeenCalledWith('HR_MANAGER', 'hr-1', {
+      departmentIds: ['dept-1', 'dept-2'],
+      cycleIds: ['cycle-1'],
+      from: new Date('2026-01-01T00:00:00.000Z'),
+      to: new Date('2026-03-31T23:59:59.999Z'),
+    })
+  })
+
+  it('不正な期間は 400', async () => {
+    mockedGetServerSession.mockResolvedValue(makeSession('ADMIN', 'admin-1'))
+    setDashboardServiceForTesting(makeService())
+
+    const res = await GET(
+      new Request(
+        'http://localhost/api/dashboard/trends?from=2026-04-01T00:00:00.000Z&to=2026-03-31T23:59:59.999Z',
+      ),
+    )
+
+    expect(res.status).toBe(400)
+  })
+})


### PR DESCRIPTION
## Summary
- add a dashboard trend API that returns score trend points for the latest three evaluation cycles
- support department, period, and evaluation cycle filters in the trend query contract
- extend dashboard service tests and route tests to cover trend filtering and empty states

## Verification
- pnpm vitest run src/tests/dashboard/dashboard-service.test.ts src/tests/dashboard/dashboard-route.test.ts src/tests/dashboard/dashboard-trends-route.test.ts
- pnpm type-check
- pnpm build
- pnpm test

Addresses #73