### PR TITLE
feat: add dashboard async export

### DIFF
--- a/src/app/api/dashboard/export/route.ts
+++ b/src/app/api/dashboard/export/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getAppSession } from '@/lib/auth/app-session'
+import { getDashboardService } from '@/lib/dashboard/dashboard-service-di'
+import { dashboardExportBodySchema } from '@/lib/dashboard/dashboard-types'
+import type { UserRole } from '@/lib/notification/notification-types'
+
+function isUserRole(value: unknown): value is UserRole {
+  return value === 'ADMIN' || value === 'HR_MANAGER' || value === 'MANAGER' || value === 'EMPLOYEE'
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const session = await getAppSession()
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const sess = session as Record<string, unknown>
+  const userId = typeof sess.userId === 'string' ? sess.userId : undefined
+  const role = sess.role
+  if (!userId || !isUserRole(role)) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+  if (role !== 'ADMIN' && role !== 'HR_MANAGER') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const body = await request.json().catch(() => null)
+  const parsed = dashboardExportBodySchema.safeParse({
+    format: body?.format,
+    cycleId: body?.cycleId ?? null,
+    departmentIds: Array.isArray(body?.departmentIds) ? body.departmentIds : [],
+    from: body?.from ? new Date(body.from as string) : null,
+    to: body?.to ? new Date(body.to as string) : null,
+  })
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'Invalid dashboard export body', details: parsed.error.flatten() },
+      { status: 400 },
+    )
+  }
+
+  let service: ReturnType<typeof getDashboardService>
+  try {
+    service = getDashboardService()
+  } catch {
+    return NextResponse.json({ error: 'Dashboard service not initialized' }, { status: 503 })
+  }
+
+  const result = await service.exportReport(role, userId, parsed.data, {
+    userId,
+    ipAddress: request.headers.get('x-forwarded-for') ?? 'unknown',
+    userAgent: request.headers.get('user-agent') ?? 'unknown',
+  })
+  return NextResponse.json({ success: true, data: result }, { status: 202 })
+}

--- a/src/lib/dashboard/dashboard-service.ts
+++ b/src/lib/dashboard/dashboard-service.ts
@@ -1,6 +1,10 @@
+import type { AuditLogEmitter } from '@/lib/audit/audit-log-emitter'
+import type { ExportJob } from '@/lib/export/export-job'
 import type { UserRole } from '@/lib/notification/notification-types'
 import type {
   DashboardAggregateRow,
+  DashboardAuditContext,
+  DashboardExportInput,
   DashboardRepository,
   DashboardService,
   DashboardSummary,
@@ -26,6 +30,16 @@ function normalizeTrendFilter(filter: Partial<DashboardTrendFilter>): DashboardT
     cycleIds: unique(filter.cycleIds ?? []),
     from: filter.from ?? null,
     to: filter.to ?? null,
+  }
+}
+
+function normalizeExportInput(input: DashboardExportInput): DashboardExportInput {
+  return {
+    format: input.format,
+    cycleId: input.cycleId,
+    departmentIds: unique(input.departmentIds),
+    from: input.from,
+    to: input.to,
   }
 }
 
@@ -109,8 +123,18 @@ function buildTrendEmptyStateMessage(points: readonly DashboardTrendPoint[]): st
     : 'トレンドを表示できるデータがありません。フィルタ条件を見直すか、評価サイクルの確定をお待ちください。'
 }
 
