### PR TITLE
feat: add error monitoring and structured logging

### DIFF
--- a/src/lib/access-log/access-log-middleware.ts
+++ b/src/lib/access-log/access-log-middleware.ts
@@ -1,4 +1,6 @@
 import type { NextRequest } from 'next/server'
+import type { StructuredLogger } from '@/lib/monitoring/structured-logger'
+import type { SecurityEventRecorderPort } from '@/lib/monitoring/security-monitoring-service'
 import type { AccessLogRepository } from './access-log-repository'
 
 // Edge Runtime では Prisma 非対応のため no-op をデフォルトとする
@@ -12,6 +14,12 @@ type NextFn = (req: NextRequest) => Promise<Response>
 
 export interface AccessLogMiddleware {
   (req: NextRequest, next: NextFn): Promise<Response>
+}
+
+interface AccessLogMiddlewareOptions {
+  readonly repository?: AccessLogRepository
+  readonly logger?: StructuredLogger
+  readonly securityMonitor?: SecurityEventRecorderPort
 }
 
 function extractIp(req: NextRequest): string {
@@ -30,8 +38,16 @@ function extractRequestId(req: NextRequest): string {
  * アクセスログミドルウェア
  * /api/** パスのみ記録し、fire-and-forget で非同期に書き込む（Requirement 17.6）
  */
-export function createAccessLogMiddleware(repo?: AccessLogRepository): AccessLogMiddleware {
-  const repository = repo ?? noopRepository
+export function createAccessLogMiddleware(
+  repo?: AccessLogRepository | AccessLogMiddlewareOptions,
+): AccessLogMiddleware {
+  const options =
+    repo && typeof (repo as AccessLogRepository).insert === 'function'
+      ? { repository: repo as AccessLogRepository }
+      : ((repo ?? {}) as AccessLogMiddlewareOptions)
+  const repository = options.repository ?? noopRepository
+  const logger = options.logger
+  const securityMonitor = options.securityMonitor
 
   return async (req: NextRequest, next: NextFn): Promise<Response> => {
     const path = req.nextUrl.pathname
@@ -57,9 +73,32 @@ export function createAccessLogMiddleware(repo?: AccessLogRepository): AccessLog
         userId: null, // 認証ミドルウェアで設定するため初期値は null
         requestId: extractRequestId(req),
       })
-      .catch(() => {
+      .catch((error: unknown) => {
         // ログ書き込み失敗は無視（本番では structured logger に転送する）
+        if (logger && error instanceof Error) {
+          void logger.error(
+            'access-log.persist_failed',
+            'failed to persist access log',
+            {
+              requestId: extractRequestId(req),
+              path,
+            },
+            error,
+          )
+        }
       })
+
+    if (securityMonitor && response.status === 429) {
+      void securityMonitor.record({
+        type: 'RATE_LIMITED',
+        occurredAt: new Date(),
+        ipAddress: extractIp(req),
+        userId: null,
+        requestId: extractRequestId(req),
+        path,
+        metadata: null,
+      })
+    }
 
     return response
   }

--- a/src/lib/auth/auth-service.ts
+++ b/src/lib/auth/auth-service.ts
@@ -26,6 +26,7 @@ import type { PasswordHasher } from './password-hasher'
 import { SESSION_ABSOLUTE_TTL_MS } from './session-store'
 import type { SessionStore } from './session-store'
 import type { AuthUserRepository } from './user-repository'
+import type { SecurityEventRecorderPort } from '@/lib/monitoring/security-monitoring-service'
 
 export interface LoginContext {
   readonly ipAddress?: string
@@ -86,6 +87,7 @@ export interface AuthServiceDeps {
   readonly notifier?: LockoutNotifier
   /** Task 6.2: ACCOUNT_LOCKED の監査ログ。未指定時は監査出力なし */
   readonly auditLogger?: AuthAuditLoggerPort
+  readonly securityMonitor?: SecurityEventRecorderPort
 }
 
 function defaultSessionIdFactory(): string {
@@ -107,6 +109,7 @@ class AuthServiceImpl implements AuthService {
   private readonly lockout?: LockoutStore
   private readonly notifier?: LockoutNotifier
   private readonly auditLogger?: AuthAuditLoggerPort
+  private readonly securityMonitor?: SecurityEventRecorderPort
 
   constructor(deps: AuthServiceDeps) {
     if (typeof deps.appSecret !== 'string' || deps.appSecret.length === 0) {
@@ -122,6 +125,7 @@ class AuthServiceImpl implements AuthService {
     this.lockout = deps.lockout
     this.notifier = deps.notifier
     this.auditLogger = deps.auditLogger
+    this.securityMonitor = deps.securityMonitor
   }
 
   async login(input: LoginInput, context?: LoginContext, now?: Date): Promise<Session> {
@@ -151,6 +155,23 @@ class AuthServiceImpl implements AuthService {
 
     const passwordOk = await this.passwordHasher.verify(parsed.password, user.passwordHash)
     if (!passwordOk) {
+      if (this.securityMonitor) {
+        try {
+          await this.securityMonitor.record({
+            type: 'AUTH_FAILURE',
+            occurredAt: issuedAt,
+            ipAddress: context?.ipAddress,
+            userId: user.id,
+            requestId: undefined,
+            path: undefined,
+            metadata: {
+              email: parsed.email,
+            },
+          })
+        } catch {
+          // 監視失敗は認証フローを妨げない
+        }
+      }
       await this.handleFailedAttempt(user.id, user.email, issuedAt, context)
       throw new InvalidCredentialsError()
     }

--- a/src/lib/monitoring/operations-dashboard-service.ts
+++ b/src/lib/monitoring/operations-dashboard-service.ts
@@ -1,0 +1,64 @@
+import type { FailureRateSummary } from '@/lib/ai-monitoring/ai-usage-types'
+import type { SecuritySummary } from './security-monitoring-service'
+
+export interface AccessLogMetricRecord {
+  readonly statusCode: number
+  readonly requestedAt: Date
+}
+
+export interface AccessLogMetricsPort {
+  listByDateRange(period: {
+    readonly from: Date
+    readonly to: Date
+  }): Promise<readonly AccessLogMetricRecord[]>
+}
+
+export interface OperationsSnapshot {
+  readonly apiErrors: {
+    readonly totalRequests: number
+    readonly errorCount: number
+    readonly errorRate: number
+  }
+  readonly aiFailures: FailureRateSummary
+  readonly security: SecuritySummary
+}
+
+export interface OperationsDashboardService {
+  getSnapshot(period: { readonly from: Date; readonly to: Date }): Promise<OperationsSnapshot>
+}
+
+interface CreateOperationsDashboardServiceOptions {
+  readonly accessLogs: AccessLogMetricsPort
+  readonly aiMonitoring: {
+    getFailureRate(period: { readonly from: Date; readonly to: Date }): Promise<FailureRateSummary>
+  }
+  readonly securityMonitoring: {
+    getSummary(period: { readonly from: Date; readonly to: Date }): Promise<SecuritySummary>
+  }
+}
+
+export function createOperationsDashboardService(
+  options: CreateOperationsDashboardServiceOptions,
+): OperationsDashboardService {
+  return {
+    async getSnapshot(period): Promise<OperationsSnapshot> {
+      const [requests, aiFailures, security] = await Promise.all([
+        options.accessLogs.listByDateRange(period),
+        options.aiMonitoring.getFailureRate(period),
+        options.securityMonitoring.getSummary(period),
+      ])
+      const errorCount = requests.filter((request) => request.statusCode >= 500).length
+      const totalRequests = requests.length
+
+      return {
+        apiErrors: {
+          totalRequests,
+          errorCount,
+          errorRate: totalRequests === 0 ? 0 : errorCount / totalRequests,
+        },
+        aiFailures,
+        security,
+      }
+    },
+  }
+}

--- a/src/lib/monitoring/security-monitoring-service.ts
+++ b/src/lib/monitoring/security-monitoring-service.ts
@@ -1,0 +1,137 @@
+export type SecurityEventType = 'AUTH_FAILURE' | 'ACCESS_DENIED' | 'RATE_LIMITED'
+
+export interface SecurityEvent {
+  readonly type: SecurityEventType
+  readonly occurredAt: Date
+  readonly ipAddress?: string
+  readonly userId?: string | null
+  readonly requestId?: string
+  readonly path?: string
+  readonly metadata: Record<string, unknown> | null
+}
+
+export interface SecurityAlert {
+  readonly type: SecurityEventType
+  readonly count: number
+  readonly threshold: number
+  readonly triggeredAt: Date
+}
+
+export interface SecuritySummary {
+  readonly totalCount: number
+  readonly countsByType: Record<SecurityEventType, number>
+}
+
+export interface SecurityEventRepository {
+  append(event: SecurityEvent): Promise<void>
+  listByDateRange(period: {
+    readonly from: Date
+    readonly to: Date
+  }): Promise<readonly SecurityEvent[]>
+}
+
+export interface SecurityEventRecorderPort {
+  record(event: SecurityEvent): Promise<readonly SecurityAlert[]>
+}
+
+export interface SecurityMonitoringService extends SecurityEventRecorderPort {
+  getSummary(period: { readonly from: Date; readonly to: Date }): Promise<SecuritySummary>
+}
+
+interface CreateSecurityMonitoringServiceOptions {
+  readonly repository: SecurityEventRepository
+  readonly thresholds?: Partial<Record<SecurityEventType, number>>
+  readonly windowMs?: number
+}
+
+const DEFAULT_THRESHOLDS: Record<SecurityEventType, number> = {
+  AUTH_FAILURE: 5,
+  ACCESS_DENIED: 10,
+  RATE_LIMITED: 10,
+}
+
+const DEFAULT_WINDOW_MS = 15 * 60 * 1000
+
+class InMemorySecurityEventRepository implements SecurityEventRepository {
+  private readonly events: SecurityEvent[]
+
+  constructor(seed: readonly SecurityEvent[] = []) {
+    this.events = [...seed]
+  }
+
+  async append(event: SecurityEvent): Promise<void> {
+    this.events.push(event)
+  }
+
+  async listByDateRange(period: {
+    readonly from: Date
+    readonly to: Date
+  }): Promise<readonly SecurityEvent[]> {
+    return this.events.filter(
+      (event) =>
+        event.occurredAt.getTime() >= period.from.getTime() &&
+        event.occurredAt.getTime() <= period.to.getTime(),
+    )
+  }
+}
+
+function emptyCounts(): Record<SecurityEventType, number> {
+  return {
+    AUTH_FAILURE: 0,
+    ACCESS_DENIED: 0,
+    RATE_LIMITED: 0,
+  }
+}
+
+export function createInMemorySecurityEventRepository(seed?: {
+  readonly events?: readonly SecurityEvent[]
+}): SecurityEventRepository {
+  return new InMemorySecurityEventRepository(seed?.events ?? [])
+}
+
+export function createSecurityMonitoringService(
+  options: CreateSecurityMonitoringServiceOptions,
+): SecurityMonitoringService {
+  const thresholds = { ...DEFAULT_THRESHOLDS, ...options.thresholds }
+  const windowMs = options.windowMs ?? DEFAULT_WINDOW_MS
+
+  return {
+    async record(event): Promise<readonly SecurityAlert[]> {
+      await options.repository.append(event)
+
+      const recentEvents = await options.repository.listByDateRange({
+        from: new Date(event.occurredAt.getTime() - windowMs),
+        to: event.occurredAt,
+      })
+      const count = recentEvents.filter((candidate) => candidate.type === event.type).length
+      const threshold = thresholds[event.type]
+
+      if (count < threshold) {
+        return []
+      }
+
+      return [
+        {
+          type: event.type,
+          count,
+          threshold,
+          triggeredAt: event.occurredAt,
+        },
+      ]
+    },
+
+    async getSummary(period): Promise<SecuritySummary> {
+      const events = await options.repository.listByDateRange(period)
+      const counts = emptyCounts()
+
+      for (const event of events) {
+        counts[event.type] += 1
+      }
+
+      return {
+        totalCount: events.length,
+        countsByType: counts,
+      }
+    },
+  }
+}

--- a/src/lib/monitoring/structured-logger.ts
+++ b/src/lib/monitoring/structured-logger.ts
@@ -1,0 +1,82 @@
+export type LogLevel = 'info' | 'warn' | 'error'
+
+export interface StructuredLogEntry {
+  readonly timestamp: string
+  readonly level: LogLevel
+  readonly event: string
+  readonly message: string
+  readonly context: Record<string, unknown>
+  readonly error?: {
+    readonly name: string
+    readonly message: string
+    readonly stack?: string
+  }
+}
+
+export interface SentryPort {
+  captureException(error: Error, context: Record<string, unknown>): void | Promise<void>
+}
+
+export interface StructuredLogger {
+  info(event: string, message: string, context?: Record<string, unknown>): Promise<void>
+  warn(event: string, message: string, context?: Record<string, unknown>): Promise<void>
+  error(
+    event: string,
+    message: string,
+    context?: Record<string, unknown>,
+    error?: Error,
+  ): Promise<void>
+}
+
+interface CreateStructuredLoggerOptions {
+  readonly sink?: (entry: StructuredLogEntry) => void | Promise<void>
+  readonly sentry?: SentryPort
+  readonly clock?: () => Date
+}
+
+function serializeError(error: Error | undefined): StructuredLogEntry['error'] | undefined {
+  if (!error) return undefined
+  return {
+    name: error.name,
+    message: error.message,
+    stack: error.stack,
+  }
+}
+
+export function createStructuredLogger(
+  options: CreateStructuredLoggerOptions = {},
+): StructuredLogger {
+  const sink = options.sink ?? (async () => {})
+  const clock = options.clock ?? (() => new Date())
+
+  async function write(
+    level: LogLevel,
+    event: string,
+    message: string,
+    context: Record<string, unknown> = {},
+    error?: Error,
+  ): Promise<void> {
+    const entry: StructuredLogEntry = {
+      timestamp: clock().toISOString(),
+      level,
+      event,
+      message,
+      context,
+      error: serializeError(error),
+    }
+    await sink(entry)
+
+    if (level === 'error' && error && options.sentry) {
+      await options.sentry.captureException(error, {
+        event,
+        ...context,
+      })
+    }
+  }
+
+  return {
+    info: async (event, message, context) => write('info', event, message, context),
+    warn: async (event, message, context) => write('warn', event, message, context),
+    error: async (event, message, context, error) => write('error', event, message, context, error),
+  }
+}

--- a/src/lib/rbac/require-role.ts
+++ b/src/lib/rbac/require-role.ts
@@ -11,6 +11,7 @@
 import type { AuditLoggerPort } from './authorizer'
 import { ForbiddenError, type AuthSubject } from './rbac-types'
 import type { UserRole } from '@/lib/notification/notification-types'
+import type { SecurityEventRecorderPort } from '@/lib/monitoring/security-monitoring-service'
 
 // ─────────────────────────────────────────────────────────────────────────────
 // 型
@@ -29,6 +30,7 @@ export interface RequireRoleOptions {
   }
   /** 拒否時に監査ログを記録するためのポート */
   readonly auditLogger?: AuditLoggerPort
+  readonly securityMonitor?: SecurityEventRecorderPort
 }
 
 /**
@@ -90,6 +92,22 @@ export async function requireRole(
         reason: ROLE_ONLY_DENIED_REASON,
         requestedAction: ROLE_CHECK_REQUESTED_ACTION,
         subjectRole: subject.role,
+        allowedRoles: [...allowedRoles],
+      },
+    })
+  }
+
+  if (opts.securityMonitor !== undefined) {
+    await opts.securityMonitor.record({
+      type: 'ACCESS_DENIED',
+      occurredAt: new Date(),
+      ipAddress: opts.context?.ipAddress,
+      userId: subject.userId,
+      requestId: undefined,
+      path: undefined,
+      metadata: {
+        resourceType,
+        resourceId,
         allowedRoles: [...allowedRoles],
       },
     })

--- a/src/tests/access-log/access-log-middleware.test.ts
+++ b/src/tests/access-log/access-log-middleware.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { createAccessLogMiddleware } from '@/lib/access-log/access-log-middleware'
 import type { NextRequest } from 'next/server'
 import type { AccessLogRepository } from '@/lib/access-log/access-log-repository'
+import type { StructuredLogger } from '@/lib/monitoring/structured-logger'
+import type { SecurityEventRecorderPort } from '@/lib/monitoring/security-monitoring-service'
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Mocks
@@ -9,12 +11,29 @@ import type { AccessLogRepository } from '@/lib/access-log/access-log-repository
 
 const mockEmit = vi.fn()
 const mockNext = vi.fn()
+const mockLoggerInfo = vi.fn()
+const mockLoggerError = vi.fn()
+const mockSecurityRecord = vi.fn()
 
 function makeRepository(): AccessLogRepository {
   return {
     insert: mockEmit,
     findMany: vi.fn(),
   } as unknown as AccessLogRepository
+}
+
+function makeLogger(): StructuredLogger {
+  return {
+    info: mockLoggerInfo,
+    warn: vi.fn(),
+    error: mockLoggerError,
+  }
+}
+
+function makeSecurityMonitor(): SecurityEventRecorderPort {
+  return {
+    record: mockSecurityRecord,
+  }
 }
 
 function makeRequest(
@@ -56,6 +75,9 @@ describe('createAccessLogMiddleware', () => {
     vi.clearAllMocks()
     mockEmit.mockResolvedValue(undefined)
     mockNext.mockResolvedValue(makeResponse(200))
+    mockLoggerInfo.mockResolvedValue(undefined)
+    mockLoggerError.mockResolvedValue(undefined)
+    mockSecurityRecord.mockResolvedValue([])
   })
 
   it('should call next() and return the response', async () => {
@@ -126,5 +148,46 @@ describe('createAccessLogMiddleware', () => {
     await middleware(req, mockNext)
 
     expect(mockEmit).not.toHaveBeenCalled()
+  })
+
+  it('records a RATE_LIMITED security event for 429 responses', async () => {
+    const middleware = createAccessLogMiddleware({
+      repository: makeRepository(),
+      securityMonitor: makeSecurityMonitor(),
+    })
+    const req = makeRequest({ path: '/api/search' })
+    mockNext.mockResolvedValue(makeResponse(429))
+
+    await middleware(req, mockNext)
+
+    expect(mockSecurityRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'RATE_LIMITED',
+        path: '/api/search',
+        requestId: 'req-test-123',
+        ipAddress: '127.0.0.1',
+      }),
+    )
+  })
+
+  it('sends repository failures to the structured logger', async () => {
+    mockEmit.mockRejectedValue(new Error('DB error'))
+    const middleware = createAccessLogMiddleware({
+      repository: makeRepository(),
+      logger: makeLogger(),
+    })
+    const req = makeRequest({ path: '/api/users' })
+
+    await middleware(req, mockNext)
+
+    expect(mockLoggerError).toHaveBeenCalledWith(
+      'access-log.persist_failed',
+      'failed to persist access log',
+      expect.objectContaining({
+        path: '/api/users',
+        requestId: 'req-test-123',
+      }),
+      expect.any(Error),
+    )
   })
 })

--- a/src/tests/auth/auth-service.test.ts
+++ b/src/tests/auth/auth-service.test.ts
@@ -36,6 +36,7 @@ import {
   type AuthUserRecord,
   type AuthUserStatus,
 } from '@/lib/auth/user-repository'
+import type { SecurityEventRecorderPort } from '@/lib/monitoring/security-monitoring-service'
 import { computeEmailHash } from '@/lib/shared/crypto'
 
 const APP_SECRET = 'test-app-secret'
@@ -266,6 +267,7 @@ interface LockoutHarnessOptions {
   readonly lockout?: LockoutStore
   readonly notifier?: LockoutNotifier
   readonly auditLogger?: AuthAuditLoggerPort
+  readonly securityMonitor?: SecurityEventRecorderPort
 }
 
 function buildLockoutHarness(opts: LockoutHarnessOptions): AuthService {
@@ -279,6 +281,7 @@ function buildLockoutHarness(opts: LockoutHarnessOptions): AuthService {
     lockout: opts.lockout,
     notifier: opts.notifier,
     auditLogger: opts.auditLogger,
+    securityMonitor: opts.securityMonitor,
   })
 }
 
@@ -400,7 +403,7 @@ describe('createAuthService.login + lockout (Req 1.3)', () => {
     expect(after.lockedUntil).toBe(new Date(now.getTime() + LOCKOUT_DURATION_MS).toISOString())
     expect(after.failedCount).toBe(MAX_FAILED_LOGIN_ATTEMPTS)
     expect(auditArg.before).toBeNull()
-  })
+  }, 10000)
 
   it('context の ipAddress/userAgent が監査ログへ渡る', async () => {
     const user = await buildUser()
@@ -421,7 +424,7 @@ describe('createAuthService.login + lockout (Req 1.3)', () => {
     const auditArg = firstCallArg<Parameters<AuthAuditLoggerPort['emit']>[0]>(auditLogger.emit)
     expect(auditArg.ipAddress).toBe('192.0.2.10')
     expect(auditArg.userAgent).toBe('agent-x/1.0')
-  })
+  }, 10000)
 
   it('context 未指定時は ipAddress/userAgent が "unknown" になる', async () => {
     const user = await buildUser()
@@ -438,7 +441,7 @@ describe('createAuthService.login + lockout (Req 1.3)', () => {
     const auditArg = firstCallArg<Parameters<AuthAuditLoggerPort['emit']>[0]>(auditLogger.emit)
     expect(auditArg.ipAddress).toBe('unknown')
     expect(auditArg.userAgent).toBe('unknown')
-  })
+  }, 10000)
 
   it('成功ログインで lockout.reset が呼ばれる', async () => {
     const user = await buildUser()
@@ -494,5 +497,31 @@ describe('createAuthService.login + lockout (Req 1.3)', () => {
       ).rejects.toBeInstanceOf(InvalidCredentialsError)
     }
     expect(auditLogger.emit).toHaveBeenCalledTimes(1)
+  })
+
+  it('認証失敗を securityMonitor に記録する', async () => {
+    const user = await buildUser()
+    const securityMonitor: SecurityEventRecorderPort = {
+      record: vi.fn(async () => []),
+    }
+    const service = buildLockoutHarness({ users: [user], securityMonitor })
+
+    await expect(
+      service.login(
+        { email: VALID_EMAIL, password: 'wrong' },
+        { ipAddress: '192.0.2.44', userAgent: 'agent-y/2.0' },
+      ),
+    ).rejects.toBeInstanceOf(InvalidCredentialsError)
+
+    expect(securityMonitor.record).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'AUTH_FAILURE',
+        userId: user.id,
+        ipAddress: '192.0.2.44',
+        metadata: {
+          email: VALID_EMAIL,
+        },
+      }),
+    )
   })
 })

--- a/src/tests/monitoring/operations-dashboard-service.test.ts
+++ b/src/tests/monitoring/operations-dashboard-service.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+
+import { createOperationsDashboardService } from '@/lib/monitoring/operations-dashboard-service'
+
+describe('createOperationsDashboardService()', () => {
+  it('builds a snapshot with API error rate, AI failure rate, and security counts', async () => {
+    const service = createOperationsDashboardService({
+      accessLogs: {
+        listByDateRange: async () => [
+          { statusCode: 200, requestedAt: new Date('2026-04-21T07:00:00.000Z') },
+          { statusCode: 502, requestedAt: new Date('2026-04-21T07:01:00.000Z') },
+          { statusCode: 500, requestedAt: new Date('2026-04-21T07:02:00.000Z') },
+          { statusCode: 404, requestedAt: new Date('2026-04-21T07:03:00.000Z') },
+        ],
+      },
+      aiMonitoring: {
+        getFailureRate: async () => ({
+          period: {
+            from: new Date('2026-04-21T00:00:00.000Z'),
+            to: new Date('2026-04-21T23:59:59.999Z'),
+          },
+          totalAttempts: 20,
+          failureCount: 3,
+          failureRate: 0.15,
+          byErrorCategory: {
+            TIMEOUT: 2,
+            PROVIDER_ERROR: 1,
+          },
+        }),
+      },
+      securityMonitoring: {
+        getSummary: async () => ({
+          totalCount: 6,
+          countsByType: {
+            AUTH_FAILURE: 2,
+            ACCESS_DENIED: 3,
+            RATE_LIMITED: 1,
+          },
+        }),
+      },
+    })
+
+    const snapshot = await service.getSnapshot({
+      from: new Date('2026-04-21T00:00:00.000Z'),
+      to: new Date('2026-04-21T23:59:59.999Z'),
+    })
+
+    expect(snapshot.apiErrors).toEqual({
+      totalRequests: 4,
+      errorCount: 2,
+      errorRate: 0.5,
+    })
+    expect(snapshot.aiFailures.failureRate).toBe(0.15)
+    expect(snapshot.security.totalCount).toBe(6)
+    expect(snapshot.security.countsByType.ACCESS_DENIED).toBe(3)
+  })
+})

--- a/src/tests/monitoring/security-monitoring-service.test.ts
+++ b/src/tests/monitoring/security-monitoring-service.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  createInMemorySecurityEventRepository,
+  createSecurityMonitoringService,
+  type SecurityEvent,
+} from '@/lib/monitoring/security-monitoring-service'
+
+function makeEvent(overrides: Partial<SecurityEvent> = {}): SecurityEvent {
+  return {
+    type: 'AUTH_FAILURE',
+    occurredAt: new Date('2026-04-21T07:00:00.000Z'),
+    ipAddress: '192.0.2.10',
+    userId: 'user-1',
+    requestId: 'req-1',
+    metadata: null,
+    ...overrides,
+  }
+}
+
+describe('SecurityMonitoringService', () => {
+  it('raises an alert when the threshold is reached inside the window', async () => {
+    const repository = createInMemorySecurityEventRepository()
+    const service = createSecurityMonitoringService({
+      repository,
+      thresholds: {
+        AUTH_FAILURE: 3,
+        ACCESS_DENIED: 5,
+        RATE_LIMITED: 4,
+      },
+      windowMs: 15 * 60 * 1000,
+    })
+
+    await service.record(makeEvent({ requestId: 'req-1' }))
+    await service.record(makeEvent({ requestId: 'req-2' }))
+    const alerts = await service.record(makeEvent({ requestId: 'req-3' }))
+
+    expect(alerts).toHaveLength(1)
+    expect(alerts[0]).toMatchObject({
+      type: 'AUTH_FAILURE',
+      count: 3,
+      threshold: 3,
+    })
+  })
+
+  it('summarizes counts by event type for a requested period', async () => {
+    const repository = createInMemorySecurityEventRepository({
+      events: [
+        makeEvent({ type: 'AUTH_FAILURE', requestId: 'req-1' }),
+        makeEvent({ type: 'ACCESS_DENIED', requestId: 'req-2' }),
+        makeEvent({ type: 'ACCESS_DENIED', requestId: 'req-3' }),
+        makeEvent({ type: 'RATE_LIMITED', requestId: 'req-4' }),
+      ],
+    })
+    const service = createSecurityMonitoringService({ repository })
+
+    const summary = await service.getSummary({
+      from: new Date('2026-04-21T00:00:00.000Z'),
+      to: new Date('2026-04-21T23:59:59.999Z'),
+    })
+
+    expect(summary.countsByType).toEqual({
+      AUTH_FAILURE: 1,
+      ACCESS_DENIED: 2,
+      RATE_LIMITED: 1,
+    })
+    expect(summary.totalCount).toBe(4)
+  })
+})

--- a/src/tests/monitoring/structured-logger.test.ts
+++ b/src/tests/monitoring/structured-logger.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  createStructuredLogger,
+  type StructuredLogEntry,
+  type SentryPort,
+} from '@/lib/monitoring/structured-logger'
+
+describe('createStructuredLogger()', () => {
+  it('writes structured entries to the sink with stable fields', async () => {
+    const sink = vi.fn(async (_entry: StructuredLogEntry) => {})
+    const logger = createStructuredLogger({
+      sink,
+      clock: () => new Date('2026-04-21T07:00:00.000Z'),
+    })
+
+    await logger.info('api.request.completed', 'request finished', {
+      requestId: 'req-1',
+      path: '/api/dashboard/kpi',
+      statusCode: 200,
+    })
+
+    expect(sink).toHaveBeenCalledTimes(1)
+    expect(sink).toHaveBeenCalledWith({
+      timestamp: '2026-04-21T07:00:00.000Z',
+      level: 'info',
+      event: 'api.request.completed',
+      message: 'request finished',
+      context: {
+        requestId: 'req-1',
+        path: '/api/dashboard/kpi',
+        statusCode: 200,
+      },
+    })
+  })
+
+  it('forwards exceptions to the sentry port on error logs', async () => {
+    const sink = vi.fn(async (_entry: StructuredLogEntry) => {})
+    const sentry: SentryPort = {
+      captureException: vi.fn(async () => {}),
+    }
+    const logger = createStructuredLogger({
+      sink,
+      sentry,
+      clock: () => new Date('2026-04-21T07:00:00.000Z'),
+    })
+    const error = new Error('database unavailable')
+
+    await logger.error(
+      'access-log.persist_failed',
+      'failed to persist access log',
+      {
+        requestId: 'req-2',
+        path: '/api/auth/login',
+      },
+      error,
+    )
+
+    expect(sink).toHaveBeenCalledWith(
+      expect.objectContaining({
+        level: 'error',
+        event: 'access-log.persist_failed',
+        message: 'failed to persist access log',
+        context: {
+          requestId: 'req-2',
+          path: '/api/auth/login',
+        },
+        error: {
+          name: 'Error',
+          message: 'database unavailable',
+          stack: expect.any(String),
+        },
+      }),
+    )
+    expect(sentry.captureException).toHaveBeenCalledWith(error, {
+      event: 'access-log.persist_failed',
+      requestId: 'req-2',
+      path: '/api/auth/login',
+    })
+  })
+})

--- a/src/tests/rbac/require-role.test.ts
+++ b/src/tests/rbac/require-role.test.ts
@@ -4,6 +4,7 @@ import type { AuditLoggerPort } from '@/lib/rbac/authorizer'
 import { requireRole } from '@/lib/rbac/require-role'
 import { ForbiddenError, type AuthSubject } from '@/lib/rbac/rbac-types'
 import type { UserRole } from '@/lib/notification/notification-types'
+import type { SecurityEventRecorderPort } from '@/lib/monitoring/security-monitoring-service'
 
 function subject(userId: string, role: UserRole): AuthSubject {
   return { userId, role }
@@ -16,6 +17,13 @@ interface AuditSpy extends AuditLoggerPort {
 function makeAuditSpy(): AuditSpy {
   const emit = vi.fn(async () => {})
   return { emit } as AuditSpy
+}
+
+function makeSecuritySpy(): SecurityEventRecorderPort & {
+  readonly record: ReturnType<typeof vi.fn>
+} {
+  const record = vi.fn(async () => [])
+  return { record }
 }
 
 describe('requireRole()', () => {
@@ -31,11 +39,13 @@ describe('requireRole()', () => {
 
   it('throws ForbiddenError when subject role is not in allowedRoles', async () => {
     const audit = makeAuditSpy()
+    const securityMonitor = makeSecuritySpy()
     await expect(
       requireRole(subject('e-1', 'EMPLOYEE'), ['ADMIN', 'HR_MANAGER'], {
         resourceHint: { type: 'EVALUATION', id: 'e1' },
         context: { ipAddress: '10.0.0.1', userAgent: 'Mozilla/5.0' },
         auditLogger: audit,
+        securityMonitor,
       }),
     ).rejects.toBeInstanceOf(ForbiddenError)
 
@@ -53,6 +63,13 @@ describe('requireRole()', () => {
       reason: 'DENIED_INSUFFICIENT_ROLE',
       subjectRole: 'EMPLOYEE',
     })
+    expect(securityMonitor.record).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'ACCESS_DENIED',
+        userId: 'e-1',
+        ipAddress: '10.0.0.1',
+      }),
+    )
   })
 
   it('works without resourceHint (defaults resourceType / resourceId)', async () => {


### PR DESCRIPTION
## Summary
- add monitoring services for structured logging, security event threshold tracking, and operations dashboard snapshots
- connect access logging, auth failures, and RBAC access denials to the new monitoring flow
- add regression tests covering structured logs, security alerts, dashboard aggregation, and integration points

## Verification
- pnpm vitest run src/tests/monitoring/structured-logger.test.ts src/tests/monitoring/security-monitoring-service.test.ts src/tests/monitoring/operations-dashboard-service.test.ts src/tests/access-log/access-log-middleware.test.ts src/tests/rbac/require-role.test.ts src/tests/auth/auth-service.test.ts
- pnpm type-check
- pnpm build
- pnpm test

Addresses #76