### PR TITLE
feat: add backup governance service

### DIFF
--- a/src/lib/backup/backup-service.ts
+++ b/src/lib/backup/backup-service.ts
@@ -1,0 +1,133 @@
+import {
+  backupSnapshotSchema,
+  type BackupGovernanceEvaluation,
+  type BackupPolicy,
+  type BackupSnapshot,
+} from './backup-types'
+
+const HOURS_PER_DAY = 24
+const MONTHS_PER_QUARTER = 3
+
+const DEFAULT_POLICY: BackupPolicy = {
+  database: 'postgresql',
+  automatedBackupCadence: 'daily',
+  retentionDays: 7,
+  recoveryObjectives: {
+    rtoHours: 4,
+    rpoHours: 24,
+  },
+  recoveryDrillCadence: 'quarterly',
+}
+
+export interface BackupGovernanceService {
+  getPolicy(): BackupPolicy
+  evaluateSnapshot(snapshot: BackupSnapshot): BackupGovernanceEvaluation
+}
+
+interface BackupGovernanceDeps {
+  clock: () => Date
+}
+
+class DefaultBackupGovernanceService implements BackupGovernanceService {
+  constructor(private readonly deps: BackupGovernanceDeps) {}
+
+  getPolicy(): BackupPolicy {
+    return DEFAULT_POLICY
+  }
+
+  evaluateSnapshot(snapshot: BackupSnapshot): BackupGovernanceEvaluation {
+    const parsed = backupSnapshotSchema.parse(snapshot)
+    const policy = this.getPolicy()
+    const now = this.deps.clock()
+
+    const backupAgeHours = diffHours(now, new Date(parsed.lastSuccessfulBackupAt))
+    const retentionCompliant = parsed.retentionDays >= policy.retentionDays
+    const freshnessCompliant = backupAgeHours <= HOURS_PER_DAY
+    const backupCompliant = retentionCompliant && freshnessCompliant
+
+    const meetsRto = parsed.latestRestoreDurationHours <= policy.recoveryObjectives.rtoHours
+    const meetsRpo = parsed.latestRecoveryPointAgeHours <= policy.recoveryObjectives.rpoHours
+    const recoveryObjectivesCompliant = meetsRto && meetsRpo
+
+    const nextDueDate = addMonthsUtc(new Date(parsed.lastRecoveryDrillAt), MONTHS_PER_QUARTER)
+    const overdue = nextDueDate.getTime() < now.getTime()
+    const recoveryDrillCompliant = !overdue
+
+    return {
+      compliant: backupCompliant && recoveryObjectivesCompliant && recoveryDrillCompliant,
+      policy,
+      backup: {
+        compliant: backupCompliant,
+        reason: backupCompliant ? null : buildBackupReason(retentionCompliant, freshnessCompliant),
+        lastBackupAgeHours: backupAgeHours,
+        retentionCompliant,
+        freshnessCompliant,
+      },
+      recoveryObjectives: {
+        compliant: recoveryObjectivesCompliant,
+        reason: recoveryObjectivesCompliant
+          ? null
+          : buildRecoveryObjectiveReason(meetsRto, meetsRpo),
+        meetsRto,
+        meetsRpo,
+      },
+      recoveryDrill: {
+        compliant: recoveryDrillCompliant,
+        reason: recoveryDrillCompliant ? null : 'Quarterly recovery drill is overdue.',
+        overdue,
+        nextDueAt: nextDueDate.toISOString(),
+      },
+    }
+  }
+}
+
+function diffHours(later: Date, earlier: Date): number {
+  const diffMs = later.getTime() - earlier.getTime()
+  return Math.round((diffMs / (1000 * 60 * 60)) * 100) / 100
+}
+
+function addMonthsUtc(value: Date, months: number): Date {
+  return new Date(
+    Date.UTC(
+      value.getUTCFullYear(),
+      value.getUTCMonth() + months,
+      value.getUTCDate(),
+      value.getUTCHours(),
+      value.getUTCMinutes(),
+      value.getUTCSeconds(),
+      value.getUTCMilliseconds(),
+    ),
+  )
+}
+
+function buildBackupReason(retentionCompliant: boolean, freshnessCompliant: boolean): string {
+  if (!retentionCompliant && !freshnessCompliant) {
+    return 'Backup retention and daily freshness requirements are not met.'
+  }
+
+  if (!retentionCompliant) {
+    return 'Backup retention is below 7 days.'
+  }
+
+  return 'Latest successful backup is older than 24 hours.'
+}
+
+function buildRecoveryObjectiveReason(meetsRto: boolean, meetsRpo: boolean): string {
+  if (!meetsRto && !meetsRpo) {
+    return 'Recovery time and recovery point objectives are exceeded.'
+  }
+
+  if (!meetsRto) {
+    return 'Recovery time objective exceeds 4 hours.'
+  }
+
+  return 'Recovery point objective exceeds 24 hours.'
+}
+
+export function createBackupGovernanceService(
+  deps: Partial<BackupGovernanceDeps> = {},
+): BackupGovernanceService {
+  return new DefaultBackupGovernanceService({
+    clock: deps.clock ?? (() => new Date()),
+  })
+}