+export interface DashboardServiceDeps {
+  readonly repository: DashboardRepository
+  readonly exportJob?: ExportJob
+  readonly auditLogEmitter?: AuditLogEmitter
+}
+
 class DashboardServiceImpl implements DashboardService {
-  constructor(private readonly repository: DashboardRepository) {}
+  constructor(
+    private readonly repository: DashboardRepository,
+    private readonly exportJob?: ExportJob,
+    private readonly auditLogEmitter?: AuditLogEmitter,
+  ) {}
 
   async getKpiSummary(role: UserRole, userId: string): Promise<DashboardSummary> {
     if (role === 'ADMIN' || role === 'HR_MANAGER') {
@@ -184,8 +208,61 @@ class DashboardServiceImpl implements DashboardService {
       emptyStateMessage: buildTrendEmptyStateMessage(normalizedPoints),
     }
   }
+
+  async exportReport(
+    role: UserRole,
+    userId: string,
+    input: DashboardExportInput,
+    context: DashboardAuditContext,
+  ): Promise<{ jobId: string }> {
+    if ((role !== 'ADMIN' && role !== 'HR_MANAGER') || context.userId !== userId) {
+      throw new Error('Dashboard export forbidden')
+    }
+    if (!this.exportJob) {
+      throw new Error('Dashboard export job is not configured')
+    }
+
+    const normalizedInput = normalizeExportInput(input)
+    const result = await this.exportJob.enqueue({
+      type: 'DashboardReport',
+      format: normalizedInput.format,
+      cycleId: normalizedInput.cycleId,
+      departmentIds: [...normalizedInput.departmentIds],
+      from: normalizedInput.from?.toISOString() ?? null,
+      to: normalizedInput.to?.toISOString() ?? null,
+    })
+
+    await this.auditLogEmitter?.emit({
+      userId,
+      action: 'DATA_EXPORT',
+      resourceType: 'EXPORT_JOB',
+      resourceId: result.jobId,
+      ipAddress: context.ipAddress,
+      userAgent: context.userAgent,
+      before: null,
+      after: {
+        reportType: 'DASHBOARD',
+        format: normalizedInput.format,
+        cycleId: normalizedInput.cycleId,
+        departmentIds: [...normalizedInput.departmentIds],
+        from: normalizedInput.from?.toISOString() ?? null,
+        to: normalizedInput.to?.toISOString() ?? null,
+      },
+    })
+
+    return result
+  }
 }
 
-export function createDashboardService(repository: DashboardRepository): DashboardService {
-  return new DashboardServiceImpl(repository)
+export function createDashboardService(
+  repositoryOrDeps: DashboardRepository | DashboardServiceDeps,
+): DashboardService {
+  if ('repository' in repositoryOrDeps) {
+    return new DashboardServiceImpl(
+      repositoryOrDeps.repository,
+      repositoryOrDeps.exportJob,
+      repositoryOrDeps.auditLogEmitter,
+    )
+  }
+  return new DashboardServiceImpl(repositoryOrDeps)
 }

--- a/src/lib/dashboard/dashboard-types.ts
+++ b/src/lib/dashboard/dashboard-types.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod'
 import type { UserRole } from '@/lib/notification/notification-types'
+import type { ExportJobId } from '@/lib/export/export-types'
 
 export interface KpiMetric {
   readonly key:
@@ -60,6 +61,20 @@ export interface DashboardTrendSummary {
   readonly emptyStateMessage: string | null
 }
 
+export interface DashboardExportInput {
+  readonly format: 'pdf' | 'csv'
+  readonly cycleId: string | null
+  readonly departmentIds: readonly string[]
+  readonly from: Date | null
+  readonly to: Date | null
+}
+
+export interface DashboardAuditContext {
+  readonly userId: string
+  readonly ipAddress: string
+  readonly userAgent: string
+}
+
 export interface DashboardRepository {
   countEmployees(): Promise<number>
   countManagedMembers(managerId: string): Promise<number>
@@ -84,6 +99,12 @@ export interface DashboardService {
     userId: string,
     filter: Partial<DashboardTrendFilter>,
   ): Promise<DashboardTrendSummary>
+  exportReport(
+    role: UserRole,
+    userId: string,
+    input: DashboardExportInput,
+    context: DashboardAuditContext,
+  ): Promise<{ jobId: ExportJobId }>
 }
 
 export const dashboardQuerySchema = z.object({})
@@ -92,6 +113,23 @@ export const dashboardTrendQuerySchema = z
   .object({
     departmentIds: z.array(z.string().min(1)).default([]),
     cycleIds: z.array(z.string().min(1)).default([]),
+    from: z.date().nullable().default(null),
+    to: z.date().nullable().default(null),
+  })
+  .refine(
+    (value) =>
+      value.from === null || value.to === null || value.from.getTime() <= value.to.getTime(),
+    {
+      message: 'from must be earlier than or equal to to',
+      path: ['from'],
+    },
+  )
+
+export const dashboardExportBodySchema = z
+  .object({
+    format: z.enum(['pdf', 'csv']),
+    cycleId: z.string().min(1).nullable().default(null),
+    departmentIds: z.array(z.string().min(1)).default([]),
     from: z.date().nullable().default(null),
     to: z.date().nullable().default(null),
   })

--- a/src/lib/export/export-types.ts
+++ b/src/lib/export/export-types.ts
@@ -37,6 +37,15 @@ const evaluationReportSchema = z.object({
   format: z.enum(['pdf', 'csv']),
 })
 
+const dashboardReportSchema = z.object({
+  type: z.literal('DashboardReport'),
+  format: z.enum(['pdf', 'csv']),
+  cycleId: z.string().min(1).nullable(),
+  departmentIds: z.array(z.string().min(1)),
+  from: z.string().datetime().nullable(),
+  to: z.string().datetime().nullable(),
+})
+
 const auditLogSchema = z.object({
   type: z.literal('AuditLog'),
   filter: z.record(z.unknown()),
@@ -46,6 +55,7 @@ export const exportRequestSchema = z.discriminatedUnion('type', [
   masterCsvSchema,
   organizationCsvSchema,
   evaluationReportSchema,
+  dashboardReportSchema,
   auditLogSchema,
 ])
 

--- a/src/lib/export/export-worker.ts
+++ b/src/lib/export/export-worker.ts
@@ -55,6 +55,14 @@ function generateContent(payload: ExportRequest): string {
         ? `%PDF-1.4 stub for cycleId=${payload.cycleId}`
         : `cycle_id,employee_id,score\n${payload.cycleId},,,`
 
+    case 'DashboardReport':
+      return payload.format === 'pdf'
+        ? `%PDF-1.4 stub for dashboard report cycleId=${payload.cycleId ?? 'all'}`
+        : [
+            'cycle_id,department_ids,from,to',
+            `"${payload.cycleId ?? ''}","${payload.departmentIds.join('|')}","${payload.from ?? ''}","${payload.to ?? ''}"`,
+          ].join('\n')
+
     case 'AuditLog':
       return 'occurred_at,action,resource_type,resource_id,actor_id\n'
   }
@@ -89,7 +97,10 @@ function generateMasterCsv(resource: string): string {
 }
 
 function getExtension(payload: ExportRequest): string {
-  if (payload.type === 'EvaluationReport' && payload.format === 'pdf') {
+  if (
+    (payload.type === 'EvaluationReport' || payload.type === 'DashboardReport') &&
+    payload.format === 'pdf'
+  ) {
     return 'pdf'
   }
   return 'csv'

--- a/src/tests/dashboard/dashboard-export-route.test.ts
+++ b/src/tests/dashboard/dashboard-export-route.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  clearDashboardServiceForTesting,
+  setDashboardServiceForTesting,
+} from '@/lib/dashboard/dashboard-service-di'
+import type { DashboardService } from '@/lib/dashboard/dashboard-types'
+
+vi.mock('next-auth', () => ({
+  getServerSession: vi.fn(),
+}))
+
+const { getServerSession } = await import('next-auth')
+const mockedGetServerSession = vi.mocked(getServerSession)
+
+const { POST } = await import('@/app/api/dashboard/export/route')
+
+function makeSession(role: string, userId = 'user-1') {
+  return {
+    user: { email: 'user@example.com' },
+    userId,
+    role,
+  }
+}
+
+function makeService(overrides?: Partial<DashboardService>): DashboardService {
+  return {
+    getKpiSummary: vi.fn(),
+    getTrendSummary: vi.fn(),
+    exportReport: vi.fn().mockResolvedValue({ jobId: 'job-dashboard-1' }),
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+afterEach(() => {
+  clearDashboardServiceForTesting()
+})
+
+describe('POST /api/dashboard/export', () => {
+  it('未認証は 401', async () => {
+    mockedGetServerSession.mockResolvedValue(null)
+
+    const res = await POST(
+      new Request('http://localhost/api/dashboard/export', { method: 'POST' }) as never,
+    )
+
+    expect(res.status).toBe(401)
+  })
+
+  it('MANAGER は 403', async () => {
+    mockedGetServerSession.mockResolvedValue(makeSession('MANAGER', 'manager-1'))
+    setDashboardServiceForTesting(makeService())
+
+    const res = await POST(
+      new Request('http://localhost/api/dashboard/export', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ format: 'csv', cycleId: null, departmentIds: [] }),
+      }) as never,
+    )
+
+    expect(res.status).toBe(403)
+  })
+
+  it('HR_MANAGER は export job を起動して 202 を返す', async () => {
+    mockedGetServerSession.mockResolvedValue(makeSession('HR_MANAGER', 'hr-1'))
+    const service = makeService()
+    setDashboardServiceForTesting(service)
+
+    const res = await POST(
+      new Request('http://localhost/api/dashboard/export', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-forwarded-for': '203.0.113.1',
+          'user-agent': 'vitest',
+        },
+        body: JSON.stringify({
+          format: 'pdf',
+          cycleId: 'cycle-1',
+          departmentIds: ['dept-1'],
+          from: '2026-01-01T00:00:00.000Z',
+          to: '2026-03-31T23:59:59.999Z',
+        }),
+      }) as never,
+    )
+
+    expect(res.status).toBe(202)
+    expect(service.exportReport).toHaveBeenCalledWith(
+      'HR_MANAGER',
+      'hr-1',
+      {
+        format: 'pdf',
+        cycleId: 'cycle-1',
+        departmentIds: ['dept-1'],
+        from: new Date('2026-01-01T00:00:00.000Z'),
+        to: new Date('2026-03-31T23:59:59.999Z'),
+      },
+      {
+        userId: 'hr-1',
+        ipAddress: '203.0.113.1',
+        userAgent: 'vitest',
+      },
+    )
+  })
+})

--- a/src/tests/dashboard/dashboard-route.test.ts
+++ b/src/tests/dashboard/dashboard-route.test.ts
@@ -32,6 +32,7 @@ function makeService(overrides?: Partial<DashboardService>): DashboardService {
         'まだ表示できるデータがありません。評価、目標、スキル登録が進むとここにKPIが表示されます。',
     }),
     getTrendSummary: vi.fn(),
+    exportReport: vi.fn(),
     ...overrides,
   }
 }

