### PR TITLE
feat: add dashboard UI

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,0 +1,181 @@
+'use client'
+
+import Link from 'next/link'
+import { useEffect, useState, type ReactElement } from 'react'
+import { KpiSummaryPanel } from '@/components/dashboard/KpiSummaryPanel'
+import type { DashboardSummary } from '@/lib/dashboard/dashboard-types'
+
+interface DashboardEnvelope {
+  readonly success?: boolean
+  readonly data?: DashboardSummary
+  readonly error?: string
+}
+
+type DashboardState =
+  | { readonly kind: 'loading' }
+  | { readonly kind: 'ready'; readonly summary: DashboardSummary }
+  | { readonly kind: 'unauthorized'; readonly message: string }
+  | { readonly kind: 'error'; readonly message: string }
+
+const DASHBOARD_URL = '/api/dashboard/kpi'
+
+export default function DashboardPage(): ReactElement {
+  const [state, setState] = useState<DashboardState>({ kind: 'loading' })
+
+  useEffect(() => {
+    let cancelled = false
+
+    void (async () => {
+      try {
+        const res = await fetch(DASHBOARD_URL, { cache: 'no-store' })
+        const body = ((await res.json().catch(() => ({}))) ?? {}) as DashboardEnvelope
+
+        if (cancelled) return
+
+        if (res.status === 401 || res.status === 403) {
+          setState({
+            kind: 'unauthorized',
+            message:
+              body.error ??
+              'ダッシュボードを表示するにはログイン済みユーザーとしてアクセスしてください。',
+          })
+          return
+        }
+
+        if (!res.ok || !body.data) {
+          setState({
+            kind: 'error',
+            message: body.error ?? `ダッシュボードの取得に失敗しました (HTTP ${res.status})`,
+          })
+          return
+        }
+
+        setState({ kind: 'ready', summary: body.data })
+      } catch (error) {
+        if (cancelled) return
+        setState({
+          kind: 'error',
+          message:
+            error instanceof Error
+              ? error.message
+              : 'ダッシュボードの読み込み中に予期しないエラーが発生しました。',
+        })
+      }
+    })()
+
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  return (
+    <main className="min-h-screen bg-[linear-gradient(180deg,#f8fbff_0%,#ffffff_45%,#f8fafc_100%)]">
+      <div className="mx-auto flex max-w-6xl flex-col gap-8 px-6 py-10">
+        <PageHeader />
+        <QuickLinks />
+        <DashboardBody state={state} />
+      </div>
+    </main>
+  )
+}
+
+function PageHeader(): ReactElement {
+  return (
+    <header className="rounded-3xl border border-slate-200 bg-white/90 p-6 shadow-sm backdrop-blur">
+      <p className="text-xs font-semibold tracking-[0.3em] text-sky-700 uppercase">Home</p>
+      <h1 className="mt-2 text-4xl font-semibold tracking-tight text-slate-950">
+        HR Management Dashboard
+      </h1>
+      <p className="mt-3 max-w-3xl text-sm leading-7 text-slate-600">
+        人事業務に必要な主要指標をロールごとに整理して表示します。API 実装済みの KPI
+        サマリーを、この画面からそのまま確認できるようにしました。
+      </p>
+    </header>
+  )
+}
+
+function QuickLinks(): ReactElement {
+  const links = [
+    {
+      href: '/organization',
+      title: '組織管理',
+      description: '組織図の確認と編集フローへ移動',
+    },
+    {
+      href: '/organization/my-team',
+      title: 'マイチーム',
+      description: '直属メンバーの一覧を確認',
+    },
+    {
+      href: '/skill-map',
+      title: 'スキルマップ',
+      description: 'スキル充足率やレーダーチャートを表示',
+    },
+  ] as const
+
+  return (
+    <section className="grid gap-4 md:grid-cols-3">
+      {links.map((link) => (
+        <Link
+          key={link.href}
+          href={link.href}
+          className="group rounded-2xl border border-slate-200 bg-white p-5 shadow-sm transition-colors hover:border-sky-300 hover:bg-sky-50"
+        >
+          <p className="text-lg font-semibold text-slate-900">{link.title}</p>
+          <p className="mt-2 text-sm leading-6 text-slate-600">{link.description}</p>
+          <p className="mt-4 text-xs font-semibold tracking-[0.25em] text-sky-700 uppercase">
+            Open
+          </p>
+        </Link>
+      ))}
+    </section>
+  )
+}
+
+function DashboardBody({ state }: { readonly state: DashboardState }): ReactElement {
+  if (state.kind === 'loading') {
+    return (
+      <Panel>
+        <p className="animate-pulse text-sm text-slate-500">ダッシュボードを読み込んでいます…</p>
+      </Panel>
+    )
+  }
+
+  if (state.kind === 'unauthorized') {
+    return (
+      <Panel tone="warning">
+        <h2 className="text-lg font-semibold text-amber-950">ログインが必要です</h2>
+        <p className="mt-2 text-sm leading-6 text-amber-900">{state.message}</p>
+      </Panel>
+    )
+  }
+
+  if (state.kind === 'error') {
+    return (
+      <Panel tone="error">
+        <h2 className="text-lg font-semibold text-rose-950">ダッシュボードを表示できません</h2>
+        <p className="mt-2 text-sm leading-6 text-rose-900">{state.message}</p>
+      </Panel>
+    )
+  }
+
+  return <KpiSummaryPanel summary={state.summary} />
+}
+
+function Panel(
+  props: Readonly<{
+    children: ReactElement | string | readonly (ReactElement | string)[]
+    tone?: 'neutral' | 'warning' | 'error'
+  }>,
+): ReactElement {
+  const className =
+    props.tone === 'warning'
+      ? 'border-amber-300 bg-amber-50'
+      : props.tone === 'error'
+        ? 'border-rose-300 bg-rose-50'
+        : 'border-slate-200 bg-white'
+
+  return (
+    <section className={`rounded-3xl border p-6 shadow-sm ${className}`}>{props.children}</section>
+  )
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,55 @@
+import Link from 'next/link'
+
+const sections = [
+  {
+    href: '/dashboard',
+    title: 'ダッシュボード',
+    description: 'ロール別 KPI をまとめて確認するホーム画面',
+  },
+  {
+    href: '/organization',
+    title: '組織管理',
+    description: '組織図とポジション編集 UI を開く',
+  },
+  {
+    href: '/skill-map',
+    title: 'スキルマップ',
+    description: 'スキルサマリー、ヒートマップ、レーダーチャートを表示',
+  },
+] as const
+
 export default function HomePage() {
   return (
-    <main>
-      <h1>HR Management System</h1>
+    <main className="min-h-screen bg-[linear-gradient(180deg,#f8fbff_0%,#ffffff_40%,#f8fafc_100%)]">
+      <div className="mx-auto flex max-w-6xl flex-col gap-8 px-6 py-10">
+        <header className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+          <p className="text-xs font-semibold tracking-[0.3em] text-sky-700 uppercase">
+            HR Management System
+          </p>
+          <h1 className="mt-2 text-4xl font-semibold tracking-tight text-slate-950">
+            人事プラットフォーム
+          </h1>
+          <p className="mt-3 max-w-3xl text-sm leading-7 text-slate-600">
+            組織、スキル、評価、目標、インセンティブの主要機能へ移動できるエントリーポイントです。
+          </p>
+        </header>
+
+        <section className="grid gap-4 md:grid-cols-3">
+          {sections.map((section) => (
+            <Link
+              key={section.href}
+              href={section.href}
+              className="group rounded-2xl border border-slate-200 bg-white p-5 shadow-sm transition-colors hover:border-sky-300 hover:bg-sky-50"
+            >
+              <p className="text-lg font-semibold text-slate-900">{section.title}</p>
+              <p className="mt-2 text-sm leading-6 text-slate-600">{section.description}</p>
+              <p className="mt-4 text-xs font-semibold tracking-[0.25em] text-sky-700 uppercase">
+                Open
+              </p>
+            </Link>
+          ))}
+        </section>
+      </div>
     </main>
   )
 }

--- a/src/components/dashboard/KpiSummaryPanel.tsx
+++ b/src/components/dashboard/KpiSummaryPanel.tsx
@@ -1,0 +1,81 @@
+'use client'
+
+import type { ReactElement } from 'react'
+import type { DashboardSummary, KpiMetric } from '@/lib/dashboard/dashboard-types'
+
+interface KpiSummaryPanelProps {
+  readonly summary: DashboardSummary
+}
+
+const roleLabelMap: Record<DashboardSummary['role'], string> = {
+  ADMIN: '管理者ビュー',
+  HR_MANAGER: '人事ビュー',
+  MANAGER: 'マネージャービュー',
+  EMPLOYEE: 'マイビュ―',
+}
+
+export function KpiSummaryPanel({ summary }: KpiSummaryPanelProps): ReactElement {
+  return (
+    <section
+      data-testid="kpi-summary-panel"
+      aria-label="KPIダッシュボード"
+      className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm"
+    >
+      <header className="flex flex-col gap-3 border-b border-slate-100 pb-5 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <p className="text-xs font-semibold tracking-[0.25em] text-sky-700 uppercase">
+            Dashboard
+          </p>
+          <h2 className="mt-1 text-2xl font-semibold tracking-tight text-slate-950">
+            ロール別 KPI ダッシュボード
+          </h2>
+          <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-600">
+            評価、目標、スキル、インセンティブの主要指標を現在のロールに合わせて表示します。
+          </p>
+        </div>
+        <div className="inline-flex items-center rounded-full bg-sky-50 px-3 py-1 text-xs font-semibold text-sky-800">
+          {roleLabelMap[summary.role]}
+        </div>
+      </header>
+
+      <div className="mt-6 grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        {summary.metrics.map((metric) => (
+          <MetricCard key={metric.key} metric={metric} />
+        ))}
+      </div>
+
+      {summary.emptyStateMessage && (
+        <div className="mt-6 rounded-2xl border border-dashed border-amber-300 bg-amber-50 px-4 py-4 text-sm text-amber-900">
+          <p className="font-semibold">データ準備中</p>
+          <p className="mt-1 leading-6">{summary.emptyStateMessage}</p>
+        </div>
+      )}
+    </section>
+  )
+}
+
+function MetricCard({ metric }: { readonly metric: KpiMetric }): ReactElement {
+  return (
+    <article className="rounded-2xl border border-slate-200 bg-slate-50/80 p-4">
+      <p className="text-sm font-medium text-slate-600">{metric.label}</p>
+      <p className="mt-3 text-3xl font-semibold tracking-tight text-slate-950">
+        {formatMetricValue(metric)}
+      </p>
+      <p className="mt-2 text-xs tracking-[0.2em] text-slate-400 uppercase">
+        {metric.unit === 'count' ? 'Count' : metric.unit === 'percent' ? 'Percent' : 'Score'}
+      </p>
+    </article>
+  )
+}
+
+function formatMetricValue(metric: KpiMetric): string {
+  if (metric.unit === 'count') {
+    return new Intl.NumberFormat('ja-JP').format(metric.value)
+  }
+
+  if (metric.unit === 'percent') {
+    return `${metric.value.toFixed(2)}%`
+  }
+
+  return metric.value.toFixed(1)
+}

