### PR TITLE
feat: add security middleware guards

### DIFF
--- a/src/lib/security/request-security.ts
+++ b/src/lib/security/request-security.ts
@@ -1,0 +1,185 @@
+import { NextResponse, type NextRequest } from 'next/server'
+
+export interface RateLimitResult {
+  readonly allowed: boolean
+  readonly remaining: number
+  readonly retryAfterSec: number
+}
+
+export interface RateLimitBucket {
+  readonly key: string
+  readonly limit: number
+  readonly windowSec: number
+}
+
+interface WindowEntry {
+  timestamps: number[]
+}
+
+export class InMemoryRequestRateLimiter {
+  private readonly store = new Map<string, WindowEntry>()
+
+  constructor(private readonly nowFn: () => number = () => Date.now()) {}
+
+  check(bucket: RateLimitBucket): RateLimitResult {
+    const now = this.nowFn()
+    const windowStart = now - bucket.windowSec * 1000
+    const storeKey = `${bucket.key}:${bucket.limit}:${bucket.windowSec}`
+
+    let entry = this.store.get(storeKey)
+    if (!entry) {
+      entry = { timestamps: [] }
+      this.store.set(storeKey, entry)
+    }
+
+    entry.timestamps = entry.timestamps.filter((timestamp) => timestamp > windowStart)
+
+    if (entry.timestamps.length >= bucket.limit) {
+      const oldest = entry.timestamps[0] ?? now
+      const retryAfterMs = oldest + bucket.windowSec * 1000 - now
+      return {
+        allowed: false,
+        remaining: 0,
+        retryAfterSec: Math.max(1, Math.ceil(retryAfterMs / 1000)),
+      }
+    }
+
+    entry.timestamps.push(now)
+    return {
+      allowed: true,
+      remaining: bucket.limit - entry.timestamps.length,
+      retryAfterSec: 0,
+    }
+  }
+}
+
+interface RateLimitRule {
+  readonly name: 'api' | 'login' | 'ai' | 'search' | 'export'
+  readonly matcher: (request: NextRequest) => boolean
+  readonly limit: number
+  readonly windowSec: number
+  readonly key: (request: NextRequest) => string
+}
+
+function extractClientIp(request: NextRequest): string {
+  return (
+    request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ??
+    request.headers.get('x-real-ip') ??
+    'unknown'
+  )
+}
+
+function isLocalhost(hostname: string): boolean {
+  return hostname === 'localhost' || hostname === '127.0.0.1' || hostname.endsWith('.localhost')
+}
+
+function matchesPath(pathname: string, prefixes: readonly string[]): boolean {
+  return prefixes.some((prefix) => pathname.startsWith(prefix))
+}
+
+const RATE_LIMIT_RULES: readonly RateLimitRule[] = [
+  {
+    name: 'login',
+    matcher: (request) =>
+      request.nextUrl.pathname.startsWith('/api/auth/') || request.nextUrl.pathname === '/api/auth',
+    limit: 10,
+    windowSec: 60,
+    key: (request) => `login:${extractClientIp(request)}`,
+  },
+  {
+    name: 'ai',
+    matcher: (request) => request.nextUrl.pathname.startsWith('/api/evaluation/ai-coach/'),
+    limit: 20,
+    windowSec: 60,
+    key: (request) => `ai:${extractClientIp(request)}`,
+  },
+  {
+    name: 'search',
+    matcher: (request) =>
+      matchesPath(request.nextUrl.pathname, ['/api/career/map/', '/api/skills/post-candidates']),
+    limit: 60,
+    windowSec: 60,
+    key: (request) => `search:${extractClientIp(request)}`,
+  },
+  {
+    name: 'export',
+    matcher: (request) =>
+      matchesPath(request.nextUrl.pathname, [
+        '/api/dashboard/export',
+        '/api/organization/export',
+        '/api/masters/',
+      ]) && request.nextUrl.pathname.endsWith('/export'),
+    limit: 5,
+    windowSec: 60,
+    key: (request) => `export:${extractClientIp(request)}`,
+  },
+  {
+    name: 'api',
+    matcher: (request) => request.nextUrl.pathname.startsWith('/api/'),
+    limit: 100,
+    windowSec: 60,
+    key: (request) => `api:${extractClientIp(request)}`,
+  },
+]
+
+export function shouldRedirectToHttps(request: NextRequest): boolean {
+  const proto =
+    request.headers.get('x-forwarded-proto') ?? request.nextUrl.protocol.replace(':', '')
+  return proto === 'http' && !isLocalhost(request.nextUrl.hostname)
+}
+
+export function createHttpsRedirectResponse(request: NextRequest): NextResponse {
+  const redirectUrl = request.nextUrl.clone()
+  redirectUrl.protocol = 'https:'
+  return NextResponse.redirect(redirectUrl, 308)
+}
+
+export function applySecurityHeaders(response: NextResponse): NextResponse {
+  response.headers.set(
+    'Content-Security-Policy',
+    "default-src 'self'; frame-ancestors 'none'; base-uri 'self'; object-src 'none';",
+  )
+  response.headers.set('Strict-Transport-Security', 'max-age=31536000; includeSubDomains')
+  response.headers.set('X-Frame-Options', 'DENY')
+  response.headers.set('X-Content-Type-Options', 'nosniff')
+  response.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin')
+  response.headers.set('Permissions-Policy', 'camera=(), microphone=(), geolocation=()')
+  return response
+}
+
+export function enforceRateLimits(
+  request: NextRequest,
+  limiter: InMemoryRequestRateLimiter,
+): NextResponse | null {
+  let maxRetryAfter = 0
+
+  for (const rule of RATE_LIMIT_RULES) {
+    if (!rule.matcher(request)) {
+      continue
+    }
+
+    const result = limiter.check({
+      key: rule.key(request),
+      limit: rule.limit,
+      windowSec: rule.windowSec,
+    })
+    if (result.allowed) {
+      continue
+    }
+
+    maxRetryAfter = Math.max(maxRetryAfter, result.retryAfterSec)
+    const response = NextResponse.json(
+      {
+        error: 'Too Many Requests',
+        bucket: rule.name,
+        retryAfterSec: maxRetryAfter,
+      },
+      { status: 429 },
+    )
+    response.headers.set('Retry-After', String(maxRetryAfter))
+    response.headers.set('X-RateLimit-Bucket', rule.name)
+    return response
+  }
+
+  return null
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,16 +1,33 @@
 import { type NextRequest, NextResponse } from 'next/server'
 import { createAccessLogMiddleware } from '@/lib/access-log/access-log-middleware'
+import {
+  applySecurityHeaders,
+  createHttpsRedirectResponse,
+  enforceRateLimits,
+  InMemoryRequestRateLimiter,
+  shouldRedirectToHttps,
+} from '@/lib/security/request-security'
 
 const accessLog = createAccessLogMiddleware()
+const rateLimiter = new InMemoryRequestRateLimiter()
 
 export async function middleware(request: NextRequest): Promise<NextResponse> {
-  return accessLog(request, async (req) => {
-    // 認証ミドルウェアは後続のタスク（Task 6.1）で実装予定
-    // ここでは Next.js のデフォルトレスポンスをそのまま返す
+  if (shouldRedirectToHttps(request)) {
+    return applySecurityHeaders(createHttpsRedirectResponse(request))
+  }
+
+  const rateLimited = enforceRateLimits(request, rateLimiter)
+  if (rateLimited) {
+    return applySecurityHeaders(rateLimited)
+  }
+
+  const response = (await accessLog(request, async (req) => {
     return NextResponse.next({ request: req })
-  }) as Promise<NextResponse>
+  })) as NextResponse
+
+  return applySecurityHeaders(response)
 }
 
 export const config = {
-  matcher: ['/api/:path*'],
+  matcher: ['/((?!_next/static|_next/image|favicon.ico).*)'],
 }

--- a/src/tests/access-log/access-log-middleware-integration.test.ts
+++ b/src/tests/access-log/access-log-middleware-integration.test.ts
@@ -13,12 +13,18 @@ describe('Next.js middleware integration', () => {
     expect(content).toContain('createAccessLogMiddleware')
   })
 
+  it('should import request security helpers', () => {
+    expect(content).toContain('applySecurityHeaders')
+    expect(content).toContain('enforceRateLimits')
+    expect(content).toContain('shouldRedirectToHttps')
+  })
+
   it('should export middleware function', () => {
     expect(content).toContain('export async function middleware')
   })
 
-  it('should configure matcher for /api/** paths', () => {
-    expect(content).toContain("'/api/:path*'")
+  it('should configure matcher as a global route pattern', () => {
+    expect(content).toContain('/((?!_next/static|_next/image|favicon.ico).*)')
   })
 
   it('should export config with matcher', () => {

--- a/src/tests/security/request-security.test.ts
+++ b/src/tests/security/request-security.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+import { NextRequest, NextResponse } from 'next/server'
+import {
+  applySecurityHeaders,
+  createHttpsRedirectResponse,
+  enforceRateLimits,
+  InMemoryRequestRateLimiter,
+  shouldRedirectToHttps,
+} from '@/lib/security/request-security'
+
+function makeRequest(
+  url: string,
+  init?: ConstructorParameters<typeof NextRequest>[1],
+): NextRequest {
+  return new NextRequest(url, init)
+}
+
+describe('request security helpers', () => {
+  it('http production request is redirected to https', () => {
+    const request = makeRequest('http://example.com/api/users', {
+      headers: { 'x-forwarded-proto': 'http' },
+    })
+
+    expect(shouldRedirectToHttps(request)).toBe(true)
+
+    const response = createHttpsRedirectResponse(request)
+    expect(response.status).toBe(308)
+    expect(response.headers.get('location')).toBe('https://example.com/api/users')
+  })
+
+  it('localhost request is not redirected', () => {
+    const request = makeRequest('http://localhost:3000/api/users', {
+      headers: { 'x-forwarded-proto': 'http' },
+    })
+
+    expect(shouldRedirectToHttps(request)).toBe(false)
+  })
+
+  it('adds security headers to response', () => {
+    const response = applySecurityHeaders(NextResponse.next())
+
+    expect(response.headers.get('Strict-Transport-Security')).toContain('max-age=31536000')
+    expect(response.headers.get('Content-Security-Policy')).toContain("default-src 'self'")
+    expect(response.headers.get('X-Frame-Options')).toBe('DENY')
+    expect(response.headers.get('X-Content-Type-Options')).toBe('nosniff')
+  })
+
+  it('enforces login specific rate limit before generic api limit', () => {
+    const limiter = new InMemoryRequestRateLimiter(() => 1_000_000)
+    const request = makeRequest('https://example.com/api/auth/sessions', {
+      headers: { 'x-forwarded-for': '203.0.113.10' },
+    })
+
+    for (let i = 0; i < 10; i++) {
+      expect(enforceRateLimits(request, limiter)).toBeNull()
+    }
+
+    const blocked = enforceRateLimits(request, limiter)
+    expect(blocked?.status).toBe(429)
+    expect(blocked?.headers.get('X-RateLimit-Bucket')).toBe('login')
+  })
+
+  it('enforces export specific rate limit', () => {
+    const limiter = new InMemoryRequestRateLimiter(() => 2_000_000)
+    const request = makeRequest('https://example.com/api/dashboard/export', {
+      headers: { 'x-forwarded-for': '203.0.113.20' },
+      method: 'POST',
+    })
+
+    for (let i = 0; i < 5; i++) {
+      expect(enforceRateLimits(request, limiter)).toBeNull()
+    }
+
+    const blocked = enforceRateLimits(request, limiter)
+    expect(blocked?.status).toBe(429)
+    expect(blocked?.headers.get('X-RateLimit-Bucket')).toBe('export')
+    expect(blocked?.headers.get('Retry-After')).toBeTruthy()
+  })
+})


### PR DESCRIPTION
## Summary
- add reusable request security helpers for HTTPS redirects, security headers, and route-specific rate limits
- apply the security middleware globally while preserving access logging
- add tests for redirect behavior, response headers, and rate-limit enforcement

## Verification
- pnpm vitest run src/tests/security/request-security.test.ts src/tests/access-log/access-log-middleware.test.ts src/tests/access-log/access-log-middleware-integration.test.ts
- pnpm type-check
- pnpm build
- pnpm test

Addresses #75