--- a/src/lib/backup/backup-types.ts
+++ b/src/lib/backup/backup-types.ts
@@ -1,0 +1,57 @@
+import { z } from 'zod'
+
+export const BACKUP_DATABASES = ['postgresql'] as const
+export type BackupDatabase = (typeof BACKUP_DATABASES)[number]
+
+export const backupPolicySchema = z.object({
+  database: z.enum(BACKUP_DATABASES),
+  automatedBackupCadence: z.literal('daily'),
+  retentionDays: z.number().int().positive(),
+  recoveryObjectives: z.object({
+    rtoHours: z.number().positive(),
+    rpoHours: z.number().positive(),
+  }),
+  recoveryDrillCadence: z.literal('quarterly'),
+})
+
+export type BackupPolicy = z.infer<typeof backupPolicySchema>
+
+export const backupSnapshotSchema = z.object({
+  database: z.enum(BACKUP_DATABASES),
+  retentionDays: z.number().int().positive(),
+  lastSuccessfulBackupAt: z.string().datetime(),
+  lastRecoveryDrillAt: z.string().datetime(),
+  latestRestoreDurationHours: z.number().nonnegative(),
+  latestRecoveryPointAgeHours: z.number().nonnegative(),
+})
+
+export type BackupSnapshot = z.infer<typeof backupSnapshotSchema>
+
+export interface BackupCompliance {
+  compliant: boolean
+  reason: string | null
+}
+
+export interface BackupFreshnessCompliance extends BackupCompliance {
+  lastBackupAgeHours: number
+  retentionCompliant: boolean
+  freshnessCompliant: boolean
+}
+
+export interface RecoveryObjectiveCompliance extends BackupCompliance {
+  meetsRto: boolean
+  meetsRpo: boolean
+}
+
+export interface RecoveryDrillCompliance extends BackupCompliance {
+  overdue: boolean
+  nextDueAt: string
+}
+
+export interface BackupGovernanceEvaluation {
+  compliant: boolean
+  policy: BackupPolicy
+  backup: BackupFreshnessCompliance
+  recoveryObjectives: RecoveryObjectiveCompliance
+  recoveryDrill: RecoveryDrillCompliance
+}