--- a/src/tests/dashboard/dashboard-service.test.ts
+++ b/src/tests/dashboard/dashboard-service.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
+import type { AuditLogEmitter } from '@/lib/audit/audit-log-emitter'
 import { createDashboardService } from '@/lib/dashboard/dashboard-service'
 import type { DashboardRepository } from '@/lib/dashboard/dashboard-types'
+import type { ExportJob } from '@/lib/export/export-job'
 
 function makeRepository(overrides: Partial<DashboardRepository> = {}): DashboardRepository {
   return {
@@ -84,7 +86,7 @@ function makeRepository(overrides: Partial<DashboardRepository> = {}): Dashboard
   }
 }
 
-describe('DashboardService.getKpiSummary', () => {
+describe('DashboardService', () => {
   it('ADMIN は全社 KPI を返す', async () => {
     const service = createDashboardService(makeRepository())
 
@@ -189,5 +191,52 @@ describe('DashboardService.getKpiSummary', () => {
       to: new Date('2026-03-31T23:59:59.999Z'),
     })
     expect(result.emptyStateMessage).toContain('トレンドを表示できるデータがありません')
+  })
+
+  it('HR_MANAGER は dashboard report export job を投入し監査ログを残す', async () => {
+    const exportJob: ExportJob = {
+      enqueue: async () => ({ jobId: 'job-dashboard-1' }),
+      getStatus: async () => null,
+      getDownloadUrl: async () => null,
+    }
+    const entries: Parameters<AuditLogEmitter['emit']>[0][] = []
+    const auditLogEmitter: AuditLogEmitter = {
+      emit: async (entry) => {
+        entries.push(entry)
+      },
+    }
+    const service = createDashboardService({
+      repository: makeRepository(),
+      exportJob,
+      auditLogEmitter,
+    })
+
+    const result = await service.exportReport(
+      'HR_MANAGER',
+      'hr-1',
+      {
+        format: 'pdf',
+        cycleId: 'cycle-3',
+        departmentIds: ['dept-1', 'dept-2'],
+        from: new Date('2026-01-01T00:00:00.000Z'),
+        to: new Date('2026-03-31T23:59:59.999Z'),
+      },
+      {
+        userId: 'hr-1',
+        ipAddress: '127.0.0.1',
+        userAgent: 'vitest',
+      },
+    )
+
+    expect(result).toEqual({ jobId: 'job-dashboard-1' })
+    expect(entries).toHaveLength(1)
+    expect(entries[0]).toEqual(
+      expect.objectContaining({
+        userId: 'hr-1',
+        action: 'DATA_EXPORT',
+        resourceType: 'EXPORT_JOB',
+        resourceId: 'job-dashboard-1',
+      }),
+    )
   })
 })

--- a/src/tests/dashboard/dashboard-trends-route.test.ts
+++ b/src/tests/dashboard/dashboard-trends-route.test.ts
@@ -37,6 +37,7 @@ function makeService(overrides?: Partial<DashboardService>): DashboardService {
       points: [],
       emptyStateMessage: null,
     }),
+    exportReport: vi.fn(),
     ...overrides,
   }
 }
