### PR TITLE
feat: ISSUE #174 社員ライフサイクル・プロフィール・社員検索の画面実装

### DIFF
--- a/src/app/api/profile/[userId]/route.ts
+++ b/src/app/api/profile/[userId]/route.ts
@@ -1,0 +1,60 @@
+/**
+ * Issue #174 / Req 14.6: 他ユーザーのプロフィール取得 API
+ *
+ * GET /api/profile/{userId}
+ * - 全ロール参照可能（表示内容はロール別に制御）
+ * - ADMIN / 自分自身: 全項目 (ProfileViewFull)
+ * - その他: 基本情報のみ (ProfileViewBasic)
+ * - 200: 成功
+ * - 401: 未認証
+ * - 404: 対象プロフィール不在
+ * - 503: サービス未初期化
+ */
+import { getAppSession } from '@/lib/auth/app-session'
+import { type NextRequest, NextResponse } from 'next/server'
+import { getProfileService } from '@/lib/lifecycle/profile-service-di'
+import { ProfileNotFoundError } from '@/lib/lifecycle/profile-types'
+
+function getAuthorizedUserId(
+  serverSession: Awaited<ReturnType<typeof getAppSession>>,
+): { ok: true; userId: string } | { ok: false; response: NextResponse } {
+  if (!serverSession?.user?.email) {
+    return { ok: false, response: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
+  }
+  const sess = serverSession as Record<string, unknown>
+  const userId = typeof sess.userId === 'string' ? sess.userId : undefined
+  if (!userId) {
+    return { ok: false, response: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
+  }
+  return { ok: true, userId }
+}
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ userId: string }> },
+): Promise<NextResponse> {
+  const auth = getAuthorizedUserId(await getAppSession())
+  if (!auth.ok) return auth.response
+
+  const { userId: targetUserId } = await params
+  if (!targetUserId) {
+    return NextResponse.json({ error: 'userId is required' }, { status: 400 })
+  }
+
+  let svc: ReturnType<typeof getProfileService>
+  try {
+    svc = getProfileService()
+  } catch {
+    return NextResponse.json({ error: 'Profile service not initialized' }, { status: 503 })
+  }
+
+  try {
+    const profile = await svc.getProfile(auth.userId, targetUserId)
+    return NextResponse.json({ success: true, data: profile })
+  } catch (err) {
+    if (err instanceof ProfileNotFoundError) {
+      return NextResponse.json({ error: 'Profile not found' }, { status: 404 })
+    }
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/api/profile/me/route.ts
+++ b/src/app/api/profile/me/route.ts
@@ -1,0 +1,85 @@
+/**
+ * Issue #174 / Req 14.5, 14.6: 自分のプロフィール取得・更新 API
+ *
+ * GET  /api/profile/me — 自分のプロフィールを全項目で取得
+ * PATCH /api/profile/me — 自分のプロフィールを更新
+ *   - body: ProfileInput (firstName / lastName / phoneNumber / selfIntro / avatarUrl 等)
+ *   - 200: 成功
+ *   - 422: バリデーションエラー
+ *   - 401: 未認証
+ *   - 503: サービス未初期化
+ */
+import { getAppSession } from '@/lib/auth/app-session'
+import { type NextRequest, NextResponse } from 'next/server'
+import { getProfileService } from '@/lib/lifecycle/profile-service-di'
+import { profileInputSchema, ProfileNotFoundError } from '@/lib/lifecycle/profile-types'
+
+function getAuthorizedUserId(
+  serverSession: Awaited<ReturnType<typeof getAppSession>>,
+): { ok: true; userId: string } | { ok: false; response: NextResponse } {
+  if (!serverSession?.user?.email) {
+    return { ok: false, response: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
+  }
+  const sess = serverSession as Record<string, unknown>
+  const userId = typeof sess.userId === 'string' ? sess.userId : undefined
+  if (!userId) {
+    return { ok: false, response: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
+  }
+  return { ok: true, userId }
+}
+
+export async function GET(): Promise<NextResponse> {
+  const auth = getAuthorizedUserId(await getAppSession())
+  if (!auth.ok) return auth.response
+
+  let svc: ReturnType<typeof getProfileService>
+  try {
+    svc = getProfileService()
+  } catch {
+    return NextResponse.json({ error: 'Profile service not initialized' }, { status: 503 })
+  }
+
+  try {
+    const profile = await svc.getProfile(auth.userId, auth.userId)
+    return NextResponse.json({ success: true, data: profile })
+  } catch (err) {
+    if (err instanceof ProfileNotFoundError) {
+      return NextResponse.json({ error: 'Profile not found' }, { status: 404 })
+    }
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}
+
+export async function PATCH(request: NextRequest): Promise<NextResponse> {
+  const auth = getAuthorizedUserId(await getAppSession())
+  if (!auth.ok) return auth.response
+
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
+  }
+
+  const parsed = profileInputSchema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.flatten() }, { status: 422 })
+  }
+
+  let svc: ReturnType<typeof getProfileService>
+  try {
+    svc = getProfileService()
+  } catch {
+    return NextResponse.json({ error: 'Profile service not initialized' }, { status: 503 })
+  }
+
+  try {
+    await svc.editProfile(auth.userId, parsed.data)
+    return NextResponse.json({ success: true })
+  } catch (err) {
+    if (err instanceof ProfileNotFoundError) {
+      return NextResponse.json({ error: 'Profile not found' }, { status: 404 })
+    }
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/api/search/employees/route.ts
+++ b/src/app/api/search/employees/route.ts
@@ -1,0 +1,73 @@
+/**
+ * Issue #174 / Req 16.1, 16.3, 16.4, 16.5, 16.6: 社員検索 API
+ *
+ * GET /api/search/employees?keyword=...&departmentIds[]=...&statuses[]=...&limit=...
+ * - 全ロール参照可能
+ * - デフォルトで ACTIVE 社員のみ返却（退職・休職は除外）
+ * - 200: { success: true, data: EmployeeSearchResult[], meta: { total } }
+ * - 401: 未認証
+ * - 422: バリデーションエラー
+ * - 503: サービス未初期化
+ */
+import { getAppSession } from '@/lib/auth/app-session'
+import { type NextRequest, NextResponse } from 'next/server'
+import { getSearchService } from '@/lib/search/search-service-di'
+import { employeeSearchQuerySchema, EMPLOYEE_STATUSES } from '@/lib/search/search-types'
+import type { EmployeeStatus } from '@/lib/search/search-types'
+
+function getAuthorizedUserId(
+  serverSession: Awaited<ReturnType<typeof getAppSession>>,
+): { ok: true; userId: string } | { ok: false; response: NextResponse } {
+  if (!serverSession?.user?.email) {
+    return { ok: false, response: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
+  }
+  const sess = serverSession as Record<string, unknown>
+  const userId = typeof sess.userId === 'string' ? sess.userId : undefined
+  if (!userId) {
+    return { ok: false, response: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
+  }
+  return { ok: true, userId }
+}
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const auth = getAuthorizedUserId(await getAppSession())
+  if (!auth.ok) return auth.response
+
+  const { searchParams } = request.nextUrl
+  const keyword = searchParams.get('keyword') ?? ''
+  const departmentIds = searchParams.getAll('departmentIds[]')
+  const rawStatuses = searchParams.getAll('statuses[]')
+  const limit = searchParams.get('limit') ? Number(searchParams.get('limit')) : undefined
+
+  const validStatuses = rawStatuses.filter((s): s is EmployeeStatus =>
+    (EMPLOYEE_STATUSES as readonly string[]).includes(s),
+  )
+
+  const queryResult = employeeSearchQuerySchema.safeParse({
+    keyword,
+    departmentIds: departmentIds.length > 0 ? departmentIds : undefined,
+    statuses: validStatuses.length > 0 ? validStatuses : undefined,
+    limit,
+  })
+
+  if (!queryResult.success) {
+    return NextResponse.json({ error: queryResult.error.flatten() }, { status: 422 })
+  }
+
+  let svc: ReturnType<typeof getSearchService>
+  try {
+    svc = getSearchService()
+  } catch {
+    return NextResponse.json({ error: 'Search service not initialized' }, { status: 503 })
+  }
+
+  const result = await svc.queryEmployees(queryResult.data, auth.userId)
+  if (result.isErr()) {
+    return NextResponse.json({ error: 'Rate limit exceeded' }, { status: 429 })
+  }
+  return NextResponse.json({
+    success: true,
+    data: result.value,
+    meta: { total: result.value.length },
+  })
+}

--- a/src/app/employees/import/page.tsx
+++ b/src/app/employees/import/page.tsx
@@ -1,0 +1,214 @@
+/**
+ * Issue #174 / Task 9.1 / Req 14.1, 14.9: 社員データ一括インポート画面
+ *
+ * - HR_MANAGER / ADMIN のみアクセス可能
+ * - CSVファイルを選択して POST /api/lifecycle/employees/import に送信
+ * - アップロード結果（成功件数・エラー行）を表示
+ */
+'use client'
+
+import { useCallback, useRef, useState, type ReactElement } from 'react'
+
+interface ImportRow {
+  readonly row: number
+  readonly error: string
+}
+
+interface BulkImportResult {
+  readonly total: number
+  readonly succeeded: number
+  readonly failed: number
+  readonly errors: readonly ImportRow[]
+}
+
+interface ImportEnvelope {
+  readonly success?: boolean
+  readonly data?: BulkImportResult
+  readonly error?: string
+  readonly succeeded?: number
+  readonly failed?: number
+  readonly errors?: readonly ImportRow[]
+}
+
+type UploadState =
+  | { readonly kind: 'idle' }
+  | { readonly kind: 'uploading' }
+  | { readonly kind: 'success'; readonly result: BulkImportResult }
+  | { readonly kind: 'error'; readonly message: string }
+
+const IMPORT_URL = '/api/lifecycle/employees/import'
+const MAX_FILE_SIZE_MB = 5
+
+export default function EmployeeImportPage(): ReactElement {
+  const [uploadState, setUploadState] = useState<UploadState>({ kind: 'idle' })
+  const [selectedFile, setSelectedFile] = useState<File | null>(null)
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  const handleFileChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0] ?? null
+    setSelectedFile(file)
+    setUploadState({ kind: 'idle' })
+  }, [])
+
+  const handleUpload = useCallback(async () => {
+    if (!selectedFile) return
+    if (selectedFile.size > MAX_FILE_SIZE_MB * 1024 * 1024) {
+      setUploadState({
+        kind: 'error',
+        message: `ファイルサイズが ${MAX_FILE_SIZE_MB}MB を超えています`,
+      })
+      return
+    }
+
+    setUploadState({ kind: 'uploading' })
+    const form = new FormData()
+    form.append('file', selectedFile)
+
+    try {
+      const res = await fetch(IMPORT_URL, { method: 'POST', body: form })
+      const payload = (await res.json().catch(() => ({}))) as ImportEnvelope
+
+      if (!res.ok && res.status !== 207) {
+        throw new Error(payload.error ?? `HTTP ${res.status}`)
+      }
+
+      const result: BulkImportResult = payload.data ?? {
+        total: (payload.succeeded ?? 0) + (payload.failed ?? 0),
+        succeeded: payload.succeeded ?? 0,
+        failed: payload.failed ?? 0,
+        errors: payload.errors ?? [],
+      }
+      setUploadState({ kind: 'success', result })
+    } catch (err) {
+      setUploadState({ kind: 'error', message: readError(err) })
+    }
+  }, [selectedFile])
+
+  const handleReset = useCallback(() => {
+    setSelectedFile(null)
+    setUploadState({ kind: 'idle' })
+    if (fileInputRef.current) fileInputRef.current.value = ''
+  }, [])
+
+  return (
+    <main className="mx-auto max-w-3xl px-6 py-10">
+      <header className="mb-8">
+        <p className="text-xs font-semibold tracking-widest text-indigo-600 uppercase">Employees</p>
+        <h1 className="mt-1 text-3xl font-bold text-slate-900">社員一括インポート</h1>
+        <p className="mt-2 text-sm text-slate-600">
+          CSVファイルから社員データを一括登録します。最大 {MAX_FILE_SIZE_MB}MB まで。
+        </p>
+      </header>
+
+      <section className="space-y-6">
+        <CsvFormatGuide />
+
+        <div className="space-y-4 rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+          <h2 className="text-sm font-semibold text-slate-800">CSVファイルを選択</h2>
+
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept=".csv"
+            onChange={handleFileChange}
+            className="block w-full text-sm text-slate-700 file:mr-4 file:rounded-md file:border-0 file:bg-indigo-50 file:px-4 file:py-2 file:text-sm file:font-semibold file:text-indigo-700 hover:file:bg-indigo-100"
+          />
+
+          {selectedFile !== null && (
+            <p className="text-xs text-slate-500">
+              選択中: <span className="font-medium text-slate-700">{selectedFile.name}</span> (
+              {(selectedFile.size / 1024).toFixed(1)} KB)
+            </p>
+          )}
+
+          <div className="flex gap-3">
+            <button
+              type="button"
+              onClick={handleUpload}
+              disabled={selectedFile === null || uploadState.kind === 'uploading'}
+              className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-indigo-700 disabled:cursor-not-allowed disabled:bg-slate-300"
+            >
+              {uploadState.kind === 'uploading' ? 'インポート中…' : 'インポート実行'}
+            </button>
+            <button
+              type="button"
+              onClick={handleReset}
+              disabled={uploadState.kind === 'uploading'}
+              className="rounded-md border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              リセット
+            </button>
+          </div>
+        </div>
+
+        <UploadResult state={uploadState} />
+      </section>
+    </main>
+  )
+}
+
+function CsvFormatGuide(): ReactElement {
+  return (
+    <div className="rounded-lg border border-indigo-200 bg-indigo-50 p-4 text-xs text-indigo-800">
+      <p className="mb-1 font-semibold">CSVフォーマット（1行目はヘッダー）</p>
+      <p className="rounded bg-white/60 px-2 py-1 font-mono">
+        email,firstName,lastName,hireDate,departmentId,positionId,role
+      </p>
+      <p className="mt-2 text-indigo-600">
+        ※ hireDate は YYYY-MM-DD 形式。role は EMPLOYEE / MANAGER / HR_MANAGER / ADMIN のいずれか。
+      </p>
+    </div>
+  )
+}
+
+interface UploadResultProps {
+  readonly state: UploadState
+}
+
+function UploadResult({ state }: UploadResultProps): ReactElement | null {
+  if (state.kind === 'idle' || state.kind === 'uploading') return null
+
+  if (state.kind === 'error') {
+    return (
+      <div className="rounded-lg border border-rose-300 bg-rose-50 p-4 text-sm text-rose-800">
+        <p className="font-semibold">インポートに失敗しました</p>
+        <p className="mt-1 text-xs">{state.message}</p>
+      </div>
+    )
+  }
+
+  const { result } = state
+  const allSuccess = result.failed === 0
+
+  return (
+    <div
+      className={`rounded-lg border p-4 text-sm ${
+        allSuccess
+          ? 'border-emerald-300 bg-emerald-50 text-emerald-800'
+          : 'border-amber-300 bg-amber-50 text-amber-800'
+      }`}
+    >
+      <p className="font-semibold">
+        {allSuccess ? 'インポート完了' : 'インポート完了（一部エラーあり）'}
+      </p>
+      <p className="mt-1 text-xs">
+        総件数: {result.total} / 成功: {result.succeeded} / 失敗: {result.failed}
+      </p>
+      {result.errors.length > 0 && (
+        <ul className="mt-3 space-y-1 border-t border-current/20 pt-3 text-xs">
+          {result.errors.map((e) => (
+            <li key={e.row} className="flex gap-2">
+              <span className="shrink-0 font-mono font-semibold">{e.row}行目:</span>
+              <span>{e.error}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}
+
+function readError(err: unknown): string {
+  if (err instanceof Error) return err.message
+  return '予期せぬエラーが発生しました'
+}

--- a/src/app/employees/page.tsx
+++ b/src/app/employees/page.tsx
@@ -1,0 +1,274 @@
+/**
+ * Issue #174 / Task 9.2 / Req 14.2, 14.3, 14.4: 社員ステータス管理画面
+ *
+ * - HR_MANAGER / ADMIN のみアクセス可能
+ * - 社員一覧を表示し、ステータス（在籍/休職/退職/入社予定）を変更できる
+ * - PATCH /api/lifecycle/employees/{id}/status でステータス更新
+ */
+'use client'
+
+import { useCallback, useEffect, useState, type ReactElement } from 'react'
+
+type EmployeeStatus = 'ACTIVE' | 'ON_LEAVE' | 'RESIGNED' | 'PENDING_JOIN'
+
+interface Employee {
+  readonly id: string
+  readonly email: string
+  readonly firstName: string
+  readonly lastName: string
+  readonly role: string
+  readonly hireDate: string
+  readonly status: EmployeeStatus
+  readonly departmentId: string | null
+  readonly positionId: string | null
+}
+
+interface EmployeeListEnvelope {
+  readonly success?: boolean
+  readonly data?: readonly Employee[]
+  readonly error?: string
+}
+
+type LoadState =
+  | { readonly kind: 'loading' }
+  | { readonly kind: 'error'; readonly message: string }
+  | { readonly kind: 'ready'; readonly employees: readonly Employee[] }
+
+interface StatusUpdateState {
+  readonly [employeeId: string]: 'saving' | 'success' | 'error'
+}
+
+const EMPLOYEES_URL = '/api/lifecycle/employees'
+
+const STATUS_LABELS: Record<EmployeeStatus, string> = {
+  ACTIVE: '在籍',
+  ON_LEAVE: '休職',
+  RESIGNED: '退職',
+  PENDING_JOIN: '入社予定',
+}
+
+const STATUS_COLORS: Record<EmployeeStatus, string> = {
+  ACTIVE: 'bg-emerald-100 text-emerald-800',
+  ON_LEAVE: 'bg-amber-100 text-amber-800',
+  RESIGNED: 'bg-slate-100 text-slate-600',
+  PENDING_JOIN: 'bg-blue-100 text-blue-800',
+}
+
+export default function EmployeeStatusPage(): ReactElement {
+  const [loadState, setLoadState] = useState<LoadState>({ kind: 'loading' })
+  const [updateStates, setUpdateStates] = useState<StatusUpdateState>({})
+
+  useEffect(() => {
+    let cancelled = false
+    void (async () => {
+      try {
+        const res = await fetch(EMPLOYEES_URL, { cache: 'no-store' })
+        const payload = ((await res.json().catch(() => ({}))) ?? {}) as EmployeeListEnvelope
+        if (!res.ok) throw new Error(payload.error ?? `HTTP ${res.status}`)
+        if (!cancelled) setLoadState({ kind: 'ready', employees: payload.data ?? [] })
+      } catch (err) {
+        if (!cancelled) setLoadState({ kind: 'error', message: readError(err) })
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const handleStatusChange = useCallback(
+    async (employeeId: string, newStatus: EmployeeStatus, effectiveDate: string) => {
+      setUpdateStates((prev) => ({ ...prev, [employeeId]: 'saving' }))
+      try {
+        const res = await fetch(`${EMPLOYEES_URL}/${employeeId}/status`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ newStatus, effectiveDate }),
+        })
+        if (!res.ok) {
+          const body = (await res.json().catch(() => ({}))) as { error?: string }
+          throw new Error(body.error ?? `HTTP ${res.status}`)
+        }
+        setUpdateStates((prev) => ({ ...prev, [employeeId]: 'success' }))
+        setLoadState((prev) => {
+          if (prev.kind !== 'ready') return prev
+          return {
+            ...prev,
+            employees: prev.employees.map((e) =>
+              e.id === employeeId ? { ...e, status: newStatus } : e,
+            ),
+          }
+        })
+        setTimeout(() => {
+          setUpdateStates((prev) => {
+            const { [employeeId]: _, ...rest } = prev
+            void _
+            return rest
+          })
+        }, 2000)
+      } catch {
+        setUpdateStates((prev) => ({ ...prev, [employeeId]: 'error' }))
+        setTimeout(() => {
+          setUpdateStates((prev) => {
+            const { [employeeId]: _, ...rest } = prev
+            void _
+            return rest
+          })
+        }, 3000)
+      }
+    },
+    [],
+  )
+
+  return (
+    <main className="mx-auto max-w-6xl px-6 py-10">
+      <header className="mb-8">
+        <p className="text-xs font-semibold tracking-widest text-indigo-600 uppercase">Employees</p>
+        <h1 className="mt-1 text-3xl font-bold text-slate-900">社員ステータス管理</h1>
+        <p className="mt-2 text-sm text-slate-600">
+          社員の在籍状態を管理します。退職・休職処理は進行中の評価から自動除外されます。
+        </p>
+      </header>
+
+      <PageBody
+        loadState={loadState}
+        updateStates={updateStates}
+        onStatusChange={handleStatusChange}
+      />
+    </main>
+  )
+}
+
+interface PageBodyProps {
+  readonly loadState: LoadState
+  readonly updateStates: StatusUpdateState
+  readonly onStatusChange: (id: string, status: EmployeeStatus, effectiveDate: string) => void
+}
+
+function PageBody({ loadState, updateStates, onStatusChange }: PageBodyProps): ReactElement {
+  if (loadState.kind === 'loading') {
+    return (
+      <div className="flex items-center justify-center rounded-xl border border-slate-200 bg-white py-16 text-sm text-slate-500">
+        <span className="animate-pulse">社員データを読み込み中…</span>
+      </div>
+    )
+  }
+
+  if (loadState.kind === 'error') {
+    return (
+      <div className="rounded-xl border border-rose-300 bg-rose-50 p-6 text-sm text-rose-800">
+        <p className="font-semibold">データの取得に失敗しました</p>
+        <p className="mt-1 text-xs">{loadState.message}</p>
+      </div>
+    )
+  }
+
+  if (loadState.employees.length === 0) {
+    return (
+      <div className="rounded-xl border border-slate-200 bg-white py-16 text-center text-sm text-slate-500">
+        社員が登録されていません
+      </div>
+    )
+  }
+
+  return (
+    <div className="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
+      <table className="w-full text-sm">
+        <thead className="border-b border-slate-200 bg-slate-50">
+          <tr>
+            <th className="px-4 py-3 text-left font-semibold text-slate-700">氏名</th>
+            <th className="px-4 py-3 text-left font-semibold text-slate-700">メール</th>
+            <th className="px-4 py-3 text-left font-semibold text-slate-700">入社日</th>
+            <th className="px-4 py-3 text-left font-semibold text-slate-700">現在のステータス</th>
+            <th className="px-4 py-3 text-left font-semibold text-slate-700">ステータス変更</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-slate-100">
+          {loadState.employees.map((employee) => (
+            <EmployeeRow
+              key={employee.id}
+              employee={employee}
+              updateState={updateStates[employee.id]}
+              onStatusChange={onStatusChange}
+            />
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+interface EmployeeRowProps {
+  readonly employee: Employee
+  readonly updateState: 'saving' | 'success' | 'error' | undefined
+  readonly onStatusChange: (id: string, status: EmployeeStatus, effectiveDate: string) => void
+}
+
+function EmployeeRow({ employee, updateState, onStatusChange }: EmployeeRowProps): ReactElement {
+  const [selectedStatus, setSelectedStatus] = useState<EmployeeStatus>(employee.status)
+  const [effectiveDate, setEffectiveDate] = useState<string>(new Date().toISOString().slice(0, 10))
+
+  const changed = selectedStatus !== employee.status
+
+  return (
+    <tr className="transition-colors hover:bg-slate-50">
+      <td className="px-4 py-3 font-medium text-slate-900">
+        {employee.lastName} {employee.firstName}
+      </td>
+      <td className="px-4 py-3 text-slate-600">{employee.email}</td>
+      <td className="px-4 py-3 text-slate-600">{employee.hireDate}</td>
+      <td className="px-4 py-3">
+        <span
+          className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${STATUS_COLORS[employee.status]}`}
+        >
+          {STATUS_LABELS[employee.status]}
+        </span>
+      </td>
+      <td className="px-4 py-3">
+        <div className="flex flex-wrap items-center gap-2">
+          <select
+            value={selectedStatus}
+            onChange={(e) => setSelectedStatus(e.target.value as EmployeeStatus)}
+            className="rounded-md border border-slate-300 bg-white px-2 py-1.5 text-xs focus:border-indigo-500 focus:outline-none"
+          >
+            {(Object.keys(STATUS_LABELS) as EmployeeStatus[]).map((s) => (
+              <option key={s} value={s}>
+                {STATUS_LABELS[s]}
+              </option>
+            ))}
+          </select>
+
+          {changed && (
+            <>
+              <input
+                type="date"
+                value={effectiveDate}
+                onChange={(e) => setEffectiveDate(e.target.value)}
+                className="rounded-md border border-slate-300 bg-white px-2 py-1.5 text-xs focus:border-indigo-500 focus:outline-none"
+              />
+              <button
+                type="button"
+                onClick={() => onStatusChange(employee.id, selectedStatus, effectiveDate)}
+                disabled={updateState === 'saving'}
+                className="rounded-md bg-indigo-600 px-3 py-1.5 text-xs font-semibold text-white hover:bg-indigo-700 disabled:cursor-not-allowed disabled:bg-slate-300"
+              >
+                {updateState === 'saving' ? '更新中…' : '更新'}
+              </button>
+            </>
+          )}
+
+          {updateState === 'success' && (
+            <span className="text-xs font-medium text-emerald-600">✓ 更新しました</span>
+          )}
+          {updateState === 'error' && (
+            <span className="text-xs font-medium text-rose-600">更新に失敗しました</span>
+          )}
+        </div>
+      </td>
+    </tr>
+  )
+}
+
+function readError(err: unknown): string {
+  if (err instanceof Error) return err.message
+  return '予期せぬエラーが発生しました'
+}

--- a/src/app/employees/search/page.tsx
+++ b/src/app/employees/search/page.tsx
@@ -1,0 +1,213 @@
+/**
+ * Issue #174 / Task 10.2 / Req 16.1, 16.3, 16.4, 16.5, 16.6: 社員検索画面
+ *
+ * - 全ロールアクセス可能
+ * - GET /api/search/employees?keyword=...&statuses[]=... で検索
+ * - デフォルト: ACTIVE のみ（チェックボックスで非アクティブを含められる）
+ * - 結果テーブル: 氏名 / 部署 / 役職 / ステータス
+ */
+'use client'
+
+import { useCallback, useState, type FormEvent, type ReactElement, type ReactNode } from 'react'
+
+interface EmployeeSearchResult {
+  readonly id: string
+  readonly firstName: string
+  readonly lastName: string
+  readonly departmentName: string
+  readonly roleName: string
+  readonly status: 'ACTIVE' | 'ON_LEAVE' | 'RESIGNED' | 'PENDING_JOIN'
+}
+
+interface SearchEnvelope {
+  readonly success?: boolean
+  readonly data?: readonly EmployeeSearchResult[]
+  readonly error?: string
+}
+
+type SearchState =
+  | { readonly kind: 'idle' }
+  | { readonly kind: 'searching' }
+  | { readonly kind: 'results'; readonly employees: readonly EmployeeSearchResult[] }
+  | { readonly kind: 'error'; readonly message: string }
+
+const STATUS_LABELS: Record<string, string> = {
+  ACTIVE: '在籍',
+  ON_LEAVE: '休職',
+  RESIGNED: '退職',
+  PENDING_JOIN: '入社予定',
+}
+
+const STATUS_COLORS: Record<string, string> = {
+  ACTIVE: 'bg-emerald-100 text-emerald-800',
+  ON_LEAVE: 'bg-amber-100 text-amber-800',
+  RESIGNED: 'bg-slate-100 text-slate-600',
+  PENDING_JOIN: 'bg-blue-100 text-blue-800',
+}
+
+const ALL_STATUSES = ['ACTIVE', 'ON_LEAVE', 'RESIGNED', 'PENDING_JOIN'] as const
+
+const SEARCH_URL = '/api/search/employees'
+
+export default function EmployeeSearchPage(): ReactElement {
+  const [keyword, setKeyword] = useState('')
+  const [includeInactive, setIncludeInactive] = useState(false)
+  const [searchState, setSearchState] = useState<SearchState>({ kind: 'idle' })
+
+  const handleSubmit = useCallback(
+    async (e: FormEvent) => {
+      e.preventDefault()
+      const trimmed = keyword.trim()
+      if (!trimmed) return
+
+      setSearchState({ kind: 'searching' })
+
+      const params = new URLSearchParams({ keyword: trimmed })
+      const statuses = includeInactive ? ALL_STATUSES : (['ACTIVE'] as const)
+      statuses.forEach((s) => params.append('statuses[]', s))
+
+      try {
+        const res = await fetch(`${SEARCH_URL}?${params.toString()}`, { cache: 'no-store' })
+        const payload = (await res.json().catch(() => ({}))) as SearchEnvelope
+        if (!res.ok) throw new Error(payload.error ?? `HTTP ${res.status}`)
+        setSearchState({ kind: 'results', employees: payload.data ?? [] })
+      } catch (err) {
+        setSearchState({ kind: 'error', message: readError(err) })
+      }
+    },
+    [keyword, includeInactive],
+  )
+
+  return (
+    <main className="mx-auto max-w-5xl px-6 py-10">
+      <header className="mb-8">
+        <p className="text-xs font-semibold tracking-widest text-indigo-600 uppercase">Employees</p>
+        <h1 className="mt-1 text-3xl font-bold text-slate-900">社員検索</h1>
+        <p className="mt-2 text-sm text-slate-600">
+          氏名・部署・役職などのキーワードで社員を検索できます。
+        </p>
+      </header>
+
+      <form
+        onSubmit={handleSubmit}
+        className="mb-6 space-y-4 rounded-xl border border-slate-200 bg-white p-6 shadow-sm"
+      >
+        <div className="flex gap-3">
+          <input
+            type="text"
+            value={keyword}
+            onChange={(e) => setKeyword(e.target.value)}
+            placeholder="氏名・部署・役職などを入力"
+            className="block flex-1 rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+          />
+          <button
+            type="submit"
+            disabled={!keyword.trim() || searchState.kind === 'searching'}
+            className="rounded-md bg-indigo-600 px-5 py-2 text-sm font-semibold text-white hover:bg-indigo-700 disabled:cursor-not-allowed disabled:bg-slate-300"
+          >
+            {searchState.kind === 'searching' ? '検索中…' : '検索'}
+          </button>
+        </div>
+
+        <label className="flex cursor-pointer items-center gap-2 text-sm text-slate-700">
+          <input
+            type="checkbox"
+            checked={includeInactive}
+            onChange={(e) => setIncludeInactive(e.target.checked)}
+            className="rounded border-slate-300 text-indigo-600 focus:ring-indigo-500"
+          />
+          休職・退職・入社予定の社員も含める
+        </label>
+      </form>
+
+      <SearchResults state={searchState} />
+    </main>
+  )
+}
+
+interface SearchResultsProps {
+  readonly state: SearchState
+}
+
+function SearchResults({ state }: SearchResultsProps): ReactElement {
+  if (state.kind === 'idle') {
+    return (
+      <div className="rounded-xl border border-slate-200 bg-white py-16 text-center text-sm text-slate-400">
+        キーワードを入力して検索してください
+      </div>
+    )
+  }
+
+  if (state.kind === 'searching') {
+    return (
+      <div className="flex items-center justify-center rounded-xl border border-slate-200 bg-white py-16 text-sm text-slate-500">
+        <span className="animate-pulse">検索中…</span>
+      </div>
+    )
+  }
+
+  if (state.kind === 'error') {
+    return (
+      <div className="rounded-xl border border-rose-300 bg-rose-50 p-6 text-sm text-rose-800">
+        <p className="font-semibold">検索に失敗しました</p>
+        <p className="mt-1 text-xs">{state.message}</p>
+      </div>
+    )
+  }
+
+  if (state.employees.length === 0) {
+    return (
+      <div className="rounded-xl border border-slate-200 bg-white py-16 text-center text-sm text-slate-500">
+        該当する社員が見つかりませんでした
+      </div>
+    )
+  }
+
+  return (
+    <div className="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
+      <div className="border-b border-slate-200 bg-slate-50 px-4 py-3">
+        <p className="text-xs font-medium text-slate-600">
+          検索結果: <span className="font-semibold text-slate-900">{state.employees.length}</span>{' '}
+          件
+        </p>
+      </div>
+      <table className="w-full text-sm">
+        <thead className="border-b border-slate-200">
+          <tr>
+            <Th>氏名</Th>
+            <Th>部署</Th>
+            <Th>役職</Th>
+            <Th>ステータス</Th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-slate-100">
+          {state.employees.map((emp) => (
+            <tr key={emp.id} className="transition-colors hover:bg-slate-50">
+              <td className="px-4 py-3 font-medium text-slate-900">
+                {emp.lastName} {emp.firstName}
+              </td>
+              <td className="px-4 py-3 text-slate-600">{emp.departmentName}</td>
+              <td className="px-4 py-3 text-slate-600">{emp.roleName}</td>
+              <td className="px-4 py-3">
+                <span
+                  className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${STATUS_COLORS[emp.status] ?? 'bg-slate-100 text-slate-600'}`}
+                >
+                  {STATUS_LABELS[emp.status] ?? emp.status}
+                </span>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+function Th({ children }: { readonly children: ReactNode }): ReactElement {
+  return <th className="px-4 py-3 text-left text-xs font-semibold text-slate-700">{children}</th>
+}
+
+function readError(err: unknown): string {
+  if (err instanceof Error) return err.message
+  return '予期せぬエラーが発生しました'
+}

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,0 +1,331 @@
+/**
+ * Issue #174 / Task 9.3 / Req 14.5, 14.6: プロフィール編集画面
+ *
+ * - 全ロールアクセス可能（自分のプロフィールのみ編集）
+ * - GET /api/profile/me でプロフィールを取得
+ * - PATCH /api/profile/me でプロフィールを更新
+ * - ADMIN または自分自身: 全項目表示・編集可
+ * - その他: 基本情報のみ表示
+ */
+'use client'
+
+import {
+  useCallback,
+  useEffect,
+  useState,
+  type FormEvent,
+  type ReactElement,
+  type ReactNode,
+} from 'react'
+
+interface ProfileViewFull {
+  readonly kind: 'full'
+  readonly userId: string
+  readonly firstName: string
+  readonly lastName: string
+  readonly firstNameKana: string | null
+  readonly lastNameKana: string | null
+  readonly employeeCode: string | null
+  readonly phoneNumber: string | null
+  readonly avatarUrl: string | null
+  readonly selfIntro: string | null
+  readonly email: string
+}
+
+interface ProfileViewBasic {
+  readonly kind: 'basic'
+  readonly userId: string
+  readonly firstName: string
+  readonly lastName: string
+  readonly avatarUrl: string | null
+  readonly selfIntro: string | null
+}
+
+type ProfileView = ProfileViewFull | ProfileViewBasic
+
+interface ProfileEnvelope {
+  readonly success?: boolean
+  readonly data?: ProfileView
+  readonly error?: string
+}
+
+type LoadState =
+  | { readonly kind: 'loading' }
+  | { readonly kind: 'error'; readonly message: string }
+  | { readonly kind: 'ready'; readonly profile: ProfileView }
+
+type SaveState =
+  | { readonly kind: 'idle' }
+  | { readonly kind: 'saving' }
+  | { readonly kind: 'success' }
+  | { readonly kind: 'error'; readonly message: string }
+
+const PROFILE_ME_URL = '/api/profile/me'
+
+export default function ProfilePage(): ReactElement {
+  const [loadState, setLoadState] = useState<LoadState>({ kind: 'loading' })
+  const [saveState, setSaveState] = useState<SaveState>({ kind: 'idle' })
+
+  useEffect(() => {
+    let cancelled = false
+    void (async () => {
+      try {
+        const res = await fetch(PROFILE_ME_URL, { cache: 'no-store' })
+        const payload = (await res.json().catch(() => ({}))) as ProfileEnvelope
+        if (!res.ok || !payload.data) {
+          throw new Error(payload.error ?? `HTTP ${res.status}`)
+        }
+        if (!cancelled) setLoadState({ kind: 'ready', profile: payload.data })
+      } catch (err) {
+        if (!cancelled) setLoadState({ kind: 'error', message: readError(err) })
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const handleSave = useCallback(async (input: Record<string, unknown>) => {
+    setSaveState({ kind: 'saving' })
+    try {
+      const res = await fetch(PROFILE_ME_URL, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(input),
+      })
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string }
+        throw new Error(body.error ?? `HTTP ${res.status}`)
+      }
+      setSaveState({ kind: 'success' })
+      setLoadState((prev) => {
+        if (prev.kind !== 'ready' || prev.profile.kind !== 'full') return prev
+        return { ...prev, profile: { ...prev.profile, ...input } as ProfileViewFull }
+      })
+      setTimeout(() => setSaveState({ kind: 'idle' }), 2000)
+    } catch (err) {
+      setSaveState({ kind: 'error', message: readError(err) })
+    }
+  }, [])
+
+  return (
+    <main className="mx-auto max-w-2xl px-6 py-10">
+      <header className="mb-8">
+        <p className="text-xs font-semibold tracking-widest text-indigo-600 uppercase">Profile</p>
+        <h1 className="mt-1 text-3xl font-bold text-slate-900">プロフィール編集</h1>
+        <p className="mt-2 text-sm text-slate-600">自分のプロフィール情報を確認・編集できます。</p>
+      </header>
+
+      <PageBody loadState={loadState} saveState={saveState} onSave={handleSave} />
+    </main>
+  )
+}
+
+interface PageBodyProps {
+  readonly loadState: LoadState
+  readonly saveState: SaveState
+  readonly onSave: (input: Record<string, unknown>) => void
+}
+
+function PageBody({ loadState, saveState, onSave }: PageBodyProps): ReactElement {
+  if (loadState.kind === 'loading') {
+    return (
+      <div className="flex items-center justify-center rounded-xl border border-slate-200 bg-white py-16 text-sm text-slate-500">
+        <span className="animate-pulse">プロフィールを読み込み中…</span>
+      </div>
+    )
+  }
+
+  if (loadState.kind === 'error') {
+    return (
+      <div className="rounded-xl border border-rose-300 bg-rose-50 p-6 text-sm text-rose-800">
+        <p className="font-semibold">プロフィールの取得に失敗しました</p>
+        <p className="mt-1 text-xs">{loadState.message}</p>
+      </div>
+    )
+  }
+
+  const { profile } = loadState
+
+  if (profile.kind === 'basic') {
+    return <BasicProfileView profile={profile} />
+  }
+
+  return <FullProfileForm profile={profile} saveState={saveState} onSave={onSave} />
+}
+
+interface BasicProfileViewProps {
+  readonly profile: ProfileViewBasic
+}
+
+function BasicProfileView({ profile }: BasicProfileViewProps): ReactElement {
+  return (
+    <div className="space-y-4 rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+      <div className="flex items-center gap-4">
+        <div className="flex h-16 w-16 items-center justify-center rounded-full bg-indigo-100 text-xl font-bold text-indigo-600">
+          {profile.lastName.slice(0, 1)}
+        </div>
+        <p className="text-lg font-semibold text-slate-900">
+          {profile.lastName} {profile.firstName}
+        </p>
+      </div>
+      {profile.selfIntro !== null && (
+        <p className="border-t border-slate-100 pt-4 text-sm text-slate-600">{profile.selfIntro}</p>
+      )}
+    </div>
+  )
+}
+
+interface FullProfileFormProps {
+  readonly profile: ProfileViewFull
+  readonly saveState: SaveState
+  readonly onSave: (input: Record<string, unknown>) => void
+}
+
+function FullProfileForm({ profile, saveState, onSave }: FullProfileFormProps): ReactElement {
+  const [lastName, setLastName] = useState(profile.lastName)
+  const [firstName, setFirstName] = useState(profile.firstName)
+  const [lastNameKana, setLastNameKana] = useState(profile.lastNameKana ?? '')
+  const [firstNameKana, setFirstNameKana] = useState(profile.firstNameKana ?? '')
+  const [phoneNumber, setPhoneNumber] = useState(profile.phoneNumber ?? '')
+  const [selfIntro, setSelfIntro] = useState(profile.selfIntro ?? '')
+
+  const handleSubmit = useCallback(
+    (e: FormEvent) => {
+      e.preventDefault()
+      onSave({
+        firstName: firstName.trim() || undefined,
+        lastName: lastName.trim() || undefined,
+        firstNameKana: firstNameKana.trim() || null,
+        lastNameKana: lastNameKana.trim() || null,
+        phoneNumber: phoneNumber.trim() || null,
+        selfIntro: selfIntro.trim() || null,
+      })
+    },
+    [firstName, lastName, firstNameKana, lastNameKana, phoneNumber, selfIntro, onSave],
+  )
+
+  const saving = saveState.kind === 'saving'
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="space-y-6 rounded-xl border border-slate-200 bg-white p-6 shadow-sm"
+    >
+      <div className="flex items-center gap-4 border-b border-slate-100 pb-4">
+        <div className="flex h-16 w-16 items-center justify-center rounded-full bg-indigo-100 text-xl font-bold text-indigo-600">
+          {profile.lastName.slice(0, 1)}
+        </div>
+        <div>
+          <p className="text-xs text-slate-500">{profile.email}</p>
+          {profile.employeeCode !== null && (
+            <p className="mt-0.5 text-xs text-slate-400">社員番号: {profile.employeeCode}</p>
+          )}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <Field label="姓" required>
+          <input
+            type="text"
+            value={lastName}
+            onChange={(e) => setLastName(e.target.value)}
+            required
+            className={inputCls}
+          />
+        </Field>
+        <Field label="名" required>
+          <input
+            type="text"
+            value={firstName}
+            onChange={(e) => setFirstName(e.target.value)}
+            required
+            className={inputCls}
+          />
+        </Field>
+        <Field label="姓（カナ）">
+          <input
+            type="text"
+            value={lastNameKana}
+            onChange={(e) => setLastNameKana(e.target.value)}
+            className={inputCls}
+          />
+        </Field>
+        <Field label="名（カナ）">
+          <input
+            type="text"
+            value={firstNameKana}
+            onChange={(e) => setFirstNameKana(e.target.value)}
+            className={inputCls}
+          />
+        </Field>
+      </div>
+
+      <Field label="電話番号">
+        <input
+          type="tel"
+          value={phoneNumber}
+          onChange={(e) => setPhoneNumber(e.target.value)}
+          placeholder="090-0000-0000"
+          className={inputCls}
+        />
+      </Field>
+
+      <Field label="自己紹介">
+        <textarea
+          value={selfIntro}
+          onChange={(e) => setSelfIntro(e.target.value)}
+          rows={4}
+          maxLength={500}
+          placeholder="500文字以内で入力してください"
+          className={`${inputCls} resize-none`}
+        />
+        <p className="mt-1 text-right text-xs text-slate-400">{selfIntro.length} / 500</p>
+      </Field>
+
+      <div className="flex items-center gap-3 border-t border-slate-100 pt-2">
+        <button
+          type="submit"
+          disabled={saving}
+          className="rounded-md bg-indigo-600 px-5 py-2 text-sm font-semibold text-white hover:bg-indigo-700 disabled:cursor-not-allowed disabled:bg-slate-300"
+        >
+          {saving ? '保存中…' : '保存する'}
+        </button>
+        {saveState.kind === 'success' && (
+          <span className="text-sm font-medium text-emerald-600">✓ 保存しました</span>
+        )}
+        {saveState.kind === 'error' && (
+          <span className="text-sm font-medium text-rose-600">
+            保存に失敗しました: {saveState.message}
+          </span>
+        )}
+      </div>
+    </form>
+  )
+}
+
+const inputCls =
+  'block w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500'
+
+interface FieldProps {
+  readonly label: string
+  readonly required?: boolean
+  readonly children: ReactNode
+}
+
+function Field({ label, required = false, children }: FieldProps): ReactElement {
+  return (
+    <div className="space-y-1">
+      <label className="block text-xs font-medium text-slate-700">
+        {label}
+        {required && <span className="ml-1 text-rose-500">*</span>}
+      </label>
+      {children}
+    </div>
+  )
+}
+
+function readError(err: unknown): string {
+  if (err instanceof Error) return err.message
+  return '予期せぬエラーが発生しました'
+}

--- a/src/lib/lifecycle/profile-service-di.ts
+++ b/src/lib/lifecycle/profile-service-di.ts
@@ -1,0 +1,28 @@
+/**
+ * Issue #174 / Req 14.5, 14.6: ProfileService のシングルトン DI モジュール。
+ * lifecycle-service-di.ts / search-service-di.ts と同一パターン。
+ */
+import type { ProfileService } from './profile-service'
+
+let _profileService: ProfileService | null = null
+
+export function setProfileServiceForTesting(svc: ProfileService): void {
+  _profileService = svc
+}
+
+export function clearProfileServiceForTesting(): void {
+  _profileService = null
+}
+
+export function getProfileService(): ProfileService {
+  if (_profileService) return _profileService
+  throw new Error(
+    'ProfileService is not initialized. ' +
+      'テストでは setProfileServiceForTesting() を呼んでください。' +
+      'プロダクションではサーバー起動前に initProfileService() を呼んでください。',
+  )
+}
+
+export function initProfileService(svc: ProfileService): void {
+  _profileService = svc
+}


### PR DESCRIPTION
## Summary

- **Task 9.1**: 社員データ一括インポート画面 (`/employees/import`) — CSV アップロード、5MB 上限、207 Multi-Status 対応
- **Task 9.2**: 社員ステータス管理画面 (`/employees`) — 一覧テーブル、行ごとのステータス変更・有効日付入力
- **Task 9.3**: プロフィール編集・閲覧画面 (`/profile`) — full/basic ロール別表示、自己紹介 500 文字カウンター
- **Task 10.2**: 社員検索画面 (`/employees/search`) — キーワード検索、非アクティブ含めるチェックボックス、結果テーブル

## Backend changes

- `src/lib/lifecycle/profile-service-di.ts`: ProfileService 用 DI モジュール（既存 lifecycle-service-di.ts パターンに準拠）
- `src/app/api/profile/me/route.ts`: GET/PATCH `/api/profile/me`
- `src/app/api/profile/[userId]/route.ts`: GET `/api/profile/{userId}`
- `src/app/api/search/employees/route.ts`: GET `/api/search/employees`（`queryEmployees` + `Result` 型対応）

## Test plan

- [ ] `/employees/import` — CSV ファイル選択→インポート実行→成功/エラー行表示
- [ ] `/employees` — 社員一覧表示→ステータス変更→更新ボタン→成功フィードバック
- [ ] `/profile` — プロフィール取得→編集→保存→成功メッセージ
- [ ] `/employees/search` — キーワード入力→検索→結果テーブル表示、0件表示、非アクティブ含めるチェック
- [ ] 未認証アクセス → 401 レスポンス確認

Closes #174