--- a/src/tests/backup/backup-service.test.ts
+++ b/src/tests/backup/backup-service.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest'
+import { createBackupGovernanceService } from '@/lib/backup/backup-service'
+
+describe('BackupGovernanceService.getPolicy', () => {
+  it('returns the required PostgreSQL backup and recovery policy', () => {
+    const service = createBackupGovernanceService()
+
+    expect(service.getPolicy()).toEqual({
+      database: 'postgresql',
+      automatedBackupCadence: 'daily',
+      retentionDays: 7,
+      recoveryObjectives: {
+        rtoHours: 4,
+        rpoHours: 24,
+      },
+      recoveryDrillCadence: 'quarterly',
+    })
+  })
+})
+
+describe('BackupGovernanceService.evaluateSnapshot', () => {
+  it('marks the snapshot compliant when backup, recovery objectives, and drill cadence all meet the policy', () => {
+    const service = createBackupGovernanceService({
+      clock: () => new Date('2026-04-21T09:00:00.000Z'),
+    })
+
+    const result = service.evaluateSnapshot({
+      database: 'postgresql',
+      retentionDays: 7,
+      lastSuccessfulBackupAt: '2026-04-20T12:00:00.000Z',
+      lastRecoveryDrillAt: '2026-02-01T00:00:00.000Z',
+      latestRestoreDurationHours: 3.5,
+      latestRecoveryPointAgeHours: 12,
+    })
+
+    expect(result.compliant).toBe(true)
+    expect(result.backup.compliant).toBe(true)
+    expect(result.backup.lastBackupAgeHours).toBe(21)
+    expect(result.recoveryObjectives.compliant).toBe(true)
+    expect(result.recoveryDrill.compliant).toBe(true)
+    expect(result.recoveryDrill.nextDueAt).toBe('2026-05-01T00:00:00.000Z')
+  })
+
+  it('marks the snapshot non-compliant when backup retention or freshness misses the policy', () => {
+    const service = createBackupGovernanceService({
+      clock: () => new Date('2026-04-21T09:00:00.000Z'),
+    })
+
+    const result = service.evaluateSnapshot({
+      database: 'postgresql',
+      retentionDays: 5,
+      lastSuccessfulBackupAt: '2026-04-19T08:00:00.000Z',
+      lastRecoveryDrillAt: '2026-02-01T00:00:00.000Z',
+      latestRestoreDurationHours: 3,
+      latestRecoveryPointAgeHours: 8,
+    })
+
+    expect(result.compliant).toBe(false)
+    expect(result.backup.compliant).toBe(false)
+    expect(result.backup.retentionCompliant).toBe(false)
+    expect(result.backup.freshnessCompliant).toBe(false)
+    expect(result.backup.lastBackupAgeHours).toBe(49)
+  })
+
+  it('marks the snapshot non-compliant when RTO or RPO exceeds the target', () => {
+    const service = createBackupGovernanceService()
+
+    const result = service.evaluateSnapshot({
+      database: 'postgresql',
+      retentionDays: 7,
+      lastSuccessfulBackupAt: '2026-04-20T12:00:00.000Z',
+      lastRecoveryDrillAt: '2026-02-01T00:00:00.000Z',
+      latestRestoreDurationHours: 4.5,
+      latestRecoveryPointAgeHours: 26,
+    })
+
+    expect(result.compliant).toBe(false)
+    expect(result.recoveryObjectives.compliant).toBe(false)
+    expect(result.recoveryObjectives.meetsRto).toBe(false)
+    expect(result.recoveryObjectives.meetsRpo).toBe(false)
+  })
+
+  it('marks the snapshot non-compliant when the quarterly recovery drill is overdue', () => {
+    const service = createBackupGovernanceService({
+      clock: () => new Date('2026-04-21T09:00:00.000Z'),
+    })
+
+    const result = service.evaluateSnapshot({
+      database: 'postgresql',
+      retentionDays: 7,
+      lastSuccessfulBackupAt: '2026-04-20T12:00:00.000Z',
+      lastRecoveryDrillAt: '2025-12-15T00:00:00.000Z',
+      latestRestoreDurationHours: 3,
+      latestRecoveryPointAgeHours: 8,
+    })
+
+    expect(result.compliant).toBe(false)
+    expect(result.recoveryDrill.compliant).toBe(false)
+    expect(result.recoveryDrill.overdue).toBe(true)
+    expect(result.recoveryDrill.nextDueAt).toBe('2026-03-15T00:00:00.000Z')
+  })
+})

--- a/src/tests/backup/backup-types.test.ts
+++ b/src/tests/backup/backup-types.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { backupSnapshotSchema } from '@/lib/backup/backup-types'
+
+describe('backupSnapshotSchema', () => {
+  it('accepts a valid backup governance snapshot', () => {
+    const result = backupSnapshotSchema.safeParse({
+      database: 'postgresql',
+      retentionDays: 7,
+      lastSuccessfulBackupAt: '2026-04-20T12:00:00.000Z',
+      lastRecoveryDrillAt: '2026-02-01T00:00:00.000Z',
+      latestRestoreDurationHours: 3.5,
+      latestRecoveryPointAgeHours: 12,
+    })
+
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects unsupported databases and invalid retention periods', () => {
+    const result = backupSnapshotSchema.safeParse({
+      database: 'mysql',
+      retentionDays: 0,
+      lastSuccessfulBackupAt: '2026-04-20T12:00:00.000Z',
+      lastRecoveryDrillAt: '2026-02-01T00:00:00.000Z',
+      latestRestoreDurationHours: 3.5,
+      latestRecoveryPointAgeHours: 12,
+    })
+
+    expect(result.success).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- add backup governance types for PostgreSQL backup policy and recovery drill inputs
- add a service that evaluates daily backup freshness, 7-day retention, RTO/RPO compliance, and quarterly recovery drill deadlines
- add focused tests covering compliant and non-compliant backup/recovery scenarios

## Verification
- pnpm vitest run src/tests/backup/backup-service.test.ts src/tests/backup/backup-types.test.ts
- pnpm type-check
- pnpm build
- pnpm test (fails only in existing auth timeouts at src/tests/auth/auth-service.test.ts)

Addresses #77