### PR TITLE
fix: add development fallbacks for dashboard and organization UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,6 +51,15 @@ NODE_ENV="development"
 # アプリケーション URL（通知メールのリンク生成に使用）
 NEXT_PUBLIC_APP_URL="http://localhost:3000"
 
+# 開発専用: 認証バイパス（画面確認用）
+# true にすると development 環境でダミーセッションを返す
+DEV_AUTH_BYPASS="false"
+DEV_AUTH_ROLE="ADMIN"
+DEV_AUTH_USER_ID="dev-user-1"
+DEV_AUTH_SESSION_ID="dev-session-1"
+DEV_AUTH_EMAIL="dev-admin@example.com"
+DEV_AUTH_NAME="Development User"
+
 # ─── ストレージ（CSV/PDF エクスポート） ───────────────────────────
 # S3 互換ストレージ（AWS S3 または Cloudflare R2）
 STORAGE_ENDPOINT="https://s3.amazonaws.com"

--- a/src/app/api/organization/commit/route.ts
+++ b/src/app/api/organization/commit/route.ts
@@ -16,7 +16,28 @@ import {
 import { getOrganizationService } from '@/lib/organization/organization-service-di'
 import { orgChangeSchema } from '@/lib/organization/organization-types'
 
-const bodySchema = z.object({ changes: z.array(orgChangeSchema) })
+const operationsSchema = z.object({
+  operations: z.array(
+    z.object({
+      nodeId: z.string().min(1),
+      newParentId: z.string().min(1).nullable(),
+    }),
+  ),
+})
+
+const bodySchema = z.union([z.object({ changes: z.array(orgChangeSchema) }), operationsSchema])
+
+function normalizeChanges(body: z.infer<typeof bodySchema>) {
+  if ('changes' in body) {
+    return body.changes
+  }
+
+  return body.operations.map((operation) => ({
+    type: 'MoveDepartment' as const,
+    departmentId: operation.nodeId,
+    newParentId: operation.newParentId,
+  }))
+}
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
   const guard = await requireHrManager()
@@ -38,8 +59,9 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   }
 
   try {
+    const changes = normalizeChanges(validated.data)
     const context = extractOrganizationAuditContext(request, guard.session.userId)
-    const result = await svc.commitHierarchyChange(validated.data.changes, context)
+    const result = await svc.commitHierarchyChange(changes, context)
     if (!result.ok) {
       return NextResponse.json(
         {
@@ -50,7 +72,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
         { status: 422 },
       )
     }
-    return NextResponse.json({ success: true }, { status: 200 })
+    return NextResponse.json({ success: true, appliedOperations: changes.length }, { status: 200 })
   } catch (err) {
     return organizationErrorToResponse(err)
   }

--- a/src/app/api/organization/my-team/route.ts
+++ b/src/app/api/organization/my-team/route.ts
@@ -1,0 +1,68 @@
+import { NextResponse } from 'next/server'
+import { getAppSession } from '@/lib/auth/app-session'
+import type { MyTeamResponse } from '@/lib/organization/organization-types'
+
+type MyTeamRole = 'MANAGER' | 'HR_MANAGER' | 'ADMIN'
+
+function isMyTeamRole(value: unknown): value is MyTeamRole {
+  return value === 'MANAGER' || value === 'HR_MANAGER' || value === 'ADMIN'
+}
+
+function isDevelopmentMyTeamFallbackEnabled(): boolean {
+  if (process.env.NODE_ENV !== 'development') {
+    return false
+  }
+
+  return process.env.DEV_AUTH_BYPASS === 'true' || process.env.DEV_AUTH_BYPASS === '1'
+}
+
+function buildDevelopmentMyTeamResponse(userId: string, role: MyTeamRole): MyTeamResponse {
+  return {
+    managerId: userId,
+    managerName: process.env.DEV_AUTH_NAME ?? 'Development User',
+    departmentName: role === 'MANAGER' ? 'Engineering' : 'People Operations',
+    directReports: [
+      {
+        userId: 'team-user-1',
+        name: 'Aiko Tanaka',
+        email: 'aiko.tanaka@example.com',
+        roleName: 'Senior Engineer',
+        departmentName: 'Engineering',
+      },
+      {
+        userId: 'team-user-2',
+        name: 'Shota Sato',
+        email: 'shota.sato@example.com',
+        roleName: 'Product Designer',
+        departmentName: 'Design',
+      },
+      {
+        userId: 'team-user-3',
+        name: 'Mina Suzuki',
+        email: 'mina.suzuki@example.com',
+        roleName: 'Sales Associate',
+        departmentName: 'Sales',
+      },
+    ],
+  }
+}
+
+export async function GET(): Promise<NextResponse> {
+  const session = await getAppSession()
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const sess = session as Record<string, unknown>
+  const userId = typeof sess.userId === 'string' ? sess.userId : undefined
+  const role = sess.role
+  if (!userId || !isMyTeamRole(role)) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  if (isDevelopmentMyTeamFallbackEnabled()) {
+    return NextResponse.json(buildDevelopmentMyTeamResponse(userId, role), { status: 200 })
+  }
+
+  return NextResponse.json({ error: 'My team API is not implemented' }, { status: 501 })
+}

--- a/src/app/organization/page.tsx
+++ b/src/app/organization/page.tsx
@@ -21,6 +21,12 @@ import { OrgChangeError } from '@/lib/organization/organization-types'
 import { hasStructuralDiff, flattenNodes } from '@/lib/organization/org-tree-ops'
 import { OrganizationChart } from '@/components/organization/OrganizationChart'
 
+interface OrgTreeEnvelope {
+  readonly success?: boolean
+  readonly data?: OrgTree
+  readonly error?: string
+}
+
 type LoadState =
   | { readonly kind: 'loading' }
   | { readonly kind: 'error'; readonly message: string }
@@ -47,10 +53,11 @@ export default function OrganizationPage(): ReactElement {
     void (async () => {
       try {
         const res = await fetch(ORG_TREE_URL, { cache: 'no-store' })
-        if (!res.ok) {
-          throw new Error(`Failed to load org tree: ${res.status}`)
+        const payload = ((await res.json().catch(() => ({}))) ?? {}) as OrgTreeEnvelope
+        if (!res.ok || !payload.data) {
+          throw new Error(payload.error ?? `Failed to load org tree: ${res.status}`)
         }
-        const tree = (await res.json()) as OrgTree
+        const tree = payload.data
         if (cancelled) return
         setLoadState({ kind: 'ready', original: tree, current: tree })
       } catch (err) {

--- a/src/lib/auth/app-session.ts
+++ b/src/lib/auth/app-session.ts
@@ -6,6 +6,25 @@ export type AppSession =
 
 type LegacySessionGetter = () => Promise<AppSession>
 
+function isDevelopmentAuthBypassEnabled(): boolean {
+  return (
+    process.env.NODE_ENV === 'development' &&
+    (process.env.DEV_AUTH_BYPASS === 'true' || process.env.DEV_AUTH_BYPASS === '1')
+  )
+}
+
+function getDevelopmentSession(): AppSession {
+  return {
+    user: {
+      email: process.env.DEV_AUTH_EMAIL ?? 'dev-admin@example.com',
+      name: process.env.DEV_AUTH_NAME ?? 'Development User',
+    },
+    userId: process.env.DEV_AUTH_USER_ID ?? 'dev-user-1',
+    sessionId: process.env.DEV_AUTH_SESSION_ID ?? 'dev-session-1',
+    role: process.env.DEV_AUTH_ROLE ?? 'ADMIN',
+  }
+}
+
 function getLegacySessionGetter(): LegacySessionGetter | undefined {
   return undefined
 }
@@ -18,6 +37,10 @@ async function getLegacySessionGetterForTest(): Promise<LegacySessionGetter | un
 }
 
 export async function getAppSession(): Promise<AppSession> {
+  if (isDevelopmentAuthBypassEnabled()) {
+    return getDevelopmentSession()
+  }
+
   const legacyGetter = getLegacySessionGetter() ?? (await getLegacySessionGetterForTest())
   if (legacyGetter) {
     return legacyGetter()

--- a/src/lib/dashboard/dashboard-dev-service.ts
+++ b/src/lib/dashboard/dashboard-dev-service.ts
@@ -1,0 +1,109 @@
+import { createDashboardService } from './dashboard-service'
+import type {
+  DashboardAggregateRow,
+  DashboardRepository,
+  DashboardTrendFilter,
+  DashboardTrendPoint,
+  DashboardService,
+  EmployeeDashboardRow,
+} from './dashboard-types'
+
+const companyAggregate: DashboardAggregateRow = {
+  completedEvaluations: 108,
+  totalEvaluations: 120,
+  completedGoals: 86,
+  totalGoals: 120,
+  coveredSkills: 412,
+  totalSkills: 480,
+}
+
+const managerAggregate: DashboardAggregateRow = {
+  completedEvaluations: 25,
+  totalEvaluations: 30,
+  completedGoals: 22,
+  totalGoals: 30,
+  coveredSkills: 97,
+  totalSkills: 120,
+}
+
+const employeeAggregate: EmployeeDashboardRow = {
+  completedEvaluations: 2,
+  totalEvaluations: 2,
+  completedGoals: 4,
+  totalGoals: 5,
+  coveredSkills: 18,
+  totalSkills: 24,
+  latestFinalScore: 4.2,
+  latestIncentiveScore: 3.8,
+}
+
+function buildTrendPoints(filter: DashboardTrendFilter): readonly DashboardTrendPoint[] {
+  const anchor = filter.to ?? new Date('2026-03-31T00:00:00.000Z')
+  const periods = [
+    {
+      cycleId: 'cycle-2026-01',
+      cycleName: '2026 Q1',
+      periodEnd: new Date(anchor.getFullYear(), anchor.getMonth() - 2, 31),
+      score: 72,
+    },
+    {
+      cycleId: 'cycle-2026-02',
+      cycleName: '2026 Q2',
+      periodEnd: new Date(anchor.getFullYear(), anchor.getMonth() - 1, 30),
+      score: 78,
+    },
+    {
+      cycleId: 'cycle-2026-03',
+      cycleName: '2026 Q3',
+      periodEnd: new Date(anchor.getFullYear(), anchor.getMonth(), 30),
+      score: 84,
+    },
+  ] as const
+
+  return periods.map((period) => ({
+    cycleId: period.cycleId,
+    cycleName: period.cycleName,
+    periodStart: new Date(period.periodEnd.getFullYear(), period.periodEnd.getMonth(), 1),
+    periodEnd: period.periodEnd,
+    score: period.score,
+  }))
+}
+
+const repository: DashboardRepository = {
+  async countEmployees(): Promise<number> {
+    return 120
+  },
+  async countManagedMembers(): Promise<number> {
+    return 30
+  },
+  async getCompanyAggregate(): Promise<DashboardAggregateRow> {
+    return companyAggregate
+  },
+  async getManagerAggregate(): Promise<DashboardAggregateRow> {
+    return managerAggregate
+  },
+  async getEmployeeAggregate(): Promise<EmployeeDashboardRow> {
+    return employeeAggregate
+  },
+  async listCompanyTrend(filter: DashboardTrendFilter): Promise<readonly DashboardTrendPoint[]> {
+    return buildTrendPoints(filter)
+  },
+  async listManagerTrend(
+    filterOwnerId: string,
+    filter: DashboardTrendFilter,
+  ): Promise<readonly DashboardTrendPoint[]> {
+    void filterOwnerId
+    return buildTrendPoints(filter)
+  },
+  async listEmployeeTrend(
+    filterOwnerId: string,
+    filter: DashboardTrendFilter,
+  ): Promise<readonly DashboardTrendPoint[]> {
+    void filterOwnerId
+    return buildTrendPoints(filter)
+  },
+}
+
+export function createDevelopmentDashboardService(): DashboardService {
+  return createDashboardService(repository)
+}

--- a/src/lib/dashboard/dashboard-service-di.ts
+++ b/src/lib/dashboard/dashboard-service-di.ts
@@ -1,6 +1,15 @@
+import { createDevelopmentDashboardService } from './dashboard-dev-service'
 import type { DashboardService } from './dashboard-types'
 
 let service: DashboardService | null = null
+
+function isDevelopmentDashboardFallbackEnabled(): boolean {
+  if (process.env.NODE_ENV !== 'development') {
+    return false
+  }
+
+  return process.env.DEV_AUTH_BYPASS === 'true' || process.env.DEV_AUTH_BYPASS === '1'
+}
 
 export function setDashboardServiceForTesting(svc: DashboardService): void {
   service = svc
@@ -15,6 +24,10 @@ export function initDashboardService(svc: DashboardService): void {
 }
 
 export function getDashboardService(): DashboardService {
+  if (!service && isDevelopmentDashboardFallbackEnabled()) {
+    service = createDevelopmentDashboardService()
+  }
+
   if (!service) {
     throw new Error(
       'DashboardService is not initialized. ' +

--- a/src/lib/organization/organization-dev-service.ts
+++ b/src/lib/organization/organization-dev-service.ts
@@ -1,0 +1,162 @@
+import { applyOperations } from './org-tree-ops'
+import type { OrganizationAuditContext, OrganizationService, Result } from './organization-service'
+import {
+  toDepartmentId,
+  toPositionId,
+  toTransferRecordId,
+  type CyclicReferenceError,
+  type OrgChange,
+  type OrgTree,
+  type OrgTreePreview,
+  type PositionId,
+  type TransferRecord,
+  type UserId,
+} from './organization-types'
+
+function createInitialTree(): OrgTree {
+  return {
+    roots: [
+      {
+        id: toDepartmentId('dept-company'),
+        name: 'Company',
+        parentId: null,
+        department: {
+          id: toDepartmentId('dept-company'),
+          name: 'Company',
+          parentId: null,
+          createdAt: new Date('2026-01-01T00:00:00.000Z'),
+          deletedAt: null,
+        },
+        positions: [],
+        children: [
+          {
+            id: toDepartmentId('dept-engineering'),
+            name: 'Engineering',
+            parentId: toDepartmentId('dept-company'),
+            department: {
+              id: toDepartmentId('dept-engineering'),
+              name: 'Engineering',
+              parentId: toDepartmentId('dept-company'),
+              createdAt: new Date('2026-01-01T00:00:00.000Z'),
+              deletedAt: null,
+            },
+            positions: [
+              {
+                id: toPositionId('pos-eng-manager'),
+                departmentId: toDepartmentId('dept-engineering'),
+                roleId: 'role_manager',
+                holderUserId: 'dev-user-1',
+                holderName: 'Development User',
+                supervisorPositionId: null,
+              },
+            ],
+            children: [
+              {
+                id: toDepartmentId('dept-platform'),
+                name: 'Platform',
+                parentId: toDepartmentId('dept-engineering'),
+                department: {
+                  id: toDepartmentId('dept-platform'),
+                  name: 'Platform',
+                  parentId: toDepartmentId('dept-engineering'),
+                  createdAt: new Date('2026-01-01T00:00:00.000Z'),
+                  deletedAt: null,
+                },
+                positions: [
+                  {
+                    id: toPositionId('pos-platform-lead'),
+                    departmentId: toDepartmentId('dept-platform'),
+                    roleId: 'role_lead',
+                    holderUserId: 'team-user-1',
+                    holderName: 'Aiko Tanaka',
+                    supervisorPositionId: toPositionId('pos-eng-manager'),
+                  },
+                ],
+                children: [],
+              },
+            ],
+          },
+          {
+            id: toDepartmentId('dept-sales'),
+            name: 'Sales',
+            parentId: toDepartmentId('dept-company'),
+            department: {
+              id: toDepartmentId('dept-sales'),
+              name: 'Sales',
+              parentId: toDepartmentId('dept-company'),
+              createdAt: new Date('2026-01-01T00:00:00.000Z'),
+              deletedAt: null,
+            },
+            positions: [
+              {
+                id: toPositionId('pos-sales-rep'),
+                departmentId: toDepartmentId('dept-sales'),
+                roleId: 'role_sales',
+                holderUserId: 'team-user-3',
+                holderName: 'Mina Suzuki',
+                supervisorPositionId: null,
+              },
+            ],
+            children: [],
+          },
+        ],
+      },
+    ],
+    capturedAt: new Date('2026-04-21T00:00:00.000Z'),
+  }
+}
+
+let currentTree: OrgTree = createInitialTree()
+
+function cloneTree(tree: OrgTree): OrgTree {
+  return structuredClone(tree) as OrgTree
+}
+
+export function resetDevelopmentOrganizationTree(): void {
+  currentTree = createInitialTree()
+}
+
+export function createDevelopmentOrganizationService(): OrganizationService {
+  return {
+    async getCurrentTree(): Promise<OrgTree> {
+      return cloneTree(currentTree)
+    },
+    async previewHierarchyChange(changes: readonly OrgChange[]): Promise<OrgTreePreview> {
+      void changes
+      return { tree: cloneTree(currentTree), summary: ['Development preview is enabled'] }
+    },
+    async commitHierarchyChange(
+      changes: readonly OrgChange[],
+      context: OrganizationAuditContext,
+    ): Promise<Result<void, CyclicReferenceError>> {
+      void context
+      const operations = changes.flatMap((change) =>
+        change.type === 'MoveDepartment'
+          ? [{ nodeId: change.departmentId, newParentId: change.newParentId }]
+          : [],
+      )
+      if (operations.length > 0) {
+        currentTree = applyOperations(cloneTree(currentTree), operations)
+      }
+      return { ok: true, value: undefined }
+    },
+    async changePosition(
+      userId: UserId,
+      newPositionId: PositionId | null,
+      context: OrganizationAuditContext,
+    ): Promise<TransferRecord> {
+      return {
+        id: toTransferRecordId('dev-transfer-1'),
+        userId,
+        fromPositionId: null,
+        toPositionId: newPositionId,
+        effectiveDate: new Date(),
+        changedBy: context.userId,
+        createdAt: new Date(),
+      }
+    },
+    async exportCsv(): Promise<{ jobId: string }> {
+      return { jobId: 'dev-organization-export-job' }
+    },
+  }
+}

--- a/src/lib/organization/organization-service-di.ts
+++ b/src/lib/organization/organization-service-di.ts
@@ -2,9 +2,18 @@
  * Issue #27: OrganizationService のシングルトン DI モジュール。
  * master-service-di.ts と同一パターン。
  */
+import { createDevelopmentOrganizationService } from './organization-dev-service'
 import type { OrganizationService } from './organization-service'
 
 let _organizationService: OrganizationService | null = null
+
+function isDevelopmentOrganizationFallbackEnabled(): boolean {
+  if (process.env.NODE_ENV !== 'development') {
+    return false
+  }
+
+  return process.env.DEV_AUTH_BYPASS === 'true' || process.env.DEV_AUTH_BYPASS === '1'
+}
 
 export function setOrganizationServiceForTesting(svc: OrganizationService): void {
   _organizationService = svc
@@ -15,6 +24,10 @@ export function clearOrganizationServiceForTesting(): void {
 }
 
 export function getOrganizationService(): OrganizationService {
+  if (!_organizationService && isDevelopmentOrganizationFallbackEnabled()) {
+    _organizationService = createDevelopmentOrganizationService()
+  }
+
   if (_organizationService) return _organizationService
   throw new Error(
     'OrganizationService is not initialized. ' +

--- a/src/lib/skill/skill-analytics-dev-service.ts
+++ b/src/lib/skill/skill-analytics-dev-service.ts
@@ -1,0 +1,53 @@
+import {
+  createSkillAnalyticsService,
+  type EmployeeRow,
+  type EmployeeSkillRow,
+  type SkillAnalyticsRepository,
+  type SkillAnalyticsService,
+  type SkillMasterRow,
+} from './skill-analytics-service'
+
+const skillMasters: readonly SkillMasterRow[] = [
+  { id: 'skill-ts', name: 'TypeScript', category: 'language', deprecated: false },
+  { id: 'skill-react', name: 'React', category: 'frontend', deprecated: false },
+  { id: 'skill-aws', name: 'AWS', category: 'cloud', deprecated: false },
+  { id: 'skill-sql', name: 'SQL', category: 'data', deprecated: false },
+]
+
+const employees: readonly EmployeeRow[] = [
+  { userId: 'dev-user-1', departmentId: 'dept-eng', departmentName: 'Engineering' },
+  { userId: 'dev-user-2', departmentId: 'dept-eng', departmentName: 'Engineering' },
+  { userId: 'dev-user-3', departmentId: 'dept-sales', departmentName: 'Sales' },
+]
+
+const employeeSkills: readonly EmployeeSkillRow[] = [
+  { id: 'es-1', userId: 'dev-user-1', skillId: 'skill-ts', level: 5, approved: true },
+  { id: 'es-2', userId: 'dev-user-1', skillId: 'skill-react', level: 4, approved: true },
+  { id: 'es-3', userId: 'dev-user-1', skillId: 'skill-aws', level: 3, approved: true },
+  { id: 'es-4', userId: 'dev-user-2', skillId: 'skill-ts', level: 3, approved: true },
+  { id: 'es-5', userId: 'dev-user-2', skillId: 'skill-sql', level: 2, approved: false },
+  { id: 'es-6', userId: 'dev-user-3', skillId: 'skill-react', level: 2, approved: true },
+  { id: 'es-7', userId: 'dev-user-3', skillId: 'skill-sql', level: 4, approved: true },
+]
+
+const repository: SkillAnalyticsRepository = {
+  async listEmployeeSkills(): Promise<EmployeeSkillRow[]> {
+    return [...employeeSkills]
+  },
+  async listEmployeeSkillsByUser(userId: string): Promise<EmployeeSkillRow[]> {
+    return employeeSkills.filter((skill) => skill.userId === userId)
+  },
+  async listSkillMasters(): Promise<SkillMasterRow[]> {
+    return [...skillMasters]
+  },
+  async listEmployeesWithDepartment(): Promise<EmployeeRow[]> {
+    return [...employees]
+  },
+  async countActiveEmployees(): Promise<number> {
+    return employees.length
+  },
+}
+
+export function createDevelopmentSkillAnalyticsService(): SkillAnalyticsService {
+  return createSkillAnalyticsService(repository)
+}

--- a/src/lib/skill/skill-analytics-di.ts
+++ b/src/lib/skill/skill-analytics-di.ts
@@ -4,9 +4,18 @@
  * master-service-di.ts と同一パターン。テストでは set/clear で差し替え、
  * プロダクションでは init* で注入する。
  */
+import { createDevelopmentSkillAnalyticsService } from './skill-analytics-dev-service'
 import type { SkillAnalyticsService } from './skill-analytics-service'
 
 let _service: SkillAnalyticsService | null = null
+
+function isDevelopmentSkillAnalyticsFallbackEnabled(): boolean {
+  if (process.env.NODE_ENV !== 'development') {
+    return false
+  }
+
+  return process.env.DEV_AUTH_BYPASS === 'true' || process.env.DEV_AUTH_BYPASS === '1'
+}
 
 export function setSkillAnalyticsServiceForTesting(svc: SkillAnalyticsService): void {
   _service = svc
@@ -21,6 +30,10 @@ export function initSkillAnalyticsService(svc: SkillAnalyticsService): void {
 }
 
 export function getSkillAnalyticsService(): SkillAnalyticsService {
+  if (!_service && isDevelopmentSkillAnalyticsFallbackEnabled()) {
+    _service = createDevelopmentSkillAnalyticsService()
+  }
+
   if (_service) return _service
   throw new Error(
     'SkillAnalyticsService is not initialized. ' +

--- a/src/tests/auth/app-session.test.ts
+++ b/src/tests/auth/app-session.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+async function importAppSessionModule() {
+  vi.resetModules()
+  return import('@/lib/auth/app-session')
+}
+
+describe('getAppSession', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.resetModules()
+    vi.doUnmock('@/auth')
+  })
+
+  it('returns a development bypass session when explicitly enabled', async () => {
+    vi.stubEnv('NODE_ENV', 'development')
+    vi.stubEnv('DEV_AUTH_BYPASS', 'true')
+    vi.stubEnv('DEV_AUTH_ROLE', 'HR_MANAGER')
+    vi.stubEnv('DEV_AUTH_USER_ID', 'dev-hr-1')
+    vi.stubEnv('DEV_AUTH_EMAIL', 'hr@example.com')
+
+    const { getAppSession } = await importAppSessionModule()
+    const session = await getAppSession()
+
+    expect(session).toMatchObject({
+      user: { email: 'hr@example.com' },
+      userId: 'dev-hr-1',
+      role: 'HR_MANAGER',
+    })
+  })
+
+  it('falls back to auth() when the development bypass is disabled', async () => {
+    vi.stubEnv('NODE_ENV', 'development')
+    vi.stubEnv('DEV_AUTH_BYPASS', 'false')
+
+    vi.doMock('@/auth', () => ({
+      auth: vi.fn(async () => ({
+        user: { email: 'real-user@example.com' },
+        userId: 'real-user-1',
+        role: 'EMPLOYEE',
+      })),
+    }))
+
+    const { getAppSession } = await importAppSessionModule()
+    const session = await getAppSession()
+
+    expect(session).toMatchObject({
+      user: { email: 'real-user@example.com' },
+      userId: 'real-user-1',
+      role: 'EMPLOYEE',
+    })
+  })
+})

--- a/src/tests/dashboard/dashboard-service-di.test.ts
+++ b/src/tests/dashboard/dashboard-service-di.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { clearDashboardServiceForTesting } from '@/lib/dashboard/dashboard-service-di'
+
+afterEach(() => {
+  clearDashboardServiceForTesting()
+  vi.unstubAllEnvs()
+  vi.resetModules()
+})
+
+describe('dashboard-service-di', () => {
+  it('returns development fallback service when auth bypass is enabled', async () => {
+    vi.stubEnv('NODE_ENV', 'development')
+    vi.stubEnv('DEV_AUTH_BYPASS', 'true')
+
+    const { getDashboardService: loadService } =
+      await import('@/lib/dashboard/dashboard-service-di')
+    const service = loadService()
+    const summary = await service.getKpiSummary('ADMIN', 'dev-user-1')
+
+    expect(summary.metrics.length).toBeGreaterThan(0)
+    expect(summary.role).toBe('ADMIN')
+  })
+
+  it('throws when service is not initialized outside development fallback', async () => {
+    vi.stubEnv('NODE_ENV', 'test')
+    vi.stubEnv('DEV_AUTH_BYPASS', 'false')
+
+    const { getDashboardService: loadService } =
+      await import('@/lib/dashboard/dashboard-service-di')
+
+    expect(() => loadService()).toThrow('DashboardService is not initialized')
+  })
+})

--- a/src/tests/organization/my-team-route.test.ts
+++ b/src/tests/organization/my-team-route.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('next-auth', () => ({
+  getServerSession: vi.fn(),
+}))
+
+const { getServerSession } = await import('next-auth')
+const mockedGetServerSession = vi.mocked(getServerSession)
+
+const { GET } = await import('@/app/api/organization/my-team/route')
+
+function makeSession(role: string, userId = 'manager-1') {
+  return {
+    user: { email: 'user@example.com' },
+    userId,
+    role,
+  }
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+describe('GET /api/organization/my-team', () => {
+  it('returns 401 when unauthenticated', async () => {
+    mockedGetServerSession.mockResolvedValue(null)
+
+    const res = await GET()
+
+    expect(res.status).toBe(401)
+  })
+
+  it('returns development fallback data for manager role', async () => {
+    vi.stubEnv('NODE_ENV', 'development')
+    vi.stubEnv('DEV_AUTH_BYPASS', 'true')
+    vi.stubEnv('DEV_AUTH_USER_ID', 'manager-1')
+    vi.stubEnv('DEV_AUTH_ROLE', 'MANAGER')
+    mockedGetServerSession.mockResolvedValue(makeSession('MANAGER', 'manager-1'))
+
+    const res = await GET()
+    const body = (await res.json()) as {
+      managerId: string
+      directReports: readonly unknown[]
+    }
+
+    expect(res.status).toBe(200)
+    expect(body.managerId).toBe('manager-1')
+    expect(body.directReports.length).toBeGreaterThan(0)
+  })
+
+  it('returns 403 for unsupported roles', async () => {
+    vi.stubEnv('NODE_ENV', 'test')
+    vi.stubEnv('DEV_AUTH_BYPASS', 'false')
+    mockedGetServerSession.mockResolvedValue(makeSession('EMPLOYEE', 'employee-1'))
+
+    const res = await GET()
+
+    expect(res.status).toBe(403)
+  })
+})

--- a/src/tests/organization/organization-service-di.test.ts
+++ b/src/tests/organization/organization-service-di.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { resetDevelopmentOrganizationTree } from '@/lib/organization/organization-dev-service'
+import { clearOrganizationServiceForTesting } from '@/lib/organization/organization-service-di'
+
+afterEach(() => {
+  clearOrganizationServiceForTesting()
+  resetDevelopmentOrganizationTree()
+  vi.unstubAllEnvs()
+  vi.resetModules()
+})
+
+describe('organization-service-di', () => {
+  it('returns development fallback service when auth bypass is enabled', async () => {
+    vi.stubEnv('NODE_ENV', 'development')
+    vi.stubEnv('DEV_AUTH_BYPASS', 'true')
+
+    const { getOrganizationService } = await import('@/lib/organization/organization-service-di')
+    const service = getOrganizationService()
+    const tree = await service.getCurrentTree()
+
+    expect(tree.roots.length).toBeGreaterThan(0)
+  })
+
+  it('throws when service is not initialized outside development fallback', async () => {
+    vi.stubEnv('NODE_ENV', 'test')
+    vi.stubEnv('DEV_AUTH_BYPASS', 'false')
+
+    const { getOrganizationService } = await import('@/lib/organization/organization-service-di')
+
+    expect(() => getOrganizationService()).toThrow('OrganizationService is not initialized')
+  })
+})

--- a/src/tests/organization/organization-tree-route.test.ts
+++ b/src/tests/organization/organization-tree-route.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  clearOrganizationServiceForTesting,
+  setOrganizationServiceForTesting,
+} from '@/lib/organization/organization-service-di'
+import type { OrganizationService } from '@/lib/organization/organization-service'
+
+vi.mock('next-auth', () => ({
+  getServerSession: vi.fn(),
+}))
+
+const { getServerSession } = await import('next-auth')
+const mockedGetServerSession = vi.mocked(getServerSession)
+
+const { GET } = await import('@/app/api/organization/tree/route')
+
+function makeSession(role: string, userId = 'hr-1') {
+  return {
+    user: { email: 'user@example.com' },
+    userId,
+    role,
+  }
+}
+
+function makeService(overrides?: Partial<OrganizationService>): OrganizationService {
+  return {
+    getCurrentTree: vi.fn().mockResolvedValue({ roots: [], capturedAt: new Date() }),
+    previewHierarchyChange: vi.fn(),
+    commitHierarchyChange: vi.fn(),
+    changePosition: vi.fn(),
+    exportCsv: vi.fn(),
+    ...overrides,
+  } as OrganizationService
+}
+
+afterEach(() => {
+  clearOrganizationServiceForTesting()
+})
+
+describe('GET /api/organization/tree', () => {
+  it('returns 401 when unauthenticated', async () => {
+    mockedGetServerSession.mockResolvedValue(null)
+
+    const res = await GET()
+
+    expect(res.status).toBe(401)
+  })
+
+  it('returns tree for HR manager', async () => {
+    mockedGetServerSession.mockResolvedValue(makeSession('HR_MANAGER', 'hr-1'))
+    const service = makeService()
+    setOrganizationServiceForTesting(service)
+
+    const res = await GET()
+
+    expect(res.status).toBe(200)
+    expect(service.getCurrentTree).toHaveBeenCalled()
+  })
+
+  it('returns 503 when service is not initialized', async () => {
+    mockedGetServerSession.mockResolvedValue(makeSession('ADMIN', 'admin-1'))
+
+    const res = await GET()
+
+    expect(res.status).toBe(503)
+  })
+})

--- a/src/tests/skill/skill-analytics-di.test.ts
+++ b/src/tests/skill/skill-analytics-di.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { clearSkillAnalyticsServiceForTesting } from '@/lib/skill/skill-analytics-di'
+
+afterEach(() => {
+  clearSkillAnalyticsServiceForTesting()
+  vi.unstubAllEnvs()
+  vi.resetModules()
+})
+
+describe('skill-analytics-di', () => {
+  it('returns development fallback service when auth bypass is enabled', async () => {
+    vi.stubEnv('NODE_ENV', 'development')
+    vi.stubEnv('DEV_AUTH_BYPASS', 'true')
+
+    const { getSkillAnalyticsService } = await import('@/lib/skill/skill-analytics-di')
+    const service = getSkillAnalyticsService()
+    const summary = await service.getOrganizationSummary()
+
+    expect(summary.totalEmployees).toBeGreaterThan(0)
+    expect(summary.totalSkillEntries).toBeGreaterThan(0)
+  })
+
+  it('throws when service is not initialized outside development fallback', async () => {
+    vi.stubEnv('NODE_ENV', 'test')
+    vi.stubEnv('DEV_AUTH_BYPASS', 'false')
+
+    const { getSkillAnalyticsService } = await import('@/lib/skill/skill-analytics-di')
+
+    expect(() => getSkillAnalyticsService()).toThrow('SkillAnalyticsService is not initialized')
+  })
+})

--- a/src/tests/skill/skill-analytics-heatmap-route.test.ts
+++ b/src/tests/skill/skill-analytics-heatmap-route.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  clearSkillAnalyticsServiceForTesting,
+  setSkillAnalyticsServiceForTesting,
+} from '@/lib/skill/skill-analytics-di'
+import type { SkillAnalyticsService } from '@/lib/skill/skill-analytics-service'
+
+vi.mock('next-auth', () => ({
+  getServerSession: vi.fn(),
+}))
+
+const { getServerSession } = await import('next-auth')
+const mockedGetServerSession = vi.mocked(getServerSession)
+
+const { GET } = await import('@/app/api/skill-analytics/heatmap/route')
+
+function makeSession(role: string, userId = 'user-1') {
+  return {
+    user: { email: 'user@example.com' },
+    userId,
+    role,
+  }
+}
+
+function makeService(overrides?: Partial<SkillAnalyticsService>): SkillAnalyticsService {
+  return {
+    getOrganizationSummary: vi.fn(),
+    getHeatmap: vi.fn().mockResolvedValue({
+      cells: [],
+      departments: ['Engineering'],
+      categories: ['language'],
+    }),
+    getEmployeeRadar: vi.fn(),
+    ...overrides,
+  }
+}
+
+afterEach(() => {
+  clearSkillAnalyticsServiceForTesting()
+})
+
+describe('GET /api/skill-analytics/heatmap', () => {
+  it('returns 200 for admin role', async () => {
+    mockedGetServerSession.mockResolvedValue(makeSession('ADMIN', 'admin-1'))
+    const service = makeService()
+    setSkillAnalyticsServiceForTesting(service)
+
+    const res = await GET()
+
+    expect(res.status).toBe(200)
+    expect(service.getHeatmap).toHaveBeenCalled()
+  })
+
+  it('returns 403 for employee role', async () => {
+    mockedGetServerSession.mockResolvedValue(makeSession('EMPLOYEE', 'employee-1'))
+    setSkillAnalyticsServiceForTesting(makeService())
+
+    const res = await GET()
+
+    expect(res.status).toBe(403)
+  })
+
+  it('returns 503 when service is not initialized', async () => {
+    mockedGetServerSession.mockResolvedValue(makeSession('ADMIN', 'admin-1'))
+
+    const res = await GET()
+
+    expect(res.status).toBe(503)
+  })
+})

--- a/src/tests/skill/skill-analytics-summary-route.test.ts
+++ b/src/tests/skill/skill-analytics-summary-route.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  clearSkillAnalyticsServiceForTesting,
+  setSkillAnalyticsServiceForTesting,
+} from '@/lib/skill/skill-analytics-di'
+import type { SkillAnalyticsService } from '@/lib/skill/skill-analytics-service'
+
+vi.mock('next-auth', () => ({
+  getServerSession: vi.fn(),
+}))
+
+const { getServerSession } = await import('next-auth')
+const mockedGetServerSession = vi.mocked(getServerSession)
+
+const { GET } = await import('@/app/api/skill-analytics/summary/route')
+
+function makeSession(role: string, userId = 'user-1') {
+  return {
+    user: { email: 'user@example.com' },
+    userId,
+    role,
+  }
+}
+
+function makeService(overrides?: Partial<SkillAnalyticsService>): SkillAnalyticsService {
+  return {
+    getOrganizationSummary: vi.fn().mockResolvedValue({
+      totalEmployees: 3,
+      totalSkillEntries: 7,
+      averageFulfillmentRate: 0.72,
+      topCategories: [],
+    }),
+    getHeatmap: vi.fn(),
+    getEmployeeRadar: vi.fn(),
+    ...overrides,
+  }
+}
+
+afterEach(() => {
+  clearSkillAnalyticsServiceForTesting()
+})
+
+describe('GET /api/skill-analytics/summary', () => {
+  it('returns 401 when unauthenticated', async () => {
+    mockedGetServerSession.mockResolvedValue(null)
+
+    const res = await GET()
+
+    expect(res.status).toBe(401)
+  })
+
+  it('returns summary for HR manager', async () => {
+    mockedGetServerSession.mockResolvedValue(makeSession('HR_MANAGER', 'hr-1'))
+    const service = makeService()
+    setSkillAnalyticsServiceForTesting(service)
+
+    const res = await GET()
+
+    expect(res.status).toBe(200)
+    expect(service.getOrganizationSummary).toHaveBeenCalled()
+  })
+
+  it('returns 503 when service is not initialized', async () => {
+    mockedGetServerSession.mockResolvedValue(makeSession('ADMIN', 'admin-1'))
+
+    const res = await GET()
+
+    expect(res.status).toBe(503)
+  })
+})


### PR DESCRIPTION
## Summary
- add development auth/session and service fallbacks for dashboard, organization, and skill analytics UI flows
- add /api/organization/my-team and development organization tree data so the UI can load without full backend wiring
- align organization page and commit API request/response handling with the current frontend contract

## Testing
- pnpm vitest run src/tests/organization/my-team-route.test.ts src/tests/organization/organization-service-di.test.ts src/tests/organization/organization-tree-route.test.ts src/tests/skill/skill-analytics-di.test.ts src/tests/skill/skill-analytics-summary-route.test.ts src/tests/skill/skill-analytics-heatmap-route.test.ts src/tests/dashboard/dashboard-service-di.test.ts src/tests/auth/app-session.test.ts
- pnpm exec tsc --noEmit --pretty false