### PR TITLE
feat: ISSUE #175 スキル登録・承認・ポスト候補者画面の実装

### DIFF
--- a/src/app/api/skills/catalog/route.ts
+++ b/src/app/api/skills/catalog/route.ts
@@ -1,0 +1,30 @@
+/**
+ * Issue #175 / Task 11.2 / Req 4.4: スキルカタログ取得 API
+ *
+ * GET /api/skills/catalog
+ * - 全ロール（認証済み）で参照可能
+ * - 非推奨スキルを除外した SkillMaster 一覧を返す
+ * - スキル登録フォームのドロップダウン用途
+ */
+import { type NextRequest, NextResponse } from 'next/server'
+import { requireAuthenticated } from '@/lib/skill/skill-route-helpers'
+import { getMasterService } from '@/lib/master/master-service-di'
+
+export async function GET(_request: NextRequest): Promise<NextResponse> {
+  const guard = await requireAuthenticated()
+  if (!guard.ok) return guard.response
+
+  let svc: ReturnType<typeof getMasterService>
+  try {
+    svc = getMasterService()
+  } catch {
+    return NextResponse.json({ error: 'Master service not initialized' }, { status: 503 })
+  }
+
+  try {
+    const skills = await svc.listSkills(false) // 非推奨を除外
+    return NextResponse.json({ success: true, data: skills })
+  } catch {
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/api/skills/post-candidates/gap-ranking/route.ts
+++ b/src/app/api/skills/post-candidates/gap-ranking/route.ts
@@ -1,0 +1,39 @@
+/**
+ * Issue #175 / Task 11.4 / Req 4.8: スキルギャップランキング API
+ *
+ * GET /api/skills/post-candidates/gap-ranking
+ * - HR_MANAGER / ADMIN のみ
+ * - 組織目標に対するスキルギャップ上位一覧を返す
+ */
+import { type NextRequest, NextResponse } from 'next/server'
+import { requireAuthenticated } from '@/lib/skill/skill-route-helpers'
+import { getPostCandidateService } from '@/lib/skill/post-candidate-service-di'
+
+const HR_MANAGER_ROLES = ['HR_MANAGER', 'ADMIN'] as const
+
+function isHrManagerOrAbove(role: string): boolean {
+  return (HR_MANAGER_ROLES as readonly string[]).includes(role)
+}
+
+export async function GET(_request: NextRequest): Promise<NextResponse> {
+  const guard = await requireAuthenticated()
+  if (!guard.ok) return guard.response
+
+  if (!isHrManagerOrAbove(guard.session.role)) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  let svc: ReturnType<typeof getPostCandidateService>
+  try {
+    svc = getPostCandidateService()
+  } catch {
+    return NextResponse.json({ error: 'Post candidate service not initialized' }, { status: 503 })
+  }
+
+  try {
+    const data = await svc.getSkillGapRanking()
+    return NextResponse.json({ success: true, data })
+  } catch {
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/api/skills/post-candidates/understaffed/route.ts
+++ b/src/app/api/skills/post-candidates/understaffed/route.ts
@@ -1,0 +1,49 @@
+/**
+ * Issue #175 / Task 11.4 / Req 4.7: 充足率不足ポスト一覧 API
+ *
+ * GET /api/skills/post-candidates/understaffed?threshold=0.6
+ * - HR_MANAGER / ADMIN のみ
+ * - threshold: 0〜1、デフォルト 0.6
+ */
+import { type NextRequest, NextResponse } from 'next/server'
+import { requireAuthenticated } from '@/lib/skill/skill-route-helpers'
+import { getPostCandidateService } from '@/lib/skill/post-candidate-service-di'
+
+const HR_MANAGER_ROLES = ['HR_MANAGER', 'ADMIN'] as const
+
+function isHrManagerOrAbove(role: string): boolean {
+  return (HR_MANAGER_ROLES as readonly string[]).includes(role)
+}
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const guard = await requireAuthenticated()
+  if (!guard.ok) return guard.response
+
+  if (!isHrManagerOrAbove(guard.session.role)) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const thresholdParam = request.nextUrl.searchParams.get('threshold')
+  const threshold = thresholdParam !== null ? parseFloat(thresholdParam) : undefined
+
+  if (threshold !== undefined && (isNaN(threshold) || threshold < 0 || threshold > 1)) {
+    return NextResponse.json(
+      { error: 'threshold must be a number between 0 and 1' },
+      { status: 400 },
+    )
+  }
+
+  let svc: ReturnType<typeof getPostCandidateService>
+  try {
+    svc = getPostCandidateService()
+  } catch {
+    return NextResponse.json({ error: 'Post candidate service not initialized' }, { status: 503 })
+  }
+
+  try {
+    const data = await svc.listUnderstaffedPosts(threshold)
+    return NextResponse.json({ success: true, data })
+  } catch {
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/skills/approval/page.tsx
+++ b/src/app/skills/approval/page.tsx
@@ -1,0 +1,220 @@
+/**
+ * Issue #175 / Task 11.2 / Req 4.5: マネージャースキル承認画面
+ *
+ * - MANAGER / HR_MANAGER / ADMIN のみアクセス可能
+ * - GET /api/skills/pending で承認待ちスキル一覧を取得
+ * - GET /api/skills/catalog でスキル名を解決
+ * - POST /api/skills/{id}/approve で承認
+ */
+'use client'
+
+import { useCallback, useEffect, useState, type ReactElement, type ReactNode } from 'react'
+
+interface SkillMasterItem {
+  readonly id: string
+  readonly name: string
+  readonly category: string
+}
+
+interface PendingSkill {
+  readonly id: string
+  readonly userId: string
+  readonly skillId: string
+  readonly level: number
+  readonly acquiredAt: string
+  readonly approvedByManagerId: string | null
+}
+
+interface ApiEnvelope<T> {
+  readonly success?: boolean
+  readonly data?: T
+  readonly error?: string
+}
+
+type LoadState =
+  | { readonly kind: 'loading' }
+  | { readonly kind: 'error'; readonly message: string }
+  | {
+      readonly kind: 'ready'
+      readonly pendingSkills: readonly PendingSkill[]
+      readonly catalog: readonly SkillMasterItem[]
+    }
+
+type ApproveState = Record<string, 'approving' | 'done' | 'error'>
+
+const PENDING_URL = '/api/skills/pending'
+const CATALOG_URL = '/api/skills/catalog'
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const res = await fetch(url, { cache: 'no-store' })
+  const envelope = (await res.json().catch(() => ({}))) as ApiEnvelope<T>
+  if (!res.ok) throw new Error(envelope.error ?? `HTTP ${res.status}`)
+  return (envelope.data ?? []) as T
+}
+
+export default function SkillApprovalPage(): ReactElement {
+  const [loadState, setLoadState] = useState<LoadState>({ kind: 'loading' })
+  const [approveStates, setApproveStates] = useState<ApproveState>({})
+
+  useEffect(() => {
+    let cancelled = false
+    void (async () => {
+      try {
+        const [pendingSkills, catalog] = await Promise.all([
+          fetchJson<PendingSkill[]>(PENDING_URL),
+          fetchJson<SkillMasterItem[]>(CATALOG_URL),
+        ])
+        if (!cancelled) setLoadState({ kind: 'ready', pendingSkills, catalog })
+      } catch (err) {
+        if (!cancelled) setLoadState({ kind: 'error', message: readError(err) })
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const handleApprove = useCallback(async (skillId: string) => {
+    setApproveStates((prev) => ({ ...prev, [skillId]: 'approving' }))
+    try {
+      const res = await fetch(`/api/skills/${skillId}/approve`, { method: 'POST' })
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string }
+        throw new Error(body.error ?? `HTTP ${res.status}`)
+      }
+      setApproveStates((prev) => ({ ...prev, [skillId]: 'done' }))
+      // 承認済みを一覧から除去
+      setLoadState((prev) => {
+        if (prev.kind !== 'ready') return prev
+        return {
+          ...prev,
+          pendingSkills: prev.pendingSkills.filter((s) => s.id !== skillId),
+        }
+      })
+    } catch {
+      setApproveStates((prev) => ({ ...prev, [skillId]: 'error' }))
+      setTimeout(() => {
+        setApproveStates((prev) => {
+          const { [skillId]: _, ...rest } = prev
+          void _
+          return rest
+        })
+      }, 3000)
+    }
+  }, [])
+
+  return (
+    <main className="mx-auto max-w-4xl px-6 py-10">
+      <header className="mb-8">
+        <p className="text-xs font-semibold tracking-widest text-indigo-600 uppercase">Skills</p>
+        <h1 className="mt-1 text-3xl font-bold text-slate-900">スキル承認</h1>
+        <p className="mt-2 text-sm text-slate-600">
+          部下から申請されたスキルを確認し、承認してください。
+        </p>
+      </header>
+
+      <PageBody loadState={loadState} approveStates={approveStates} onApprove={handleApprove} />
+    </main>
+  )
+}
+
+interface PageBodyProps {
+  readonly loadState: LoadState
+  readonly approveStates: ApproveState
+  readonly onApprove: (skillId: string) => void
+}
+
+function PageBody({ loadState, approveStates, onApprove }: PageBodyProps): ReactElement {
+  if (loadState.kind === 'loading') {
+    return (
+      <div className="flex items-center justify-center rounded-xl border border-slate-200 bg-white py-16 text-sm text-slate-500">
+        <span className="animate-pulse">データを読み込み中…</span>
+      </div>
+    )
+  }
+
+  if (loadState.kind === 'error') {
+    return (
+      <div className="rounded-xl border border-rose-300 bg-rose-50 p-6 text-sm text-rose-800">
+        <p className="font-semibold">データの取得に失敗しました</p>
+        <p className="mt-1 text-xs">{loadState.message}</p>
+      </div>
+    )
+  }
+
+  const { pendingSkills, catalog } = loadState
+
+  if (pendingSkills.length === 0) {
+    return (
+      <div className="rounded-xl border border-slate-200 bg-white py-16 text-center text-sm text-slate-500">
+        承認待ちのスキルはありません
+      </div>
+    )
+  }
+
+  return (
+    <div className="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
+      <div className="border-b border-slate-200 bg-slate-50 px-4 py-3">
+        <p className="text-xs font-medium text-slate-600">
+          承認待ち: <span className="font-semibold text-slate-900">{pendingSkills.length}</span> 件
+        </p>
+      </div>
+      <table className="w-full text-sm">
+        <thead className="border-b border-slate-200">
+          <tr>
+            <Th>社員 ID</Th>
+            <Th>スキル名</Th>
+            <Th>カテゴリ</Th>
+            <Th>レベル</Th>
+            <Th>習得日</Th>
+            <Th>操作</Th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-slate-100">
+          {pendingSkills.map((skill) => {
+            const masterItem = catalog.find((c) => c.id === skill.skillId)
+            const state = approveStates[skill.id]
+            return (
+              <tr key={skill.id} className="transition-colors hover:bg-slate-50">
+                <td className="px-4 py-3 font-mono text-xs text-slate-500">{skill.userId}</td>
+                <td className="px-4 py-3 font-medium text-slate-900">
+                  {masterItem?.name ?? skill.skillId}
+                </td>
+                <td className="px-4 py-3 text-slate-600">{masterItem?.category ?? '—'}</td>
+                <td className="px-4 py-3 text-slate-700">
+                  <span className="font-semibold text-indigo-600">{skill.level}</span>
+                  <span className="text-slate-400"> / 5</span>
+                </td>
+                <td className="px-4 py-3 text-slate-600">{skill.acquiredAt.slice(0, 10)}</td>
+                <td className="px-4 py-3">
+                  <div className="flex items-center gap-2">
+                    <button
+                      type="button"
+                      onClick={() => onApprove(skill.id)}
+                      disabled={state === 'approving' || state === 'done'}
+                      className="rounded-md bg-emerald-600 px-3 py-1.5 text-xs font-semibold text-white hover:bg-emerald-700 disabled:cursor-not-allowed disabled:bg-slate-300"
+                    >
+                      {state === 'approving' ? '承認中…' : '承認'}
+                    </button>
+                    {state === 'error' && (
+                      <span className="text-xs font-medium text-rose-600">失敗</span>
+                    )}
+                  </div>
+                </td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+function Th({ children }: { readonly children: ReactNode }): ReactElement {
+  return <th className="px-4 py-3 text-left text-xs font-semibold text-slate-700">{children}</th>
+}
+
+function readError(err: unknown): string {
+  if (err instanceof Error) return err.message
+  return '予期せぬエラーが発生しました'
+}

--- a/src/app/skills/candidates/page.tsx
+++ b/src/app/skills/candidates/page.tsx
@@ -1,0 +1,287 @@
+/**
+ * Issue #175 / Task 11.4 / Req 4.6, 4.7, 4.8: ポスト候補者リスト / 採用アラート画面
+ *
+ * - HR_MANAGER / ADMIN のみアクセス可能
+ * - 採用アラート: GET /api/skills/post-candidates/understaffed?threshold=0.6
+ * - スキルギャップランキング: GET /api/skills/post-candidates/gap-ranking
+ */
+'use client'
+
+import {
+  useCallback,
+  useEffect,
+  useState,
+  type FormEvent,
+  type ReactElement,
+  type ReactNode,
+} from 'react'
+
+interface UnderstaffedPost {
+  readonly positionId: string
+  readonly roleId: string
+  readonly roleName: string
+  readonly fulfillmentRate: number
+}
+
+interface SkillGapRankItem {
+  readonly skillId: string
+  readonly skillName: string
+  readonly averageGap: number
+  readonly affectedEmployeeCount: number
+}
+
+interface ApiEnvelope<T> {
+  readonly success?: boolean
+  readonly data?: T
+  readonly error?: string
+}
+
+type AlertState =
+  | { readonly kind: 'loading' }
+  | { readonly kind: 'error'; readonly message: string }
+  | { readonly kind: 'ready'; readonly posts: readonly UnderstaffedPost[] }
+
+type RankingState =
+  | { readonly kind: 'loading' }
+  | { readonly kind: 'error'; readonly message: string }
+  | { readonly kind: 'ready'; readonly items: readonly SkillGapRankItem[] }
+
+const DEFAULT_THRESHOLD = 0.6
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const res = await fetch(url, { cache: 'no-store' })
+  const envelope = (await res.json().catch(() => ({}))) as ApiEnvelope<T>
+  if (!res.ok) throw new Error(envelope.error ?? `HTTP ${res.status}`)
+  return (envelope.data ?? []) as T
+}
+
+export default function SkillCandidatesPage(): ReactElement {
+  const [threshold, setThreshold] = useState(DEFAULT_THRESHOLD)
+  const [thresholdInput, setThresholdInput] = useState(String(DEFAULT_THRESHOLD))
+  const [alertState, setAlertState] = useState<AlertState>({ kind: 'loading' })
+  const [rankingState, setRankingState] = useState<RankingState>({ kind: 'loading' })
+
+  const loadAlerts = useCallback(async (t: number) => {
+    setAlertState({ kind: 'loading' })
+    try {
+      const posts = await fetchJson<UnderstaffedPost[]>(
+        `/api/skills/post-candidates/understaffed?threshold=${t}`,
+      )
+      setAlertState({ kind: 'ready', posts })
+    } catch (err) {
+      setAlertState({ kind: 'error', message: readError(err) })
+    }
+  }, [])
+
+  const loadRanking = useCallback(async () => {
+    setRankingState({ kind: 'loading' })
+    try {
+      const items = await fetchJson<SkillGapRankItem[]>('/api/skills/post-candidates/gap-ranking')
+      setRankingState({ kind: 'ready', items })
+    } catch (err) {
+      setRankingState({ kind: 'error', message: readError(err) })
+    }
+  }, [])
+
+  useEffect(() => {
+    void loadAlerts(threshold)
+    void loadRanking()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const handleThresholdSubmit = useCallback(
+    (e: FormEvent) => {
+      e.preventDefault()
+      const parsed = parseFloat(thresholdInput)
+      if (isNaN(parsed) || parsed < 0 || parsed > 1) return
+      setThreshold(parsed)
+      void loadAlerts(parsed)
+    },
+    [thresholdInput, loadAlerts],
+  )
+
+  return (
+    <main className="mx-auto max-w-5xl space-y-10 px-6 py-10">
+      <header>
+        <p className="text-xs font-semibold tracking-widest text-indigo-600 uppercase">Skills</p>
+        <h1 className="mt-1 text-3xl font-bold text-slate-900">ポスト候補者 / 採用アラート</h1>
+        <p className="mt-2 text-sm text-slate-600">
+          役職ごとのスキル充足率と組織全体のスキルギャップを確認できます。
+        </p>
+      </header>
+
+      {/* 採用アラートセクション */}
+      <section>
+        <div className="mb-4 flex flex-wrap items-center gap-4">
+          <h2 className="text-lg font-semibold text-slate-900">採用アラート</h2>
+          <form onSubmit={handleThresholdSubmit} className="flex items-center gap-2">
+            <label className="text-xs text-slate-600">充足率閾値</label>
+            <input
+              type="number"
+              min={0}
+              max={1}
+              step={0.05}
+              value={thresholdInput}
+              onChange={(e) => setThresholdInput(e.target.value)}
+              className="w-20 rounded-md border border-slate-300 px-2 py-1.5 text-xs focus:border-indigo-500 focus:outline-none"
+            />
+            <button
+              type="submit"
+              className="rounded-md bg-indigo-600 px-3 py-1.5 text-xs font-semibold text-white hover:bg-indigo-700"
+            >
+              更新
+            </button>
+          </form>
+          <p className="text-xs text-slate-400">
+            現在: {Math.round(threshold * 100)}% 未満のポストを表示
+          </p>
+        </div>
+
+        <AlertSection state={alertState} />
+      </section>
+
+      {/* スキルギャップランキングセクション */}
+      <section>
+        <h2 className="mb-4 text-lg font-semibold text-slate-900">スキルギャップランキング</h2>
+        <RankingSection state={rankingState} />
+      </section>
+    </main>
+  )
+}
+
+function AlertSection({ state }: { readonly state: AlertState }): ReactElement {
+  if (state.kind === 'loading') {
+    return (
+      <div className="flex items-center justify-center rounded-xl border border-slate-200 bg-white py-12 text-sm text-slate-500">
+        <span className="animate-pulse">読み込み中…</span>
+      </div>
+    )
+  }
+
+  if (state.kind === 'error') {
+    return (
+      <div className="rounded-xl border border-rose-300 bg-rose-50 p-5 text-sm text-rose-800">
+        <p className="font-semibold">採用アラートの取得に失敗しました</p>
+        <p className="mt-1 text-xs">{state.message}</p>
+      </div>
+    )
+  }
+
+  if (state.posts.length === 0) {
+    return (
+      <div className="rounded-xl border border-emerald-200 bg-emerald-50 py-12 text-center text-sm text-emerald-700">
+        ✓ 充足率が閾値を下回るポストはありません
+      </div>
+    )
+  }
+
+  return (
+    <div className="overflow-hidden rounded-xl border border-amber-200 bg-white shadow-sm">
+      <div className="border-b border-amber-200 bg-amber-50 px-4 py-3">
+        <p className="text-xs font-medium text-amber-800">
+          ⚠ 充足率不足: <span className="font-semibold">{state.posts.length}</span> ポスト
+        </p>
+      </div>
+      <table className="w-full text-sm">
+        <thead className="border-b border-slate-200">
+          <tr>
+            <Th>役職名</Th>
+            <Th>役割 ID</Th>
+            <Th>充足率</Th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-slate-100">
+          {state.posts.map((post) => (
+            <tr key={post.positionId} className="transition-colors hover:bg-slate-50">
+              <td className="px-4 py-3 font-medium text-slate-900">{post.roleName}</td>
+              <td className="px-4 py-3 font-mono text-xs text-slate-500">{post.roleId}</td>
+              <td className="px-4 py-3">
+                <FulfillmentBar rate={post.fulfillmentRate} />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+function RankingSection({ state }: { readonly state: RankingState }): ReactElement {
+  if (state.kind === 'loading') {
+    return (
+      <div className="flex items-center justify-center rounded-xl border border-slate-200 bg-white py-12 text-sm text-slate-500">
+        <span className="animate-pulse">読み込み中…</span>
+      </div>
+    )
+  }
+
+  if (state.kind === 'error') {
+    return (
+      <div className="rounded-xl border border-rose-300 bg-rose-50 p-5 text-sm text-rose-800">
+        <p className="font-semibold">ギャップランキングの取得に失敗しました</p>
+        <p className="mt-1 text-xs">{state.message}</p>
+      </div>
+    )
+  }
+
+  if (state.items.length === 0) {
+    return (
+      <div className="rounded-xl border border-slate-200 bg-white py-12 text-center text-sm text-slate-500">
+        スキルギャップデータがありません
+      </div>
+    )
+  }
+
+  return (
+    <div className="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
+      <table className="w-full text-sm">
+        <thead className="border-b border-slate-200 bg-slate-50">
+          <tr>
+            <Th>順位</Th>
+            <Th>スキル名</Th>
+            <Th>平均ギャップ</Th>
+            <Th>影響人数</Th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-slate-100">
+          {state.items.map((item, idx) => (
+            <tr key={item.skillId} className="transition-colors hover:bg-slate-50">
+              <td className="px-4 py-3 text-center font-semibold text-slate-500">{idx + 1}</td>
+              <td className="px-4 py-3 font-medium text-slate-900">{item.skillName}</td>
+              <td className="px-4 py-3">
+                <span className="font-semibold text-rose-600">{item.averageGap.toFixed(2)}</span>
+                <span className="ml-1 text-xs text-slate-400">レベル不足</span>
+              </td>
+              <td className="px-4 py-3 text-slate-700">
+                {item.affectedEmployeeCount}
+                <span className="ml-1 text-xs text-slate-400">名</span>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+function FulfillmentBar({ rate }: { readonly rate: number }): ReactElement {
+  const pct = Math.round(rate * 100)
+  const color = pct >= 80 ? 'bg-emerald-500' : pct >= 60 ? 'bg-amber-500' : 'bg-rose-500'
+  return (
+    <div className="flex items-center gap-2">
+      <div className="h-2 flex-1 overflow-hidden rounded-full bg-slate-100">
+        <div className={`h-2 rounded-full ${color}`} style={{ width: `${pct}%` }} />
+      </div>
+      <span className="w-10 text-right text-xs font-semibold text-slate-700">{pct}%</span>
+    </div>
+  )
+}
+
+function Th({ children }: { readonly children: ReactNode }): ReactElement {
+  return <th className="px-4 py-3 text-left text-xs font-semibold text-slate-700">{children}</th>
+}
+
+function readError(err: unknown): string {
+  if (err instanceof Error) return err.message
+  return '予期せぬエラーが発生しました'
+}

--- a/src/app/skills/register/page.tsx
+++ b/src/app/skills/register/page.tsx
@@ -1,0 +1,370 @@
+/**
+ * Issue #175 / Task 11.2 / Req 4.4, 4.5: 社員スキル登録画面
+ *
+ * - 全ロールアクセス可能（自分のスキルのみ登録）
+ * - GET /api/skills/catalog でスキルマスタ一覧を取得（フォームのドロップダウン）
+ * - GET /api/skills で自分の登録済みスキルを取得
+ * - POST /api/skills でスキルを新規登録
+ * - 承認済み（approvedByManagerId != null）は ✓ 承認済み と表示
+ */
+'use client'
+
+import {
+  useCallback,
+  useEffect,
+  useState,
+  type FormEvent,
+  type ReactElement,
+  type ReactNode,
+} from 'react'
+
+interface SkillMasterItem {
+  readonly id: string
+  readonly name: string
+  readonly category: string
+}
+
+interface EmployeeSkill {
+  readonly id: string
+  readonly skillId: string
+  readonly level: number
+  readonly acquiredAt: string
+  readonly approvedByManagerId: string | null
+  readonly approvedAt: string | null
+}
+
+interface ApiEnvelope<T> {
+  readonly success?: boolean
+  readonly data?: T
+  readonly error?: string
+}
+
+type LoadState =
+  | { readonly kind: 'loading' }
+  | { readonly kind: 'error'; readonly message: string }
+  | {
+      readonly kind: 'ready'
+      readonly catalog: readonly SkillMasterItem[]
+      readonly mySkills: readonly EmployeeSkill[]
+    }
+
+type SaveState =
+  | { readonly kind: 'idle' }
+  | { readonly kind: 'saving' }
+  | { readonly kind: 'success' }
+  | { readonly kind: 'error'; readonly message: string }
+
+const CATALOG_URL = '/api/skills/catalog'
+const SKILLS_URL = '/api/skills'
+const LEVEL_MIN = 1
+const LEVEL_MAX = 5
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const res = await fetch(url, { cache: 'no-store' })
+  const envelope = (await res.json().catch(() => ({}))) as ApiEnvelope<T>
+  if (!res.ok) throw new Error(envelope.error ?? `HTTP ${res.status}`)
+  return (envelope.data ?? []) as T
+}
+
+export default function SkillRegisterPage(): ReactElement {
+  const [loadState, setLoadState] = useState<LoadState>({ kind: 'loading' })
+  const [saveState, setSaveState] = useState<SaveState>({ kind: 'idle' })
+
+  const [selectedSkillId, setSelectedSkillId] = useState('')
+  const [level, setLevel] = useState<number>(3)
+  const [acquiredAt, setAcquiredAt] = useState(new Date().toISOString().slice(0, 10))
+
+  const loadData = useCallback(async () => {
+    setLoadState({ kind: 'loading' })
+    try {
+      const [catalog, mySkills] = await Promise.all([
+        fetchJson<SkillMasterItem[]>(CATALOG_URL),
+        fetchJson<EmployeeSkill[]>(SKILLS_URL),
+      ])
+      setLoadState({ kind: 'ready', catalog, mySkills })
+      if (catalog.length > 0 && !selectedSkillId) {
+        setSelectedSkillId(catalog[0]?.id ?? '')
+      }
+    } catch (err) {
+      setLoadState({ kind: 'error', message: readError(err) })
+    }
+  }, [selectedSkillId])
+
+  useEffect(() => {
+    void loadData()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const handleSubmit = useCallback(
+    async (e: FormEvent) => {
+      e.preventDefault()
+      if (!selectedSkillId) return
+      setSaveState({ kind: 'saving' })
+      try {
+        const res = await fetch(SKILLS_URL, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ skillId: selectedSkillId, level, acquiredAt }),
+        })
+        const body = (await res.json().catch(() => ({}))) as ApiEnvelope<unknown>
+        if (!res.ok) throw new Error(body.error ?? `HTTP ${res.status}`)
+        setSaveState({ kind: 'success' })
+        // 登録後リストを再取得
+        const refreshed = await fetchJson<EmployeeSkill[]>(SKILLS_URL)
+        setLoadState((prev) => {
+          if (prev.kind !== 'ready') return prev
+          return { ...prev, mySkills: refreshed }
+        })
+        setTimeout(() => setSaveState({ kind: 'idle' }), 2000)
+      } catch (err) {
+        setSaveState({ kind: 'error', message: readError(err) })
+      }
+    },
+    [selectedSkillId, level, acquiredAt],
+  )
+
+  return (
+    <main className="mx-auto max-w-3xl px-6 py-10">
+      <header className="mb-8">
+        <p className="text-xs font-semibold tracking-widest text-indigo-600 uppercase">Skills</p>
+        <h1 className="mt-1 text-3xl font-bold text-slate-900">スキル登録</h1>
+        <p className="mt-2 text-sm text-slate-600">
+          自分の保有スキルとレベルを登録します。登録後はマネージャーの承認を受けてください。
+        </p>
+      </header>
+
+      <PageBody
+        loadState={loadState}
+        saveState={saveState}
+        selectedSkillId={selectedSkillId}
+        level={level}
+        acquiredAt={acquiredAt}
+        onSkillChange={setSelectedSkillId}
+        onLevelChange={setLevel}
+        onAcquiredAtChange={setAcquiredAt}
+        onSubmit={handleSubmit}
+      />
+    </main>
+  )
+}
+
+interface PageBodyProps {
+  readonly loadState: LoadState
+  readonly saveState: SaveState
+  readonly selectedSkillId: string
+  readonly level: number
+  readonly acquiredAt: string
+  readonly onSkillChange: (id: string) => void
+  readonly onLevelChange: (v: number) => void
+  readonly onAcquiredAtChange: (v: string) => void
+  readonly onSubmit: (e: FormEvent) => void
+}
+
+function PageBody({
+  loadState,
+  saveState,
+  selectedSkillId,
+  level,
+  acquiredAt,
+  onSkillChange,
+  onLevelChange,
+  onAcquiredAtChange,
+  onSubmit,
+}: PageBodyProps): ReactElement {
+  if (loadState.kind === 'loading') {
+    return (
+      <div className="flex items-center justify-center rounded-xl border border-slate-200 bg-white py-16 text-sm text-slate-500">
+        <span className="animate-pulse">データを読み込み中…</span>
+      </div>
+    )
+  }
+
+  if (loadState.kind === 'error') {
+    return (
+      <div className="rounded-xl border border-rose-300 bg-rose-50 p-6 text-sm text-rose-800">
+        <p className="font-semibold">データの取得に失敗しました</p>
+        <p className="mt-1 text-xs">{loadState.message}</p>
+      </div>
+    )
+  }
+
+  const { catalog, mySkills } = loadState
+  const saving = saveState.kind === 'saving'
+
+  // カタログをカテゴリ別にグループ化
+  const grouped = catalog.reduce<Record<string, SkillMasterItem[]>>((acc, s) => {
+    const cat = s.category
+    return { ...acc, [cat]: [...(acc[cat] ?? []), s] }
+  }, {})
+
+  return (
+    <div className="space-y-6">
+      {/* 登録フォーム */}
+      <form
+        onSubmit={onSubmit}
+        className="space-y-4 rounded-xl border border-slate-200 bg-white p-6 shadow-sm"
+      >
+        <h2 className="text-sm font-semibold text-slate-800">スキルを追加 / 更新</h2>
+
+        <Field label="スキル" required>
+          <select
+            value={selectedSkillId}
+            onChange={(e) => onSkillChange(e.target.value)}
+            required
+            className={inputCls}
+          >
+            {Object.entries(grouped).map(([cat, items]) => (
+              <optgroup key={cat} label={cat}>
+                {items.map((s) => (
+                  <option key={s.id} value={s.id}>
+                    {s.name}
+                  </option>
+                ))}
+              </optgroup>
+            ))}
+          </select>
+        </Field>
+
+        <Field label={`レベル（${LEVEL_MIN}〜${LEVEL_MAX}）`} required>
+          <div className="flex items-center gap-3">
+            <input
+              type="range"
+              min={LEVEL_MIN}
+              max={LEVEL_MAX}
+              step={1}
+              value={level}
+              onChange={(e) => onLevelChange(Number(e.target.value))}
+              className="flex-1"
+            />
+            <span className="w-6 text-center text-sm font-semibold text-indigo-600">{level}</span>
+          </div>
+          <p className="mt-1 text-xs text-slate-400">
+            1: 入門 / 2: 基礎 / 3: 中級 / 4: 上級 / 5: エキスパート
+          </p>
+        </Field>
+
+        <Field label="習得日" required>
+          <input
+            type="date"
+            value={acquiredAt}
+            onChange={(e) => onAcquiredAtChange(e.target.value)}
+            required
+            className={inputCls}
+          />
+        </Field>
+
+        <div className="flex items-center gap-3 border-t border-slate-100 pt-2">
+          <button
+            type="submit"
+            disabled={saving || !selectedSkillId}
+            className="rounded-md bg-indigo-600 px-5 py-2 text-sm font-semibold text-white hover:bg-indigo-700 disabled:cursor-not-allowed disabled:bg-slate-300"
+          >
+            {saving ? '登録中…' : '登録する'}
+          </button>
+          {saveState.kind === 'success' && (
+            <span className="text-sm font-medium text-emerald-600">✓ 登録しました</span>
+          )}
+          {saveState.kind === 'error' && (
+            <span className="text-sm font-medium text-rose-600">
+              登録に失敗: {saveState.message}
+            </span>
+          )}
+        </div>
+      </form>
+
+      {/* 登録済みスキル一覧 */}
+      <div className="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
+        <div className="border-b border-slate-200 bg-slate-50 px-4 py-3">
+          <h2 className="text-sm font-semibold text-slate-800">
+            登録済みスキル{' '}
+            <span className="font-normal text-slate-500">({mySkills.length} 件)</span>
+          </h2>
+        </div>
+        {mySkills.length === 0 ? (
+          <p className="py-10 text-center text-sm text-slate-400">スキルが登録されていません</p>
+        ) : (
+          <table className="w-full text-sm">
+            <thead className="border-b border-slate-200">
+              <tr>
+                <Th>スキル名</Th>
+                <Th>レベル</Th>
+                <Th>習得日</Th>
+                <Th>承認状態</Th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-100">
+              {mySkills.map((skill) => {
+                const masterItem = catalog.find((c) => c.id === skill.skillId)
+                const approved = skill.approvedByManagerId !== null
+                return (
+                  <tr key={skill.id} className="transition-colors hover:bg-slate-50">
+                    <td className="px-4 py-3 font-medium text-slate-900">
+                      {masterItem?.name ?? skill.skillId}
+                      {masterItem && (
+                        <span className="ml-2 text-xs text-slate-400">{masterItem.category}</span>
+                      )}
+                    </td>
+                    <td className="px-4 py-3 text-slate-700">
+                      <LevelBadge level={skill.level} />
+                    </td>
+                    <td className="px-4 py-3 text-slate-600">{skill.acquiredAt.slice(0, 10)}</td>
+                    <td className="px-4 py-3">
+                      {approved ? (
+                        <span className="inline-flex items-center rounded-full bg-emerald-100 px-2.5 py-0.5 text-xs font-medium text-emerald-800">
+                          ✓ 承認済み
+                        </span>
+                      ) : (
+                        <span className="inline-flex items-center rounded-full bg-amber-100 px-2.5 py-0.5 text-xs font-medium text-amber-800">
+                          承認待ち
+                        </span>
+                      )}
+                    </td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function LevelBadge({ level }: { readonly level: number }): ReactElement {
+  return (
+    <span className="inline-flex items-center gap-1">
+      <span className="font-semibold text-indigo-600">{level}</span>
+      <span className="text-slate-400">/ 5</span>
+    </span>
+  )
+}
+
+const inputCls =
+  'block w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500'
+
+interface FieldProps {
+  readonly label: string
+  readonly required?: boolean
+  readonly children: ReactNode
+}
+
+function Field({ label, required = false, children }: FieldProps): ReactElement {
+  return (
+    <div className="space-y-1">
+      <label className="block text-xs font-medium text-slate-700">
+        {label}
+        {required && <span className="ml-1 text-rose-500">*</span>}
+      </label>
+      {children}
+    </div>
+  )
+}
+
+function Th({ children }: { readonly children: ReactNode }): ReactElement {
+  return <th className="px-4 py-3 text-left text-xs font-semibold text-slate-700">{children}</th>
+}
+
+function readError(err: unknown): string {
+  if (err instanceof Error) return err.message
+  return '予期せぬエラーが発生しました'
+}


### PR DESCRIPTION
## Summary

- `src/app/skills/register/page.tsx` — 社員スキル登録画面（全ロール）: GET /api/skills/catalog でスキル一覧取得、POST /api/skills でスキル登録、承認状態バッジ表示
- `src/app/skills/approval/page.tsx` — マネージャースキル承認画面（MANAGER+）: GET /api/skills/pending で承認待ち一覧取得、POST /api/skills/{id}/approve で個別承認
- `src/app/skills/candidates/page.tsx` — ポスト候補者 / 採用アラート画面（HR_MANAGER+）: 充足率不足ポスト一覧・スキルギャップランキング表示
- `src/app/api/skills/catalog/route.ts` — 新規: 全認証ユーザー向けスキルカタログ API（/api/masters/skills は ADMIN 専用のため）
- `src/app/api/skills/post-candidates/understaffed/route.ts` — 新規: 充足率不足ポスト一覧 API（threshold クエリパラメータ対応）
- `src/app/api/skills/post-candidates/gap-ranking/route.ts` — 新規: スキルギャップランキング API

## Related Issue

Closes #175

## Test plan

- [ ] `/skills/register` にアクセスし、スキル登録フォームが表示されること
- [ ] スキルカテゴリ別グループ化が `<optgroup>` で表示されること
- [ ] レベルスライダー（1〜5）と習得日が入力できること
- [ ] 登録ボタン押下後、登録済みスキル一覧が更新されること
- [ ] 承認済みスキルに ✓ 承認済みバッジ、未承認に 承認待ちバッジが表示されること
- [ ] `/skills/approval` にアクセスし、承認待ちスキル一覧が表示されること
- [ ] 承認ボタン押下後、該当行が一覧から消えること
- [ ] `/skills/candidates` にアクセスし、採用アラートとギャップランキングが表示されること
- [ ] 充足率閾値フォームで値を変更し「更新」ボタンで再取得されること
- [ ] `pnpm tsc --noEmit` がエラーなしで完了すること