### PR TITLE
feat: issue #79 fix phase1 locale and timezone

### DIFF
--- a/src/components/skill/SkillList.tsx
+++ b/src/components/skill/SkillList.tsx
@@ -8,6 +8,7 @@
  * Component は presentational に保ち、fetch / mutate は親コンポーネント側で行う。
  */
 import type { ReactElement } from 'react'
+import { formatDateJapanese } from '@/lib/shared/locale'
 import { isSkillApproved, type EmployeeSkill } from '@/lib/skill/skill-types'
 import { SkillBadge } from './SkillBadge'
 
@@ -19,14 +20,8 @@ interface SkillListProps {
   readonly onApprove?: (skill: EmployeeSkill) => void
 }
 
-const JA_LOCALE = 'ja-JP'
-
 function formatAcquiredDate(date: Date): string {
-  return date.toLocaleDateString(JA_LOCALE, {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-  })
+  return formatDateJapanese(date)
 }
 
 export function SkillList({ skills, skillNames, onApprove }: SkillListProps): ReactElement {

--- a/src/lib/goal/deadline-alert-service.ts
+++ b/src/lib/goal/deadline-alert-service.ts
@@ -7,6 +7,7 @@
  */
 
 import type { NotificationRepository } from '@/lib/notification/notification-repository'
+import { formatDateJapanese } from '@/lib/shared/locale'
 import {
   ALERT_TRIGGER_DAYS,
   DEADLINE_ALERT_PROGRESS_THRESHOLD,
@@ -85,7 +86,7 @@ function buildNotificationTitle(daysUntilDeadline: number): string {
 }
 
 function buildNotificationBody(target: DeadlineAlertTarget): string {
-  return `「${target.title}」の進捗が${target.currentProgressRate}%です。期限（${target.endDate.toLocaleDateString('ja-JP')}）までに完了しましょう。`
+  return `「${target.title}」の進捗が${target.currentProgressRate}%です。期限（${formatDateJapanese(target.endDate)}）までに完了しましょう。`
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/lib/lifecycle/profile-service.ts
+++ b/src/lib/lifecycle/profile-service.ts
@@ -19,6 +19,7 @@ import {
   type ProfileViewBasic,
   type ProfileViewFull,
 } from './profile-types'
+import { PHASE1_LOCALE, PHASE1_TIMEZONE } from '@/lib/shared/locale'
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Ports (閲覧者情報取得用)
@@ -113,7 +114,9 @@ class ProfileServiceImpl implements ProfileService {
       throw new ProfileNotFoundError(userId)
     }
 
-    await this.profiles.update(userId, parsed)
+    const { locale: _locale, timezone: _timezone, ...editableFields } = parsed
+
+    await this.profiles.update(userId, editableFields)
   }
 }
 
@@ -134,8 +137,8 @@ function toFullView(record: ProfileRecord): ProfileViewFull {
     avatarUrl: record.avatarUrl,
     selfIntro: record.selfIntro,
     email: record.email,
-    locale: record.locale,
-    timezone: record.timezone,
+    locale: PHASE1_LOCALE,
+    timezone: PHASE1_TIMEZONE,
     role: record.role,
     status: record.status,
     hireDate: record.hireDate,

--- a/src/lib/shared/locale.ts
+++ b/src/lib/shared/locale.ts
@@ -1,0 +1,15 @@
+/**
+ * Phase 1 locale/timezone defaults (Req 20.14)
+ */
+
+export const PHASE1_LOCALE = 'ja-JP' as const
+export const PHASE1_TIMEZONE = 'Asia/Tokyo' as const
+
+export function formatDateJapanese(date: Date): string {
+  return new Intl.DateTimeFormat(PHASE1_LOCALE, {
+    timeZone: PHASE1_TIMEZONE,
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  }).format(date)
+}

--- a/src/tests/goal/deadline-alert-service.test.ts
+++ b/src/tests/goal/deadline-alert-service.test.ts
@@ -93,6 +93,7 @@ describe('DeadlineAlertService.scanDeadlineAlerts', () => {
       expect(result.skipped).toBe(0)
       const notifications = await notifRepo.listByUser('user-1')
       expect(notifications[0]!.title).toContain('3日')
+      expect(notifications[0]!.body).toContain('2026')
     })
 
     it('残り1日・進捗49%の目標は通知される', async () => {

--- a/src/tests/lifecycle/profile-service.test.ts
+++ b/src/tests/lifecycle/profile-service.test.ts
@@ -218,7 +218,7 @@ describe('ProfileService.editProfile', () => {
     expect(updated?.avatarUrl).toBe('https://example.com/new-avatar.png')
   })
 
-  it('locale と timezone を更新できる', async () => {
+  it('Phase 1 では locale と timezone を固定し更新入力を無視する', async () => {
     const alice = makeAliceProfile()
     const { svc, profiles } = makeSetup([alice], { 'user-alice': 'EMPLOYEE' })
 
@@ -228,8 +228,8 @@ describe('ProfileService.editProfile', () => {
     })
 
     const updated = await profiles.findByUserId('user-alice')
-    expect(updated?.locale).toBe('en-US')
-    expect(updated?.timezone).toBe('America/New_York')
+    expect(updated?.locale).toBe('ja-JP')
+    expect(updated?.timezone).toBe('Asia/Tokyo')
   })
 
   it('phoneNumber を更新できる', async () => {


### PR DESCRIPTION
## Summary
- add shared Phase 1 locale/timezone defaults for ja-JP and Asia/Tokyo
- reuse the shared formatter for date rendering in UI and notifications
- keep User.locale/timezone reserved for Phase 2 while ignoring profile update overrides in Phase 1

## Testing
- vitest run src/tests/lifecycle/profile-service.test.ts src/tests/goal/deadline-alert-service.test.ts

Closes #79