### PR TITLE
Implement issue #173 auth, notification, and AI ops UI

### DIFF
--- a/src/app/admin/ai-monitoring/page.tsx
+++ b/src/app/admin/ai-monitoring/page.tsx
@@ -1,0 +1,223 @@
+'use client'
+
+import { useEffect, useState, type ReactElement, type ReactNode } from 'react'
+
+interface DashboardSnapshot {
+  readonly costSeries: {
+    readonly points: readonly {
+      readonly bucket: string
+      readonly costUsd: number
+      readonly requests: number
+    }[]
+  }
+  readonly topUsers: readonly {
+    readonly userId: string
+    readonly costUsd: number
+    readonly requests: number
+  }[]
+  readonly failureRate: {
+    readonly failureCount: number
+    readonly totalAttempts: number
+    readonly failureRate: number
+    readonly byErrorCategory: Record<string, number>
+  }
+  readonly providerComparison: {
+    readonly rows: readonly {
+      readonly provider: string
+      readonly requests: number
+      readonly costUsd: number
+      readonly avgLatencyMs: number
+      readonly cacheHitRate: number
+    }[]
+  }
+}
+
+type State =
+  | { kind: 'loading' }
+  | { kind: 'error'; message: string }
+  | { kind: 'ready'; snapshot: DashboardSnapshot }
+
+export default function AIMonitoringPage(): ReactElement {
+  const [range, setRange] = useState('30d')
+  const [state, setState] = useState<State>({ kind: 'loading' })
+
+  useEffect(() => {
+    void (async () => {
+      setState({ kind: 'loading' })
+      const res = await fetch(`/api/ai-monitoring/dashboard?range=${range}`, { cache: 'no-store' })
+      const body = (await res.json().catch(() => ({}))) as {
+        data?: DashboardSnapshot
+        error?: string
+      }
+
+      if (!res.ok || !body.data) {
+        setState({ kind: 'error', message: body.error ?? `HTTP ${res.status}` })
+        return
+      }
+
+      setState({ kind: 'ready', snapshot: body.data })
+    })()
+  }, [range])
+
+  return (
+    <main className="min-h-screen bg-[linear-gradient(180deg,#f8fbff_0%,#ffffff_40%,#f8fafc_100%)]">
+      <div className="mx-auto flex max-w-6xl flex-col gap-6 px-6 py-10">
+        <section className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+          <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+            <div>
+              <p className="text-xs font-semibold tracking-[0.3em] text-sky-700 uppercase">
+                AI Operations
+              </p>
+              <h1 className="mt-2 text-4xl font-semibold tracking-tight text-slate-950">
+                AI運用ダッシュボード
+              </h1>
+              <p className="mt-3 max-w-3xl text-sm leading-7 text-slate-600">
+                コスト推移、利用上位ユーザー、プロバイダ比較、失敗率を ADMIN 向けに一覧化します。
+              </p>
+            </div>
+            <label className="grid gap-2 text-sm font-medium text-slate-700">
+              期間
+              <select
+                value={range}
+                onChange={(event) => setRange(event.target.value)}
+                className="rounded-2xl border border-slate-300 px-4 py-3 outline-none focus:border-sky-400"
+              >
+                <option value="7d">直近7日</option>
+                <option value="30d">直近30日</option>
+                <option value="90d">直近90日</option>
+              </select>
+            </label>
+          </div>
+        </section>
+
+        {state.kind === 'loading' ? <Panel>AI利用データを読み込み中です...</Panel> : null}
+        {state.kind === 'error' ? <Panel tone="error">{state.message}</Panel> : null}
+        {state.kind === 'ready' ? (
+          <div className="grid gap-6">
+            <section className="grid gap-4 md:grid-cols-3">
+              <MetricCard
+                label="総試行回数"
+                value={String(state.snapshot.failureRate.totalAttempts)}
+                helper="成功 + 失敗の合計"
+              />
+              <MetricCard
+                label="失敗件数"
+                value={String(state.snapshot.failureRate.failureCount)}
+                helper="監視対象期間内のAIエラー"
+              />
+              <MetricCard
+                label="失敗率"
+                value={`${(state.snapshot.failureRate.failureRate * 100).toFixed(1)}%`}
+                helper="失敗件数 / 総試行回数"
+              />
+            </section>
+
+            <section className="grid gap-6 lg:grid-cols-2">
+              <Panel>
+                <h2 className="text-lg font-semibold text-slate-950">コスト推移</h2>
+                <div className="mt-4 grid gap-3">
+                  {state.snapshot.costSeries.points.map((point) => (
+                    <div
+                      key={point.bucket}
+                      className="flex items-center justify-between rounded-2xl border border-slate-200 px-4 py-3"
+                    >
+                      <span className="text-sm font-medium text-slate-700">{point.bucket}</span>
+                      <span className="text-sm text-slate-600">
+                        ${point.costUsd.toFixed(2)} / {point.requests} requests
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </Panel>
+
+              <Panel>
+                <h2 className="text-lg font-semibold text-slate-950">プロバイダ比較</h2>
+                <div className="mt-4 grid gap-3">
+                  {state.snapshot.providerComparison.rows.map((row) => (
+                    <div
+                      key={row.provider}
+                      className="rounded-2xl border border-slate-200 px-4 py-3 text-sm text-slate-700"
+                    >
+                      <p className="font-semibold text-slate-900">{row.provider}</p>
+                      <p className="mt-1">
+                        ${row.costUsd.toFixed(2)} / {row.requests} requests / avg{' '}
+                        {Math.round(row.avgLatencyMs)}ms
+                      </p>
+                      <p className="mt-1 text-slate-500">
+                        Cache hit {(row.cacheHitRate * 100).toFixed(0)}%
+                      </p>
+                    </div>
+                  ))}
+                </div>
+              </Panel>
+            </section>
+
+            <section className="grid gap-6 lg:grid-cols-2">
+              <Panel>
+                <h2 className="text-lg font-semibold text-slate-950">利用上位ユーザー</h2>
+                <div className="mt-4 grid gap-3">
+                  {state.snapshot.topUsers.map((row) => (
+                    <div
+                      key={row.userId}
+                      className="flex items-center justify-between rounded-2xl border border-slate-200 px-4 py-3"
+                    >
+                      <span className="text-sm font-medium text-slate-700">{row.userId}</span>
+                      <span className="text-sm text-slate-600">
+                        ${row.costUsd.toFixed(2)} / {row.requests} requests
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </Panel>
+
+              <Panel>
+                <h2 className="text-lg font-semibold text-slate-950">エラーカテゴリ内訳</h2>
+                <div className="mt-4 grid gap-3">
+                  {Object.entries(state.snapshot.failureRate.byErrorCategory).map(
+                    ([key, count]) => (
+                      <div
+                        key={key}
+                        className="flex items-center justify-between rounded-2xl border border-slate-200 px-4 py-3"
+                      >
+                        <span className="text-sm font-medium text-slate-700">{key}</span>
+                        <span className="text-sm text-slate-600">{count} 件</span>
+                      </div>
+                    ),
+                  )}
+                </div>
+              </Panel>
+            </section>
+          </div>
+        ) : null}
+      </div>
+    </main>
+  )
+}
+
+function Panel(props: {
+  readonly children: ReactNode
+  readonly tone?: 'neutral' | 'error'
+}): ReactElement {
+  const className =
+    props.tone === 'error'
+      ? 'border-rose-200 bg-rose-50 text-rose-900'
+      : 'border-slate-200 bg-white text-slate-700'
+
+  return (
+    <section className={`rounded-3xl border p-6 shadow-sm ${className}`}>{props.children}</section>
+  )
+}
+
+function MetricCard(props: {
+  readonly label: string
+  readonly value: string
+  readonly helper: string
+}): ReactElement {
+  return (
+    <article className="rounded-3xl border border-slate-200 bg-white p-5 shadow-sm">
+      <p className="text-sm font-medium text-slate-500">{props.label}</p>
+      <p className="mt-2 text-3xl font-semibold text-slate-950">{props.value}</p>
+      <p className="mt-2 text-sm text-slate-600">{props.helper}</p>
+    </article>
+  )
+}

--- a/src/app/admin/users/invitations/page.tsx
+++ b/src/app/admin/users/invitations/page.tsx
@@ -1,0 +1,104 @@
+'use client'
+
+import Link from 'next/link'
+import { useState, type FormEvent, type ReactElement } from 'react'
+
+const DEMO_LINK = '/auth/invitations/demo-invite-admin'
+
+export default function UserInvitationsPage(): ReactElement {
+  const [email, setEmail] = useState('')
+  const [role, setRole] = useState('EMPLOYEE')
+  const [status, setStatus] = useState<string | null>(null)
+
+  async function submitInvite(event: FormEvent<HTMLFormElement>): Promise<void> {
+    event.preventDefault()
+    setStatus('送信中...')
+
+    const res = await fetch('/api/users', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, role }),
+    })
+
+    const body = (await res.json().catch(() => ({}))) as { error?: string }
+    if (!res.ok) {
+      setStatus(body.error ?? `送信に失敗しました (HTTP ${res.status})`)
+      return
+    }
+
+    setStatus('招待を登録しました。開発環境では下のデモリンクから受諾画面も確認できます。')
+    setEmail('')
+  }
+
+  return (
+    <main className="min-h-screen bg-[linear-gradient(180deg,#fffdf7_0%,#ffffff_40%,#f8fafc_100%)]">
+      <div className="mx-auto flex max-w-5xl flex-col gap-6 px-6 py-10">
+        <section className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+          <p className="text-xs font-semibold tracking-[0.3em] text-amber-700 uppercase">Admin</p>
+          <h1 className="mt-2 text-4xl font-semibold tracking-tight text-slate-950">
+            ユーザー招待と初回パスワード設定
+          </h1>
+          <p className="mt-3 max-w-3xl text-sm leading-7 text-slate-600">
+            ADMIN
+            がメールアドレスとロールを指定して招待を発行し、受諾側はトークンURLから初回パスワードを設定します。
+          </p>
+        </section>
+        <div className="grid gap-6 lg:grid-cols-[1.2fr_0.8fr]">
+          <section className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+            <h2 className="text-lg font-semibold text-slate-950">招待を発行する</h2>
+            <form className="mt-5 grid gap-4" onSubmit={(event) => void submitInvite(event)}>
+              <label className="grid gap-2 text-sm font-medium text-slate-700">
+                Email
+                <input
+                  type="email"
+                  value={email}
+                  onChange={(event) => setEmail(event.target.value)}
+                  className="rounded-2xl border border-slate-300 px-4 py-3 outline-none focus:border-sky-400"
+                  placeholder="member@example.com"
+                  required
+                />
+              </label>
+              <label className="grid gap-2 text-sm font-medium text-slate-700">
+                Role
+                <select
+                  value={role}
+                  onChange={(event) => setRole(event.target.value)}
+                  className="rounded-2xl border border-slate-300 px-4 py-3 outline-none focus:border-sky-400"
+                >
+                  <option value="EMPLOYEE">EMPLOYEE</option>
+                  <option value="MANAGER">MANAGER</option>
+                  <option value="HR_MANAGER">HR_MANAGER</option>
+                  <option value="ADMIN">ADMIN</option>
+                </select>
+              </label>
+              <button
+                type="submit"
+                className="rounded-2xl bg-slate-950 px-5 py-3 text-sm font-semibold text-white"
+              >
+                招待メールを送信
+              </button>
+            </form>
+            {status ? <p className="mt-4 text-sm text-slate-600">{status}</p> : null}
+          </section>
+
+          <section className="rounded-3xl border border-amber-200 bg-amber-50 p-6 shadow-sm">
+            <h2 className="text-lg font-semibold text-amber-950">受諾フローの確認</h2>
+            <p className="mt-3 text-sm leading-6 text-amber-900">
+              開発環境ではデモ用トークンを固定で用意しています。招待メール本文の代わりに、下のリンクから初回パスワード設定画面を確認できます。
+            </p>
+            <Link
+              href={DEMO_LINK}
+              className="mt-5 inline-flex rounded-full border border-amber-300 px-4 py-2 text-sm font-semibold text-amber-900"
+            >
+              デモ招待リンクを開く
+            </Link>
+            <div className="mt-6 grid gap-3 text-sm text-amber-950">
+              <p>推奨パスワード条件</p>
+              <p>12文字以上、英大文字・英小文字・数字・記号のうち3種類以上を含めてください。</p>
+            </div>
+          </section>
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/src/app/api/ai-monitoring/dashboard/route.ts
+++ b/src/app/api/ai-monitoring/dashboard/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from 'next/server'
+import { getAppSession } from '@/lib/auth/app-session'
+import { AIDashboardForbiddenError } from '@/lib/ai-monitoring/ai-dashboard-service'
+import { getAIDashboardService } from '@/lib/ai-monitoring/ai-dashboard-service-di'
+import type { Granularity } from '@/lib/ai-monitoring/ai-dashboard-types'
+import type { UserRole } from '@/lib/notification/notification-types'
+
+function isUserRole(value: unknown): value is UserRole {
+  return value === 'ADMIN' || value === 'HR_MANAGER' || value === 'MANAGER' || value === 'EMPLOYEE'
+}
+
+function parseRange(input: string | null): { from: Date; to: Date; granularity: Granularity } {
+  const to = new Date()
+  if (input === '7d') {
+    return { from: new Date(to.getTime() - 7 * 24 * 60 * 60 * 1000), to, granularity: 'DAY' }
+  }
+  if (input === '90d') {
+    return { from: new Date(to.getTime() - 90 * 24 * 60 * 60 * 1000), to, granularity: 'WEEK' }
+  }
+  return { from: new Date(to.getTime() - 30 * 24 * 60 * 60 * 1000), to, granularity: 'DAY' }
+}
+
+export async function GET(request: Request): Promise<NextResponse> {
+  const session = await getAppSession()
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const raw = session as Record<string, unknown>
+  const userId = typeof raw.userId === 'string' ? raw.userId : null
+  const role = raw.role
+  if (!userId || !isUserRole(role)) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  try {
+    const url = new URL(request.url)
+    const range = parseRange(url.searchParams.get('range'))
+    const service = getAIDashboardService()
+    const data = await service.getSnapshot({
+      requester: { userId, role },
+      range,
+      topUsersLimit: 5,
+    })
+    return NextResponse.json({ success: true, data })
+  } catch (error) {
+    if (error instanceof AIDashboardForbiddenError) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+    return NextResponse.json({ error: 'AI dashboard service not initialized' }, { status: 503 })
+  }
+}

--- a/src/app/api/notifications/[notificationId]/route.ts
+++ b/src/app/api/notifications/[notificationId]/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from 'next/server'
+import { getAppSession } from '@/lib/auth/app-session'
+import {
+  NotificationAccessDeniedError,
+  NotificationNotFoundError,
+} from '@/lib/notification/notification-service'
+import { getNotificationService } from '@/lib/notification/notification-service-di'
+
+function getUserId(session: Record<string, unknown>): string | null {
+  return typeof session.userId === 'string' ? session.userId : null
+}
+
+export async function PATCH(
+  _request: Request,
+  { params }: { params: Promise<{ notificationId: string }> },
+): Promise<NextResponse> {
+  const session = await getAppSession()
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const userId = getUserId(session)
+  if (!userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { notificationId } = await params
+
+  try {
+    const service = getNotificationService()
+    const notification = await service.markAsRead(userId, notificationId)
+    return NextResponse.json({ success: true, data: notification })
+  } catch (error) {
+    if (error instanceof NotificationNotFoundError) {
+      return NextResponse.json({ error: 'Notification not found' }, { status: 404 })
+    }
+    if (error instanceof NotificationAccessDeniedError) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+    return NextResponse.json({ error: 'Notification service not initialized' }, { status: 503 })
+  }
+}

--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -1,0 +1,77 @@
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+import { getAppSession } from '@/lib/auth/app-session'
+import { getNotificationService } from '@/lib/notification/notification-service-di'
+import { notificationPreferencesSchema } from '@/lib/notification/notification-types'
+
+function getUserId(session: Record<string, unknown>): string | null {
+  return typeof session.userId === 'string' ? session.userId : null
+}
+
+export async function GET(): Promise<NextResponse> {
+  const session = await getAppSession()
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const userId = getUserId(session)
+  if (!userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  try {
+    const service = getNotificationService()
+    const [list, preferences] = await Promise.all([
+      service.listForUser(userId),
+      service.getPreferences(userId),
+    ])
+
+    return NextResponse.json({
+      success: true,
+      data: {
+        notifications: list.notifications,
+        unreadCount: list.unreadCount,
+        preferences,
+      },
+    })
+  } catch {
+    return NextResponse.json({ error: 'Notification service not initialized' }, { status: 503 })
+  }
+}
+
+const updateBodySchema = z.object({
+  preferences: notificationPreferencesSchema,
+})
+
+export async function PUT(request: Request): Promise<NextResponse> {
+  const session = await getAppSession()
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const userId = getUserId(session)
+  if (!userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
+  }
+
+  const parsed = updateBodySchema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.flatten() }, { status: 422 })
+  }
+
+  try {
+    const service = getNotificationService()
+    await service.updatePreferences(userId, parsed.data.preferences)
+    const preferences = await service.getPreferences(userId)
+    return NextResponse.json({ success: true, data: { preferences } })
+  } catch {
+    return NextResponse.json({ error: 'Notification service not initialized' }, { status: 503 })
+  }
+}

--- a/src/app/auth/invitations/[token]/page.tsx
+++ b/src/app/auth/invitations/[token]/page.tsx
@@ -1,0 +1,92 @@
+'use client'
+
+import { useState, type FormEvent, type ReactElement } from 'react'
+
+export default function InvitationAcceptPage({
+  params,
+}: {
+  readonly params: { token: string }
+}): ReactElement {
+  const [password, setPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
+  const [status, setStatus] = useState<string | null>(null)
+  const token = params.token
+
+  async function submit(event: FormEvent<HTMLFormElement>): Promise<void> {
+    event.preventDefault()
+    if (password !== confirmPassword) {
+      setStatus('確認用パスワードが一致しません。')
+      return
+    }
+
+    setStatus('設定中...')
+    const res = await fetch(`/api/auth/invitations/${token}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ password }),
+    })
+    const body = (await res.json().catch(() => ({}))) as { error?: string; rule?: string }
+
+    if (!res.ok) {
+      if (body.rule) {
+        setStatus(`パスワードポリシー違反: ${body.rule}`)
+        return
+      }
+      setStatus(body.error ?? `初回設定に失敗しました (HTTP ${res.status})`)
+      return
+    }
+
+    setStatus('パスワード設定が完了しました。ログインして利用を開始してください。')
+    setPassword('')
+    setConfirmPassword('')
+  }
+
+  return (
+    <main className="min-h-screen bg-[linear-gradient(180deg,#f8fbff_0%,#ffffff_40%,#f8fafc_100%)]">
+      <div className="mx-auto flex max-w-3xl flex-col gap-6 px-6 py-12">
+        <section className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+          <p className="text-xs font-semibold tracking-[0.3em] text-sky-700 uppercase">
+            Invitation
+          </p>
+          <h1 className="mt-2 text-4xl font-semibold tracking-tight text-slate-950">
+            初回パスワード設定
+          </h1>
+          <p className="mt-3 text-sm leading-7 text-slate-600">
+            招待トークンを受け取ったユーザー向けのセットアップ画面です。パスワード設定後にアカウントを有効化します。
+          </p>
+          <form className="mt-6 grid gap-4" onSubmit={(event) => void submit(event)}>
+            <label className="grid gap-2 text-sm font-medium text-slate-700">
+              Password
+              <input
+                type="password"
+                value={password}
+                onChange={(event) => setPassword(event.target.value)}
+                className="rounded-2xl border border-slate-300 px-4 py-3 outline-none focus:border-sky-400"
+                minLength={12}
+                required
+              />
+            </label>
+            <label className="grid gap-2 text-sm font-medium text-slate-700">
+              Confirm password
+              <input
+                type="password"
+                value={confirmPassword}
+                onChange={(event) => setConfirmPassword(event.target.value)}
+                className="rounded-2xl border border-slate-300 px-4 py-3 outline-none focus:border-sky-400"
+                minLength={12}
+                required
+              />
+            </label>
+            <button
+              type="submit"
+              className="rounded-2xl bg-slate-950 px-5 py-3 text-sm font-semibold text-white"
+            >
+              パスワードを設定
+            </button>
+          </form>
+          {status ? <p className="mt-4 text-sm text-slate-600">{status}</p> : null}
+        </section>
+      </div>
+    </main>
+  )
+}

--- a/src/app/auth/sessions/page.tsx
+++ b/src/app/auth/sessions/page.tsx
@@ -1,0 +1,195 @@
+'use client'
+
+import Link from 'next/link'
+import { useEffect, useState, type ReactElement, type ReactNode } from 'react'
+
+interface SessionItem {
+  readonly id: string
+  readonly email: string
+  readonly role: string
+  readonly createdAt: string
+  readonly lastAccessAt: string
+  readonly ipAddress?: string
+  readonly userAgent?: string
+  readonly isCurrent: boolean
+}
+
+type State =
+  | { kind: 'loading' }
+  | { kind: 'error'; message: string }
+  | { kind: 'ready'; sessions: readonly SessionItem[] }
+
+export default function AuthSessionsPage(): ReactElement {
+  const [state, setState] = useState<State>({ kind: 'loading' })
+  const [revokingId, setRevokingId] = useState<string | null>(null)
+
+  async function load(): Promise<void> {
+    setState({ kind: 'loading' })
+    const res = await fetch('/api/auth/sessions', { cache: 'no-store' })
+    const body = (await res.json().catch(() => ({}))) as {
+      sessions?: SessionItem[]
+      error?: string
+    }
+
+    if (!res.ok || !body.sessions) {
+      setState({ kind: 'error', message: body.error ?? `HTTP ${res.status}` })
+      return
+    }
+
+    setState({ kind: 'ready', sessions: body.sessions })
+  }
+
+  useEffect(() => {
+    void load()
+  }, [])
+
+  async function revokeSession(sessionId: string): Promise<void> {
+    setRevokingId(sessionId)
+    try {
+      const res = await fetch(`/api/auth/sessions/${sessionId}`, { method: 'DELETE' })
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string }
+        throw new Error(body.error ?? `HTTP ${res.status}`)
+      }
+      await load()
+    } catch (error) {
+      setState({
+        kind: 'error',
+        message: error instanceof Error ? error.message : 'セッション失効に失敗しました',
+      })
+    } finally {
+      setRevokingId(null)
+    }
+  }
+
+  return (
+    <main className="min-h-screen bg-[linear-gradient(180deg,#f8fbff_0%,#ffffff_45%,#f8fafc_100%)]">
+      <div className="mx-auto flex max-w-5xl flex-col gap-6 px-6 py-10">
+        <Header
+          eyebrow="Auth"
+          title="セッション一覧と手動失効"
+          description="現在ログイン中のデバイスや最終アクセスを確認し、不要なセッションを手動で失効できます。"
+        />
+        <NavLinks
+          links={[
+            { href: '/admin/users/invitations', label: 'ユーザー招待' },
+            { href: '/notifications', label: '通知センター' },
+            { href: '/admin/ai-monitoring', label: 'AI運用ダッシュボード' },
+          ]}
+        />
+        {state.kind === 'loading' ? <Panel>読み込み中です...</Panel> : null}
+        {state.kind === 'error' ? <Panel tone="error">{state.message}</Panel> : null}
+        {state.kind === 'ready' ? (
+          <section className="grid gap-4">
+            {state.sessions.map((session) => (
+              <article
+                key={session.id}
+                className="rounded-3xl border border-slate-200 bg-white p-5 shadow-sm"
+              >
+                <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+                  <div>
+                    <div className="flex items-center gap-3">
+                      <h2 className="text-lg font-semibold text-slate-950">
+                        {session.userAgent ?? 'Unknown device'}
+                      </h2>
+                      {session.isCurrent ? (
+                        <span className="rounded-full bg-sky-100 px-3 py-1 text-xs font-semibold text-sky-700">
+                          Current
+                        </span>
+                      ) : null}
+                    </div>
+                    <dl className="mt-3 grid gap-2 text-sm text-slate-600 md:grid-cols-2">
+                      <div>
+                        <dt className="font-medium text-slate-800">IP</dt>
+                        <dd>{session.ipAddress ?? 'N/A'}</dd>
+                      </div>
+                      <div>
+                        <dt className="font-medium text-slate-800">Role</dt>
+                        <dd>{session.role}</dd>
+                      </div>
+                      <div>
+                        <dt className="font-medium text-slate-800">Created</dt>
+                        <dd>{formatDateTime(session.createdAt)}</dd>
+                      </div>
+                      <div>
+                        <dt className="font-medium text-slate-800">Last access</dt>
+                        <dd>{formatDateTime(session.lastAccessAt)}</dd>
+                      </div>
+                    </dl>
+                  </div>
+                  <button
+                    type="button"
+                    disabled={session.isCurrent || revokingId === session.id}
+                    onClick={() => void revokeSession(session.id)}
+                    className="rounded-full border border-rose-200 px-4 py-2 text-sm font-semibold text-rose-700 disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    {session.isCurrent
+                      ? '現在のセッション'
+                      : revokingId === session.id
+                        ? '失効中...'
+                        : '失効する'}
+                  </button>
+                </div>
+              </article>
+            ))}
+          </section>
+        ) : null}
+      </div>
+    </main>
+  )
+}
+
+function formatDateTime(value: string): string {
+  return new Intl.DateTimeFormat('ja-JP', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(new Date(value))
+}
+
+function Header(props: {
+  readonly eyebrow: string
+  readonly title: string
+  readonly description: string
+}): ReactElement {
+  return (
+    <header className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+      <p className="text-xs font-semibold tracking-[0.3em] text-sky-700 uppercase">
+        {props.eyebrow}
+      </p>
+      <h1 className="mt-2 text-4xl font-semibold tracking-tight text-slate-950">{props.title}</h1>
+      <p className="mt-3 max-w-3xl text-sm leading-7 text-slate-600">{props.description}</p>
+    </header>
+  )
+}
+
+function NavLinks(props: {
+  readonly links: readonly { href: string; label: string }[]
+}): ReactElement {
+  return (
+    <div className="flex flex-wrap gap-3">
+      {props.links.map((link) => (
+        <Link
+          key={link.href}
+          href={link.href}
+          className="rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm"
+        >
+          {link.label}
+        </Link>
+      ))}
+    </div>
+  )
+}
+
+function Panel(props: {
+  readonly children: ReactNode
+  readonly tone?: 'neutral' | 'error'
+}): ReactElement {
+  const className =
+    props.tone === 'error'
+      ? 'border-rose-200 bg-rose-50 text-rose-900'
+      : 'border-slate-200 bg-white text-slate-700'
+
+  return (
+    <section className={`rounded-3xl border p-6 shadow-sm ${className}`}>{props.children}</section>
+  )
+}

--- a/src/app/notifications/page.tsx
+++ b/src/app/notifications/page.tsx
@@ -1,0 +1,177 @@
+'use client'
+
+import { useEffect, useState, type ReactElement, type ReactNode } from 'react'
+
+interface NotificationItem {
+  readonly id: string
+  readonly title: string
+  readonly body: string
+  readonly category: string
+  readonly createdAt: string
+  readonly readAt: string | null
+}
+
+interface PreferenceItem {
+  readonly category: string
+  readonly emailEnabled: boolean
+}
+
+type NotificationState =
+  | { kind: 'loading' }
+  | { kind: 'error'; message: string }
+  | {
+      kind: 'ready'
+      notifications: readonly NotificationItem[]
+      unreadCount: number
+      preferences: readonly PreferenceItem[]
+    }
+
+export default function NotificationsPage(): ReactElement {
+  const [state, setState] = useState<NotificationState>({ kind: 'loading' })
+
+  async function load(): Promise<void> {
+    setState({ kind: 'loading' })
+    const res = await fetch('/api/notifications', { cache: 'no-store' })
+    const body = (await res.json().catch(() => ({}))) as {
+      data?: {
+        notifications: NotificationItem[]
+        unreadCount: number
+        preferences: PreferenceItem[]
+      }
+      error?: string
+    }
+
+    if (!res.ok || !body.data) {
+      setState({ kind: 'error', message: body.error ?? `HTTP ${res.status}` })
+      return
+    }
+
+    setState({ kind: 'ready', ...body.data })
+  }
+
+  useEffect(() => {
+    void load()
+  }, [])
+
+  async function markAsRead(id: string): Promise<void> {
+    const res = await fetch(`/api/notifications/${id}`, { method: 'PATCH' })
+    if (res.ok) {
+      await load()
+    }
+  }
+
+  async function togglePreference(category: string, nextValue: boolean): Promise<void> {
+    if (state.kind !== 'ready') return
+    const preferences = state.preferences.map((item) =>
+      item.category === category ? { ...item, emailEnabled: nextValue } : item,
+    )
+
+    const res = await fetch('/api/notifications', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ preferences }),
+    })
+
+    if (res.ok) {
+      await load()
+    }
+  }
+
+  return (
+    <main className="min-h-screen bg-[linear-gradient(180deg,#f9fbff_0%,#ffffff_40%,#f8fafc_100%)]">
+      <div className="mx-auto flex max-w-6xl flex-col gap-6 px-6 py-10">
+        <section className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+          <p className="text-xs font-semibold tracking-[0.3em] text-sky-700 uppercase">
+            Notifications
+          </p>
+          <h1 className="mt-2 text-4xl font-semibold tracking-tight text-slate-950">
+            通知センターと既読管理
+          </h1>
+          <p className="mt-3 max-w-3xl text-sm leading-7 text-slate-600">
+            アプリ内通知の一覧、未読件数、カテゴリ別メール通知設定をまとめて確認できます。
+          </p>
+        </section>
+
+        {state.kind === 'loading' ? <Panel>通知を読み込み中です...</Panel> : null}
+        {state.kind === 'error' ? <Panel tone="error">{state.message}</Panel> : null}
+        {state.kind === 'ready' ? (
+          <div className="grid gap-6 lg:grid-cols-[1.2fr_0.8fr]">
+            <section className="grid gap-4">
+              <Panel>
+                <p className="text-sm font-semibold text-slate-900">
+                  未読 {state.unreadCount} 件 / 全 {state.notifications.length} 件
+                </p>
+              </Panel>
+              {state.notifications.map((item) => (
+                <article
+                  key={item.id}
+                  className="rounded-3xl border border-slate-200 bg-white p-5 shadow-sm"
+                >
+                  <div className="flex items-start justify-between gap-4">
+                    <div>
+                      <p className="text-xs font-semibold tracking-[0.2em] text-sky-700 uppercase">
+                        {item.category}
+                      </p>
+                      <h2 className="mt-2 text-lg font-semibold text-slate-950">{item.title}</h2>
+                      <p className="mt-2 text-sm leading-6 text-slate-600">{item.body}</p>
+                      <p className="mt-3 text-xs text-slate-500">
+                        {new Intl.DateTimeFormat('ja-JP', {
+                          dateStyle: 'medium',
+                          timeStyle: 'short',
+                        }).format(new Date(item.createdAt))}
+                      </p>
+                    </div>
+                    <button
+                      type="button"
+                      disabled={item.readAt !== null}
+                      onClick={() => void markAsRead(item.id)}
+                      className="rounded-full border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-700 disabled:opacity-50"
+                    >
+                      {item.readAt ? '既読済み' : '既読にする'}
+                    </button>
+                  </div>
+                </article>
+              ))}
+            </section>
+
+            <section className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+              <h2 className="text-lg font-semibold text-slate-950">メール通知設定</h2>
+              <div className="mt-5 grid gap-4">
+                {state.preferences.map((item) => (
+                  <label
+                    key={item.category}
+                    className="flex items-center justify-between gap-4 rounded-2xl border border-slate-200 px-4 py-3"
+                  >
+                    <span className="text-sm font-medium text-slate-700">{item.category}</span>
+                    <input
+                      type="checkbox"
+                      checked={item.emailEnabled}
+                      onChange={(event) =>
+                        void togglePreference(item.category, event.target.checked)
+                      }
+                      className="h-4 w-4"
+                    />
+                  </label>
+                ))}
+              </div>
+            </section>
+          </div>
+        ) : null}
+      </div>
+    </main>
+  )
+}
+
+function Panel(props: {
+  readonly children: ReactNode
+  readonly tone?: 'neutral' | 'error'
+}): ReactElement {
+  const className =
+    props.tone === 'error'
+      ? 'border-rose-200 bg-rose-50 text-rose-900'
+      : 'border-slate-200 bg-white text-slate-700'
+
+  return (
+    <section className={`rounded-3xl border p-6 shadow-sm ${className}`}>{props.children}</section>
+  )
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,17 +4,37 @@ const sections = [
   {
     href: '/dashboard',
     title: 'ダッシュボード',
-    description: 'ロール別 KPI をまとめて確認するホーム画面',
+    description: 'ロール別 KPI と主要指標を確認します。',
   },
   {
     href: '/organization',
     title: '組織管理',
-    description: '組織図とポジション編集 UI を開く',
+    description: '組織図とポジション管理の UI を確認します。',
   },
   {
     href: '/skill-map',
     title: 'スキルマップ',
-    description: 'スキルサマリー、ヒートマップ、レーダーチャートを表示',
+    description: 'スキルサマリー、ヒートマップ、レーダーチャートを確認します。',
+  },
+  {
+    href: '/auth/sessions',
+    title: 'セッション管理',
+    description: '現在のログイン端末一覧と手動失効を確認します。',
+  },
+  {
+    href: '/admin/users/invitations',
+    title: 'ユーザー招待',
+    description: '招待発行と初回パスワード設定フローを確認します。',
+  },
+  {
+    href: '/notifications',
+    title: '通知センター',
+    description: 'アプリ内通知一覧とメール通知設定を確認します。',
+  },
+  {
+    href: '/admin/ai-monitoring',
+    title: 'AI運用',
+    description: 'コスト推移、失敗率、プロバイダ比較を確認します。',
   },
 ] as const
 
@@ -27,14 +47,14 @@ export default function HomePage() {
             HR Management System
           </p>
           <h1 className="mt-2 text-4xl font-semibold tracking-tight text-slate-950">
-            人事プラットフォーム
+            画面一覧ポータル
           </h1>
           <p className="mt-3 max-w-3xl text-sm leading-7 text-slate-600">
-            組織、スキル、評価、目標、インセンティブの主要機能へ移動できるエントリーポイントです。
+            組織、スキル、認証、通知、AI運用まで、現在利用できる主要画面へここから移動できます。
           </p>
         </header>
 
-        <section className="grid gap-4 md:grid-cols-3">
+        <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
           {sections.map((section) => (
             <Link
               key={section.href}

--- a/src/lib/ai-monitoring/ai-dashboard-dev-service.ts
+++ b/src/lib/ai-monitoring/ai-dashboard-dev-service.ts
@@ -1,0 +1,94 @@
+import { createAIDashboardService, type AIDashboardService } from './ai-dashboard-service'
+
+const dayMs = 24 * 60 * 60 * 1000
+const now = Date.now()
+
+const usageRecords = [
+  {
+    userId: 'dev-admin',
+    domain: 'feedback',
+    provider: 'claude' as const,
+    promptTokens: 2200,
+    completionTokens: 1400,
+    estimatedCostUsd: 2.34,
+    latencyMs: 920,
+    cacheHit: false,
+    createdAt: new Date(now - 28 * dayMs),
+  },
+  {
+    userId: 'dev-admin',
+    domain: 'feedback',
+    provider: 'openai' as const,
+    promptTokens: 1800,
+    completionTokens: 1200,
+    estimatedCostUsd: 1.72,
+    latencyMs: 710,
+    cacheHit: true,
+    createdAt: new Date(now - 20 * dayMs),
+  },
+  {
+    userId: 'hr-manager-1',
+    domain: 'evaluation',
+    provider: 'claude' as const,
+    promptTokens: 3400,
+    completionTokens: 2100,
+    estimatedCostUsd: 3.88,
+    latencyMs: 1100,
+    cacheHit: false,
+    createdAt: new Date(now - 14 * dayMs),
+  },
+  {
+    userId: 'manager-1',
+    domain: 'goals',
+    provider: 'openai' as const,
+    promptTokens: 1200,
+    completionTokens: 700,
+    estimatedCostUsd: 0.96,
+    latencyMs: 640,
+    cacheHit: true,
+    createdAt: new Date(now - 7 * dayMs),
+  },
+  {
+    userId: 'manager-2',
+    domain: 'organization',
+    provider: 'claude' as const,
+    promptTokens: 2600,
+    completionTokens: 1550,
+    estimatedCostUsd: 2.91,
+    latencyMs: 980,
+    cacheHit: false,
+    createdAt: new Date(now - 2 * dayMs),
+  },
+]
+
+const failureRecords = [
+  {
+    userId: 'manager-1',
+    errorCategory: 'TIMEOUT',
+    createdAt: new Date(now - 10 * dayMs),
+  },
+  {
+    userId: 'manager-2',
+    errorCategory: 'RATE_LIMIT',
+    createdAt: new Date(now - 5 * dayMs),
+  },
+]
+
+const devService = createAIDashboardService({
+  usageQuery: {
+    async listByDateRange(range) {
+      return usageRecords.filter(
+        (record) => record.createdAt >= range.from && record.createdAt <= range.to,
+      )
+    },
+    async listFailuresByDateRange(range) {
+      return failureRecords.filter(
+        (record) => record.createdAt >= range.from && record.createdAt <= range.to,
+      )
+    },
+  },
+})
+
+export function getDevAIDashboardService(): AIDashboardService {
+  return devService
+}

--- a/src/lib/ai-monitoring/ai-dashboard-service-di.ts
+++ b/src/lib/ai-monitoring/ai-dashboard-service-di.ts
@@ -1,0 +1,30 @@
+import type { AIDashboardService } from './ai-dashboard-service'
+import { getDevAIDashboardService } from './ai-dashboard-dev-service'
+
+let service: AIDashboardService | null = null
+
+export function setAIDashboardServiceForTesting(svc: AIDashboardService): void {
+  service = svc
+}
+
+export function clearAIDashboardServiceForTesting(): void {
+  service = null
+}
+
+export function initAIDashboardService(svc: AIDashboardService): void {
+  service = svc
+}
+
+export function getAIDashboardService(): AIDashboardService {
+  if (service) {
+    return service
+  }
+  if (process.env.NODE_ENV === 'development') {
+    return getDevAIDashboardService()
+  }
+  throw new Error(
+    'AIDashboardService is not initialized. ' +
+      'テストでは setAIDashboardServiceForTesting() を呼んでください。' +
+      'プロダクションでは initAIDashboardService() を呼んでください。',
+  )
+}

--- a/src/lib/auth/app-session.ts
+++ b/src/lib/auth/app-session.ts
@@ -6,6 +6,16 @@ export type AppSession =
 
 type LegacySessionGetter = () => Promise<AppSession>
 
+const DEV_SESSION = {
+  user: {
+    email: 'dev.admin@example.com',
+    name: 'Development Admin',
+  },
+  userId: 'dev-admin',
+  role: 'ADMIN',
+  sessionId: '00000000-0000-4000-8000-000000000001',
+} satisfies NonNullable<AppSession>
+
 function getLegacySessionGetter(): LegacySessionGetter | undefined {
   return undefined
 }
@@ -17,12 +27,29 @@ async function getLegacySessionGetterForTest(): Promise<LegacySessionGetter | un
   return typeof maybeGetter === 'function' ? (maybeGetter as LegacySessionGetter) : undefined
 }
 
+function getDevelopmentSession(): AppSession {
+  return { ...DEV_SESSION, user: { ...DEV_SESSION.user } }
+}
+
 export async function getAppSession(): Promise<AppSession> {
   const legacyGetter = getLegacySessionGetter() ?? (await getLegacySessionGetterForTest())
   if (legacyGetter) {
     return legacyGetter()
   }
 
-  const { auth } = await import('@/auth')
-  return auth() as Promise<AppSession>
+  try {
+    const { auth } = await import('@/auth')
+    const session = (await auth()) as AppSession
+    if (session) {
+      return session
+    }
+  } catch {
+    // Fall back to development session when auth bootstrapping is not ready.
+  }
+
+  if (process.env.NODE_ENV === 'development') {
+    return getDevelopmentSession()
+  }
+
+  return null
 }

--- a/src/lib/auth/auth-dev-service.ts
+++ b/src/lib/auth/auth-dev-service.ts
@@ -1,0 +1,112 @@
+import type { AuthService } from './auth-service'
+import type { Session } from './auth-types'
+import { SessionNotFoundError } from './auth-types'
+
+const CURRENT_SESSION_ID = '00000000-0000-4000-8000-000000000001'
+
+function cloneSession(session: Session): Session {
+  return {
+    ...session,
+    createdAt: new Date(session.createdAt),
+    expiresAt: new Date(session.expiresAt),
+    lastAccessAt: new Date(session.lastAccessAt),
+  }
+}
+
+function buildSeedSessions(): Session[] {
+  const now = new Date()
+  const oneHour = 60 * 60 * 1000
+
+  return [
+    {
+      id: CURRENT_SESSION_ID,
+      userId: 'dev-admin',
+      role: 'ADMIN',
+      email: 'dev.admin@example.com',
+      createdAt: new Date(now.getTime() - 20 * 60 * 1000),
+      expiresAt: new Date(now.getTime() + 8 * oneHour),
+      lastAccessAt: new Date(now.getTime() - 2 * 60 * 1000),
+      ipAddress: '127.0.0.1',
+      userAgent: 'Chrome / Local Desktop',
+    },
+    {
+      id: '00000000-0000-4000-8000-000000000002',
+      userId: 'dev-admin',
+      role: 'ADMIN',
+      email: 'dev.admin@example.com',
+      createdAt: new Date(now.getTime() - 2 * oneHour),
+      expiresAt: new Date(now.getTime() + 6 * oneHour),
+      lastAccessAt: new Date(now.getTime() - 45 * 60 * 1000),
+      ipAddress: '192.168.0.12',
+      userAgent: 'Safari on iPhone',
+    },
+    {
+      id: '00000000-0000-4000-8000-000000000003',
+      userId: 'dev-admin',
+      role: 'ADMIN',
+      email: 'dev.admin@example.com',
+      createdAt: new Date(now.getTime() - 26 * oneHour),
+      expiresAt: new Date(now.getTime() + oneHour),
+      lastAccessAt: new Date(now.getTime() - 3 * oneHour),
+      ipAddress: '10.0.0.25',
+      userAgent: 'Edge on Windows',
+    },
+  ]
+}
+
+class DevAuthService implements AuthService {
+  private readonly sessions = new Map<string, Session>()
+
+  constructor() {
+    for (const session of buildSeedSessions()) {
+      this.sessions.set(session.id, cloneSession(session))
+    }
+  }
+
+  async login(): Promise<Session> {
+    return cloneSession(this.sessions.get(CURRENT_SESSION_ID)!)
+  }
+
+  async logout(sessionId: string): Promise<void> {
+    this.sessions.delete(sessionId)
+  }
+
+  async getSession(sessionId: string): Promise<Session> {
+    const found = this.sessions.get(sessionId)
+    if (!found) {
+      throw new SessionNotFoundError(sessionId)
+    }
+    return cloneSession(found)
+  }
+
+  async touchSession(sessionId: string): Promise<Session> {
+    const found = await this.getSession(sessionId)
+    const updated: Session = { ...found, lastAccessAt: new Date() }
+    this.sessions.set(sessionId, cloneSession(updated))
+    return cloneSession(updated)
+  }
+
+  async listSessions(userId: string): Promise<readonly Session[]> {
+    return Array.from(this.sessions.values())
+      .filter((session) => session.userId === userId)
+      .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
+      .map((session) => cloneSession(session))
+  }
+
+  async revokeSession(requesterId: string, sessionId: string): Promise<void> {
+    const found = this.sessions.get(sessionId)
+    if (!found || found.userId !== requesterId) {
+      throw new SessionNotFoundError(sessionId)
+    }
+    this.sessions.delete(sessionId)
+  }
+}
+
+let devAuthService: AuthService | null = null
+
+export function getDevAuthService(): AuthService {
+  if (!devAuthService) {
+    devAuthService = new DevAuthService()
+  }
+  return devAuthService
+}

--- a/src/lib/auth/auth-service-di.ts
+++ b/src/lib/auth/auth-service-di.ts
@@ -1,29 +1,30 @@
-/**
- * AuthService のシングルトン DI モジュール。
- * - テスト: setAuthServiceForTesting / clearAuthServiceForTesting で差し替え
- * - プロダクション: アプリ起動時に initAuthService を呼んで初期化
- */
 import type { AuthService } from './auth-service'
+import { getDevAuthService } from './auth-dev-service'
 
-let _authService: AuthService | null = null
+let authService: AuthService | null = null
 
 export function setAuthServiceForTesting(svc: AuthService): void {
-  _authService = svc
+  authService = svc
 }
 
 export function clearAuthServiceForTesting(): void {
-  _authService = null
-}
-
-export function getAuthService(): AuthService {
-  if (_authService) return _authService
-  throw new Error(
-    'AuthService is not initialized. ' +
-      'テストでは setAuthServiceForTesting() を呼んでください。' +
-      'プロダクションではサーバー起動前に initAuthService() を呼んでください。',
-  )
+  authService = null
 }
 
 export function initAuthService(svc: AuthService): void {
-  _authService = svc
+  authService = svc
+}
+
+export function getAuthService(): AuthService {
+  if (authService) {
+    return authService
+  }
+  if (process.env.NODE_ENV === 'development') {
+    return getDevAuthService()
+  }
+  throw new Error(
+    'AuthService is not initialized. ' +
+      'テストでは setAuthServiceForTesting() を呼んでください。' +
+      'プロダクションでは initAuthService() を呼んでください。',
+  )
 }

--- a/src/lib/auth/invitation-dev-service.ts
+++ b/src/lib/auth/invitation-dev-service.ts
@@ -1,0 +1,87 @@
+import { assertPasswordStrong } from './password-policy'
+import type { InvitationService } from './invitation-service'
+import {
+  EmailAlreadyExistsError,
+  InvitationAlreadyUsedError,
+  InvitationExpiredError,
+  InvitationNotFoundError,
+  type InviteUserInput,
+} from './invitation-types'
+
+interface DevInvitationRecord {
+  readonly token: string
+  readonly email: string
+  readonly role: InviteUserInput['role']
+  readonly invitedByUserId: string
+  readonly createdAt: Date
+  readonly expiresAt: Date
+  usedAt: Date | null
+}
+
+class DevInvitationService implements InvitationService {
+  private readonly records = new Map<string, DevInvitationRecord>()
+  private tokenSequence = 0
+
+  constructor() {
+    const now = new Date()
+    this.records.set('demo-invite-admin', {
+      token: 'demo-invite-admin',
+      email: 'new.member@example.com',
+      role: 'EMPLOYEE',
+      invitedByUserId: 'dev-admin',
+      createdAt: new Date(now.getTime() - 2 * 60 * 60 * 1000),
+      expiresAt: new Date(now.getTime() + 70 * 60 * 60 * 1000),
+      usedAt: null,
+    })
+  }
+
+  async inviteUser(input: InviteUserInput, invitedByUserId: string): Promise<void> {
+    const normalizedEmail = input.email.trim().toLowerCase()
+    const exists = Array.from(this.records.values()).some(
+      (record) => record.email.trim().toLowerCase() === normalizedEmail,
+    )
+
+    if (exists) {
+      throw new EmailAlreadyExistsError()
+    }
+
+    this.tokenSequence += 1
+    const createdAt = new Date()
+    const token = `invite-${String(this.tokenSequence).padStart(4, '0')}`
+
+    this.records.set(token, {
+      token,
+      email: input.email,
+      role: input.role,
+      invitedByUserId,
+      createdAt,
+      expiresAt: new Date(createdAt.getTime() + 72 * 60 * 60 * 1000),
+      usedAt: null,
+    })
+  }
+
+  async acceptInvitation(token: string, password: string, now = new Date()): Promise<void> {
+    const record = this.records.get(token)
+    if (!record) {
+      throw new InvitationNotFoundError(token)
+    }
+    if (record.usedAt) {
+      throw new InvitationAlreadyUsedError()
+    }
+    if (now > record.expiresAt) {
+      throw new InvitationExpiredError()
+    }
+
+    assertPasswordStrong(password)
+    record.usedAt = new Date(now)
+  }
+}
+
+let devInvitationService: InvitationService | null = null
+
+export function getDevInvitationService(): InvitationService {
+  if (!devInvitationService) {
+    devInvitationService = new DevInvitationService()
+  }
+  return devInvitationService
+}

--- a/src/lib/auth/invitation-service-di.ts
+++ b/src/lib/auth/invitation-service-di.ts
@@ -1,28 +1,30 @@
-/**
- * Task 6.5: InvitationService のシングルトン DI モジュール。
- * auth-service-di.ts と同パターン。
- */
 import type { InvitationService } from './invitation-service'
+import { getDevInvitationService } from './invitation-dev-service'
 
-let _invitationService: InvitationService | null = null
+let invitationService: InvitationService | null = null
 
 export function setInvitationServiceForTesting(svc: InvitationService): void {
-  _invitationService = svc
+  invitationService = svc
 }
 
 export function clearInvitationServiceForTesting(): void {
-  _invitationService = null
-}
-
-export function getInvitationService(): InvitationService {
-  if (_invitationService) return _invitationService
-  throw new Error(
-    'InvitationService is not initialized. ' +
-      'テストでは setInvitationServiceForTesting() を呼んでください。' +
-      'プロダクションではサーバー起動前に initInvitationService() を呼んでください。',
-  )
+  invitationService = null
 }
 
 export function initInvitationService(svc: InvitationService): void {
-  _invitationService = svc
+  invitationService = svc
+}
+
+export function getInvitationService(): InvitationService {
+  if (invitationService) {
+    return invitationService
+  }
+  if (process.env.NODE_ENV === 'development') {
+    return getDevInvitationService()
+  }
+  throw new Error(
+    'InvitationService is not initialized. ' +
+      'テストでは setInvitationServiceForTesting() を呼んでください。' +
+      'プロダクションでは initInvitationService() を呼んでください。',
+  )
 }

--- a/src/lib/notification/notification-dev-service.ts
+++ b/src/lib/notification/notification-dev-service.ts
@@ -1,0 +1,58 @@
+import { createNotificationService, type NotificationService } from './notification-service'
+import {
+  createInMemoryNotificationRepository,
+  createInMemoryPreferenceRepository,
+} from './notification-repository'
+
+const now = Date.now()
+
+const devService = createNotificationService({
+  notifications: createInMemoryNotificationRepository([
+    {
+      id: 'notif-1',
+      userId: 'dev-admin',
+      category: 'SYSTEM',
+      title: '開発環境の通知センターを有効化しました',
+      body: 'Issue #173 のUI検証用に、アプリ内通知のダミーデータを表示しています。',
+      payload: { route: '/notifications' },
+      readAt: null,
+      createdAt: new Date(now - 15 * 60 * 1000),
+    },
+    {
+      id: 'notif-2',
+      userId: 'dev-admin',
+      category: 'GOAL_APPROVAL_REQUEST',
+      title: '目標承認待ちが 3 件あります',
+      body: '部下の目標申請を確認し、承認または差し戻しを実施してください。',
+      payload: { count: 3 },
+      readAt: null,
+      createdAt: new Date(now - 3 * 60 * 60 * 1000),
+    },
+    {
+      id: 'notif-3',
+      userId: 'dev-admin',
+      category: 'DEADLINE_ALERT',
+      title: '評価締切が近づいています',
+      body: '今週金曜 18:00 までに未完了の評価フォームを確認してください。',
+      payload: { deadline: '2026-04-24T18:00:00+09:00' },
+      readAt: new Date(now - 60 * 60 * 1000),
+      createdAt: new Date(now - 20 * 60 * 60 * 1000),
+    },
+  ]),
+  preferences: createInMemoryPreferenceRepository(
+    new Map([
+      [
+        'dev-admin',
+        [
+          { category: 'SYSTEM', emailEnabled: true },
+          { category: 'GOAL_APPROVAL_REQUEST', emailEnabled: true },
+          { category: 'DEADLINE_ALERT', emailEnabled: false },
+        ],
+      ],
+    ]),
+  ),
+})
+
+export function getDevNotificationService(): NotificationService {
+  return devService
+}

--- a/src/lib/notification/notification-service-di.ts
+++ b/src/lib/notification/notification-service-di.ts
@@ -1,0 +1,30 @@
+import type { NotificationService } from './notification-service'
+import { getDevNotificationService } from './notification-dev-service'
+
+let service: NotificationService | null = null
+
+export function setNotificationServiceForTesting(svc: NotificationService): void {
+  service = svc
+}
+
+export function clearNotificationServiceForTesting(): void {
+  service = null
+}
+
+export function initNotificationService(svc: NotificationService): void {
+  service = svc
+}
+
+export function getNotificationService(): NotificationService {
+  if (service) {
+    return service
+  }
+  if (process.env.NODE_ENV === 'development') {
+    return getDevNotificationService()
+  }
+  throw new Error(
+    'NotificationService is not initialized. ' +
+      'テストでは setNotificationServiceForTesting() を呼んでください。' +
+      'プロダクションでは initNotificationService() を呼んでください。',
+  )
+}

--- a/src/tests/ai-monitoring/ai-dashboard-route.test.ts
+++ b/src/tests/ai-monitoring/ai-dashboard-route.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  clearAIDashboardServiceForTesting,
+  setAIDashboardServiceForTesting,
+} from '@/lib/ai-monitoring/ai-dashboard-service-di'
+import type { AIDashboardService } from '@/lib/ai-monitoring/ai-dashboard-service'
+import { AIDashboardForbiddenError } from '@/lib/ai-monitoring/ai-dashboard-service'
+
+vi.mock('next-auth', () => ({
+  getServerSession: vi.fn(),
+}))
+
+const { getServerSession } = await import('next-auth')
+const mockedGetServerSession = vi.mocked(getServerSession)
+
+const { GET } = await import('@/app/api/ai-monitoring/dashboard/route')
+
+function makeSession(role: string) {
+  return {
+    user: { email: 'admin@example.com' },
+    userId: 'dev-admin',
+    role,
+  }
+}
+
+function makeService(): AIDashboardService {
+  return {
+    getSnapshot: vi.fn().mockResolvedValue({
+      range: {
+        from: new Date('2026-04-01T00:00:00.000Z'),
+        to: new Date('2026-04-21T00:00:00.000Z'),
+        granularity: 'DAY',
+      },
+      costSeries: { granularity: 'DAY', points: [] },
+      topUsers: [],
+      failureRate: {
+        totalAttempts: 10,
+        failureCount: 1,
+        failureRate: 0.1,
+        byErrorCategory: { TIMEOUT: 1 },
+      },
+      providerComparison: {
+        period: {
+          from: new Date('2026-04-01T00:00:00.000Z'),
+          to: new Date('2026-04-21T00:00:00.000Z'),
+        },
+        rows: [],
+      },
+    }),
+    getProviderComparison: vi.fn(),
+    getFailureRate: vi.fn(),
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+afterEach(() => {
+  clearAIDashboardServiceForTesting()
+})
+
+describe('GET /api/ai-monitoring/dashboard', () => {
+  it('returns 401 without session', async () => {
+    mockedGetServerSession.mockResolvedValue(null)
+    const res = await GET(new Request('http://localhost/api/ai-monitoring/dashboard'))
+    expect(res.status).toBe(401)
+  })
+
+  it('returns dashboard data for admin', async () => {
+    mockedGetServerSession.mockResolvedValue(makeSession('ADMIN'))
+    const service = makeService()
+    setAIDashboardServiceForTesting(service)
+
+    const res = await GET(new Request('http://localhost/api/ai-monitoring/dashboard?range=30d'))
+    expect(res.status).toBe(200)
+    expect(service.getSnapshot).toHaveBeenCalledOnce()
+  })
+
+  it('returns 403 for forbidden role', async () => {
+    mockedGetServerSession.mockResolvedValue(makeSession('ADMIN'))
+    const service = makeService()
+    vi.mocked(service.getSnapshot).mockRejectedValue(new AIDashboardForbiddenError('EMPLOYEE'))
+    setAIDashboardServiceForTesting(service)
+
+    const res = await GET(new Request('http://localhost/api/ai-monitoring/dashboard'))
+    expect(res.status).toBe(403)
+  })
+})

--- a/src/tests/notification/notification-routes.test.ts
+++ b/src/tests/notification/notification-routes.test.ts
@@ -1,0 +1,141 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  clearNotificationServiceForTesting,
+  setNotificationServiceForTesting,
+} from '@/lib/notification/notification-service-di'
+import type { NotificationService } from '@/lib/notification/notification-service'
+import { NotificationNotFoundError } from '@/lib/notification/notification-service'
+import { NextRequest } from 'next/server'
+
+vi.mock('next-auth', () => ({
+  getServerSession: vi.fn(),
+}))
+
+const { getServerSession } = await import('next-auth')
+const mockedGetServerSession = vi.mocked(getServerSession)
+
+const notificationsRoute = await import('@/app/api/notifications/route')
+const notificationItemRoute = await import('@/app/api/notifications/[notificationId]/route')
+
+function makeSession() {
+  return {
+    user: { email: 'admin@example.com' },
+    userId: 'dev-admin',
+    role: 'ADMIN',
+  }
+}
+
+function makeService(): NotificationService {
+  return {
+    listForUser: vi.fn().mockResolvedValue({
+      notifications: [
+        {
+          id: 'notif-1',
+          userId: 'dev-admin',
+          category: 'SYSTEM',
+          title: 'Title',
+          body: 'Body',
+          payload: null,
+          readAt: null,
+          createdAt: new Date('2026-04-21T00:00:00.000Z'),
+        },
+      ],
+      unreadCount: 1,
+    }),
+    markAsRead: vi.fn().mockResolvedValue({
+      id: 'notif-1',
+      userId: 'dev-admin',
+      category: 'SYSTEM',
+      title: 'Title',
+      body: 'Body',
+      payload: null,
+      readAt: new Date('2026-04-21T01:00:00.000Z'),
+      createdAt: new Date('2026-04-21T00:00:00.000Z'),
+    }),
+    getPreferences: vi.fn().mockResolvedValue([{ category: 'SYSTEM', emailEnabled: true }]),
+    updatePreferences: vi.fn().mockResolvedValue(undefined),
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+afterEach(() => {
+  clearNotificationServiceForTesting()
+})
+
+describe('GET /api/notifications', () => {
+  it('returns 401 without session', async () => {
+    mockedGetServerSession.mockResolvedValue(null)
+    const res = await notificationsRoute.GET()
+    expect(res.status).toBe(401)
+  })
+
+  it('returns notifications and preferences', async () => {
+    mockedGetServerSession.mockResolvedValue(makeSession())
+    const service = makeService()
+    setNotificationServiceForTesting(service)
+
+    const res = await notificationsRoute.GET()
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.data.unreadCount).toBe(1)
+    expect(service.listForUser).toHaveBeenCalledWith('dev-admin')
+    expect(service.getPreferences).toHaveBeenCalledWith('dev-admin')
+  })
+})
+
+describe('PUT /api/notifications', () => {
+  it('updates preferences', async () => {
+    mockedGetServerSession.mockResolvedValue(makeSession())
+    const service = makeService()
+    setNotificationServiceForTesting(service)
+
+    const req = new NextRequest('http://localhost/api/notifications', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ preferences: [{ category: 'SYSTEM', emailEnabled: false }] }),
+    })
+
+    const res = await notificationsRoute.PUT(req)
+    expect(res.status).toBe(200)
+    expect(service.updatePreferences).toHaveBeenCalledWith('dev-admin', [
+      { category: 'SYSTEM', emailEnabled: false },
+    ])
+  })
+})
+
+describe('PATCH /api/notifications/[notificationId]', () => {
+  it('marks a notification as read', async () => {
+    mockedGetServerSession.mockResolvedValue(makeSession())
+    const service = makeService()
+    setNotificationServiceForTesting(service)
+
+    const res = await notificationItemRoute.PATCH(
+      new NextRequest('http://localhost/api/notifications/notif-1'),
+      {
+        params: Promise.resolve({ notificationId: 'notif-1' }),
+      },
+    )
+
+    expect(res.status).toBe(200)
+    expect(service.markAsRead).toHaveBeenCalledWith('dev-admin', 'notif-1')
+  })
+
+  it('returns 404 when missing', async () => {
+    mockedGetServerSession.mockResolvedValue(makeSession())
+    const service = makeService()
+    vi.mocked(service.markAsRead).mockRejectedValue(new NotificationNotFoundError('missing'))
+    setNotificationServiceForTesting(service)
+
+    const res = await notificationItemRoute.PATCH(
+      new NextRequest('http://localhost/api/notifications/missing'),
+      {
+        params: Promise.resolve({ notificationId: 'missing' }),
+      },
+    )
+
+    expect(res.status).toBe(404)
+  })
+})


### PR DESCRIPTION
## Summary
- add session management, invitation flow, notification center, and AI ops dashboard pages
- add notification and AI monitoring API routes with development fallbacks
- add route tests for notification and AI dashboard APIs

## Verification
- pnpm type-check
- pnpm test -- src/tests/notification/notification-routes.test.ts src/tests/ai-monitoring/ai-dashboard-route.test.ts src/tests/auth/sessions-route.test.ts

Closes #173