--- a/src/tests/dashboard/kpi-summary-panel.test.tsx
+++ b/src/tests/dashboard/kpi-summary-panel.test.tsx
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { renderToString } from 'react-dom/server'
+import { KpiSummaryPanel } from '@/components/dashboard/KpiSummaryPanel'
+import type { DashboardSummary } from '@/lib/dashboard/dashboard-types'
+
+describe('KpiSummaryPanel rendering', () => {
+  it('renders role label and KPI metrics', () => {
+    const summary: DashboardSummary = {
+      role: 'MANAGER',
+      scopeUserId: 'manager-1',
+      emptyStateMessage: null,
+      metrics: [
+        { key: 'teamMemberCount', label: '担当メンバー数', value: 8, unit: 'count' },
+        { key: 'evaluationCompletionRate', label: '評価完了率', value: 75.5, unit: 'percent' },
+      ],
+    }
+
+    const html = renderToString(<KpiSummaryPanel summary={summary} />)
+
+    expect(html).toContain('KPIダッシュボード')
+    expect(html).toContain('マネージャービュー')
+    expect(html).toContain('担当メンバー数')
+    expect(html).toContain('8')
+    expect(html).toContain('75.50%')
+  })
+
+  it('renders the empty state guidance when provided', () => {
+    const summary: DashboardSummary = {
+      role: 'EMPLOYEE',
+      scopeUserId: 'employee-1',
+      emptyStateMessage: 'まだ表示できるデータがありません。',
+      metrics: [{ key: 'myFinalScore', label: '自分の総合評価', value: 0, unit: 'score' }],
+    }
+
+    const html = renderToString(<KpiSummaryPanel summary={summary} />)
+
+    expect(html).toContain('データ準備中')
+    expect(html).toContain('まだ表示できるデータがありません。')
+  })
+})


### PR DESCRIPTION
## Summary
- add an App Router dashboard page that renders role-based KPI data from `/api/dashboard/kpi`
- add a reusable KPI summary panel component with empty-state support
- turn the top page into a lightweight entry screen with links to dashboard, organization, and skill map

## Verification
- pnpm vitest run src/tests/dashboard/kpi-summary-panel.test.tsx src/tests/dashboard/dashboard-route.test.ts
- pnpm exec tsc --noEmit --pretty false

## Notes
- `pnpm build` still fails on an existing lint error in `src/lib/lifecycle/profile-service.ts` (`_locale`, `_timezone` unused)

Closes #170