@@ -53,7 +54,7 @@ describe('GET /api/dashboard/trends', () => {
   it('未認証は 401', async () => {
     mockedGetServerSession.mockResolvedValue(null)
 
-    const res = await GET(new Request('http://localhost/api/dashboard/trends'))
+    const res = await GET(new Request('http://localhost/api/dashboard/trends') as never)
 
     expect(res.status).toBe(401)
   })
@@ -66,7 +67,7 @@ describe('GET /api/dashboard/trends', () => {
     const res = await GET(
       new Request(
         'http://localhost/api/dashboard/trends?departmentIds=dept-1,dept-2&cycleIds=cycle-1&from=2026-01-01T00:00:00.000Z&to=2026-03-31T23:59:59.999Z',
-      ),
+      ) as never,
     )
 
     expect(res.status).toBe(200)
@@ -85,7 +86,7 @@ describe('GET /api/dashboard/trends', () => {
     const res = await GET(
       new Request(
         'http://localhost/api/dashboard/trends?from=2026-04-01T00:00:00.000Z&to=2026-03-31T23:59:59.999Z',
-      ),
+      ) as never,
     )
 
     expect(res.status).toBe(400)

--- a/src/tests/export/export-job.test.ts
+++ b/src/tests/export/export-job.test.ts
@@ -87,6 +87,27 @@ describe('ExportJob', () => {
         expect.objectContaining({ type: 'EvaluationReport', cycleId: 'cycle-1', format: 'pdf' }),
       )
     })
+
+    it('should pass DashboardReport request correctly', async () => {
+      const exportJob = createExportJob(queueMock, storageMock)
+      await exportJob.enqueue({
+        type: 'DashboardReport',
+        format: 'csv',
+        cycleId: 'cycle-1',
+        departmentIds: ['dept-1'],
+        from: '2026-01-01T00:00:00.000Z',
+        to: '2026-03-31T23:59:59.999Z',
+      })
+      expect(queueMock.enqueue).toHaveBeenCalledWith(
+        'export-csv',
+        expect.objectContaining({
+          type: 'DashboardReport',
+          format: 'csv',
+          cycleId: 'cycle-1',
+          departmentIds: ['dept-1'],
+        }),
+      )
+    })
   })
 
   describe('getStatus()', () => {

--- a/src/tests/export/export-types.test.ts
+++ b/src/tests/export/export-types.test.ts
@@ -30,13 +30,26 @@ describe('isExportRequest()', () => {
   })
 
   it('should return true for EvaluationReport request', () => {
-    expect(
-      isExportRequest({ type: 'EvaluationReport', cycleId: 'cycle-1', format: 'pdf' }),
-    ).toBe(true)
+    expect(isExportRequest({ type: 'EvaluationReport', cycleId: 'cycle-1', format: 'pdf' })).toBe(
+      true,
+    )
   })
 
   it('should return true for AuditLog request', () => {
     expect(isExportRequest({ type: 'AuditLog', filter: {} })).toBe(true)
+  })
+
+  it('should return true for DashboardReport request', () => {
+    expect(
+      isExportRequest({
+        type: 'DashboardReport',
+        format: 'pdf',
+        cycleId: 'cycle-1',
+        departmentIds: ['dept-1'],
+        from: '2026-01-01T00:00:00.000Z',
+        to: '2026-03-31T23:59:59.999Z',
+      }),
+    ).toBe(true)
   })
 
   it('should return false for unknown type', () => {
@@ -77,6 +90,18 @@ describe('exportRequestSchema', () => {
 
   it('should validate AuditLog variant', () => {
     const result = exportRequestSchema.safeParse({ type: 'AuditLog', filter: { userId: 'u-1' } })
+    expect(result.success).toBe(true)
+  })
+
+  it('should validate DashboardReport variant', () => {
+    const result = exportRequestSchema.safeParse({
+      type: 'DashboardReport',
+      format: 'pdf',
+      cycleId: 'cycle-1',
+      departmentIds: ['dept-1'],
+      from: '2026-01-01T00:00:00.000Z',
+      to: '2026-03-31T23:59:59.999Z',
+    })
     expect(result.success).toBe(true)
   })
 

--- a/src/tests/export/export-worker.test.ts
+++ b/src/tests/export/export-worker.test.ts
@@ -106,6 +106,21 @@ describe('processExportJob()', () => {
     expect(uploadPath).toMatch(/\.csv$/)
   })
 
+  it('should process DashboardReport (pdf) and upload a file', async () => {
+    const job = makeJob({
+      type: 'DashboardReport',
+      format: 'pdf',
+      cycleId: 'cycle-1',
+      departmentIds: ['dept-1'],
+      from: '2026-01-01T00:00:00.000Z',
+      to: '2026-03-31T23:59:59.999Z',
+    })
+    const result = await processExportJob(job, storageMock)
+    expect(result.blobKey).toBeTruthy()
+    const [uploadPath] = storageMock.upload.mock.calls[0]!
+    expect(uploadPath).toMatch(/\.pdf$/)
+  })
+
   it('should use "unknown" as fallback when job.id is undefined', async () => {
     const job = { id: undefined, data: { type: 'OrganizationCsv' } } as unknown as Parameters<
       typeof processExportJob


### PR DESCRIPTION
## Summary
- add asynchronous dashboard report export via the shared ExportJob infrastructure
- introduce POST /api/dashboard/export for ADMIN and HR_MANAGER users with PDF and CSV support
- extend export request and worker handling for dashboard report payloads and cover the flow with tests

## Verification
- pnpm vitest run src/tests/dashboard/dashboard-service.test.ts src/tests/dashboard/dashboard-route.test.ts src/tests/dashboard/dashboard-export-route.test.ts src/tests/export/export-types.test.ts src/tests/export/export-job.test.ts src/tests/export/export-worker.test.ts
- pnpm type-check
- pnpm build
- pnpm test

Addresses #74