### PR TITLE
feat: ISSUE #176 キャリア管理画面の実装

### DIFF
--- a/src/app/career/aggregate/page.tsx
+++ b/src/app/career/aggregate/page.tsx
@@ -1,0 +1,264 @@
+/**
+ * Issue #176 / Task 12.3 / Req 5.5: 組織全体のキャリア希望集計画面
+ *
+ * - HR_MANAGER / ADMIN のみアクセス可能
+ * - GET /api/career/aggregate/dashboard で集計ダッシュボードを取得
+ * - 希望役職の分布と充足予測をダッシュボード形式で表示
+ */
+'use client'
+
+import { useEffect, useState, type ReactElement, type ReactNode } from 'react'
+
+interface RoleWishDistribution {
+  readonly roleId: string
+  readonly roleName: string
+  readonly wishCount: number
+  readonly fulfillmentRate: number
+}
+
+interface CareerAggregateDashboard {
+  readonly totalWishes: number
+  readonly distribution: readonly RoleWishDistribution[]
+  readonly unfulfilledTopRoles: readonly RoleWishDistribution[]
+}
+
+interface ApiEnvelope<T> {
+  readonly success?: boolean
+  readonly data?: T
+  readonly error?: string
+}
+
+type DashboardState =
+  | { readonly kind: 'loading' }
+  | { readonly kind: 'error'; readonly message: string }
+  | { readonly kind: 'ready'; readonly dashboard: CareerAggregateDashboard }
+
+const DASHBOARD_URL = '/api/career/aggregate/dashboard'
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const res = await fetch(url, { cache: 'no-store' })
+  const envelope = (await res.json().catch(() => ({}))) as ApiEnvelope<T>
+  if (!res.ok) throw new Error(envelope.error ?? `HTTP ${res.status}`)
+  return envelope.data as T
+}
+
+export default function CareerAggregatePage(): ReactElement {
+  const [state, setState] = useState<DashboardState>({ kind: 'loading' })
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const dashboard = await fetchJson<CareerAggregateDashboard>(DASHBOARD_URL)
+        setState({ kind: 'ready', dashboard })
+      } catch (err) {
+        setState({ kind: 'error', message: readError(err) })
+      }
+    }
+    void load()
+  }, [])
+
+  return (
+    <main className="mx-auto max-w-5xl space-y-10 px-6 py-10">
+      <header>
+        <p className="text-xs font-semibold tracking-widest text-indigo-600 uppercase">Career</p>
+        <h1 className="mt-1 text-3xl font-bold text-slate-900">キャリア希望集計</h1>
+        <p className="mt-2 text-sm text-slate-600">
+          組織全体の希望役職の分布と充足予測を確認できます。
+        </p>
+      </header>
+
+      <DashboardBody state={state} />
+    </main>
+  )
+}
+
+function DashboardBody({ state }: { readonly state: DashboardState }): ReactElement {
+  if (state.kind === 'loading') {
+    return (
+      <div className="flex items-center justify-center rounded-xl border border-slate-200 bg-white py-16 text-sm text-slate-500">
+        <span className="animate-pulse">データを読み込み中…</span>
+      </div>
+    )
+  }
+
+  if (state.kind === 'error') {
+    return (
+      <div className="rounded-xl border border-rose-300 bg-rose-50 p-6 text-sm text-rose-800">
+        <p className="font-semibold">データの取得に失敗しました</p>
+        <p className="mt-1 text-xs">{state.message}</p>
+      </div>
+    )
+  }
+
+  const { dashboard } = state
+
+  return (
+    <div className="space-y-8">
+      {/* サマリーカード */}
+      <div className="grid gap-4 sm:grid-cols-3">
+        <SummaryCard
+          label="総希望件数"
+          value={String(dashboard.totalWishes)}
+          unit="件"
+          color="indigo"
+        />
+        <SummaryCard
+          label="希望役職数"
+          value={String(dashboard.distribution.length)}
+          unit="種"
+          color="slate"
+        />
+        <SummaryCard
+          label="充足率不足ロール"
+          value={String(dashboard.unfulfilledTopRoles.length)}
+          unit="件"
+          color="amber"
+        />
+      </div>
+
+      {/* 充足率不足 TOP ロール */}
+      {dashboard.unfulfilledTopRoles.length > 0 && (
+        <section>
+          <h2 className="mb-4 text-lg font-semibold text-slate-900">充足率不足ロール TOP</h2>
+          <div className="overflow-hidden rounded-xl border border-amber-200 bg-white shadow-sm">
+            <div className="border-b border-amber-200 bg-amber-50 px-4 py-3">
+              <p className="text-xs font-medium text-amber-800">
+                ⚠ 希望が多いにもかかわらず充足率が低いロール
+              </p>
+            </div>
+            <table className="w-full text-sm">
+              <thead className="border-b border-slate-200">
+                <tr>
+                  <Th>順位</Th>
+                  <Th>役職名</Th>
+                  <Th>希望者数</Th>
+                  <Th>充足率</Th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-100">
+                {dashboard.unfulfilledTopRoles.map((item, idx) => (
+                  <tr key={item.roleId} className="transition-colors hover:bg-slate-50">
+                    <td className="px-4 py-3 text-center font-semibold text-slate-500">
+                      {idx + 1}
+                    </td>
+                    <td className="px-4 py-3 font-medium text-slate-900">{item.roleName}</td>
+                    <td className="px-4 py-3 text-slate-700">
+                      {item.wishCount}
+                      <span className="ml-1 text-xs text-slate-400">名</span>
+                    </td>
+                    <td className="px-4 py-3">
+                      <FulfillmentBar rate={item.fulfillmentRate} />
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      )}
+
+      {/* 全役職の希望分布 */}
+      <section>
+        <h2 className="mb-4 text-lg font-semibold text-slate-900">希望役職の分布</h2>
+        {dashboard.distribution.length === 0 ? (
+          <div className="rounded-xl border border-slate-200 bg-white py-12 text-center text-sm text-slate-400">
+            希望データがありません
+          </div>
+        ) : (
+          <div className="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
+            <table className="w-full text-sm">
+              <thead className="border-b border-slate-200 bg-slate-50">
+                <tr>
+                  <Th>役職名</Th>
+                  <Th>希望者数</Th>
+                  <Th>充足率</Th>
+                  <Th>構成比</Th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-100">
+                {dashboard.distribution.map((item) => {
+                  const share =
+                    dashboard.totalWishes > 0
+                      ? Math.round((item.wishCount / dashboard.totalWishes) * 100)
+                      : 0
+                  return (
+                    <tr key={item.roleId} className="transition-colors hover:bg-slate-50">
+                      <td className="px-4 py-3 font-medium text-slate-900">{item.roleName}</td>
+                      <td className="px-4 py-3 text-slate-700">
+                        {item.wishCount}
+                        <span className="ml-1 text-xs text-slate-400">名</span>
+                      </td>
+                      <td className="px-4 py-3">
+                        <FulfillmentBar rate={item.fulfillmentRate} />
+                      </td>
+                      <td className="px-4 py-3">
+                        <div className="flex items-center gap-2">
+                          <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-slate-100">
+                            <div
+                              className="h-1.5 rounded-full bg-indigo-400"
+                              style={{ width: `${share}%` }}
+                            />
+                          </div>
+                          <span className="w-8 text-right text-xs text-slate-500">{share}%</span>
+                        </div>
+                      </td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+    </div>
+  )
+}
+
+interface SummaryCardProps {
+  readonly label: string
+  readonly value: string
+  readonly unit: string
+  readonly color: 'indigo' | 'slate' | 'amber'
+}
+
+function SummaryCard({ label, value, unit, color }: SummaryCardProps): ReactElement {
+  const borderCls =
+    color === 'indigo'
+      ? 'border-indigo-200 bg-indigo-50'
+      : color === 'amber'
+        ? 'border-amber-200 bg-amber-50'
+        : 'border-slate-200 bg-white'
+  const valueCls =
+    color === 'indigo' ? 'text-indigo-700' : color === 'amber' ? 'text-amber-700' : 'text-slate-700'
+  return (
+    <div className={`rounded-xl border p-5 ${borderCls}`}>
+      <p className="text-xs font-medium text-slate-500">{label}</p>
+      <p className={`mt-1 text-3xl font-bold ${valueCls}`}>
+        {value}
+        <span className="ml-1 text-base font-normal">{unit}</span>
+      </p>
+    </div>
+  )
+}
+
+function FulfillmentBar({ rate }: { readonly rate: number }): ReactElement {
+  const pct = Math.round(rate * 100)
+  const color = pct >= 80 ? 'bg-emerald-500' : pct >= 60 ? 'bg-amber-500' : 'bg-rose-500'
+  return (
+    <div className="flex items-center gap-2">
+      <div className="h-2 w-24 overflow-hidden rounded-full bg-slate-100">
+        <div className={`h-2 rounded-full ${color}`} style={{ width: `${pct}%` }} />
+      </div>
+      <span className="w-8 text-right text-xs font-semibold text-slate-700">{pct}%</span>
+    </div>
+  )
+}
+
+function Th({ children }: { readonly children: ReactNode }): ReactElement {
+  return <th className="px-4 py-3 text-left text-xs font-semibold text-slate-700">{children}</th>
+}
+
+function readError(err: unknown): string {
+  if (err instanceof Error) return err.message
+  return '予期せぬエラーが発生しました'
+}

--- a/src/app/career/map/page.tsx
+++ b/src/app/career/map/page.tsx
@@ -1,0 +1,414 @@
+/**
+ * Issue #176 / Task 12.2 / Req 5.1, 5.3, 5.4: キャリアマップ / ギャップ表示画面
+ *
+ * - 全ロールアクセス可能
+ * - GET /api/career/map/roles で役職一覧を取得（Req 5.1）
+ * - GET /api/career/map/gap?desiredRoleId=... でスキルギャップを計算（Req 5.3）
+ * - GET /api/career/map/subordinates/wishes で部下の希望一覧（MANAGER+ / Req 5.4）
+ */
+'use client'
+
+import {
+  useCallback,
+  useEffect,
+  useState,
+  type FormEvent,
+  type ReactElement,
+  type ReactNode,
+} from 'react'
+
+interface SkillRequirement {
+  readonly skillId: string
+  readonly skillName: string
+  readonly requiredLevel: number
+}
+
+interface RoleNode {
+  readonly id: string
+  readonly name: string
+  readonly skillRequirements: readonly SkillRequirement[]
+}
+
+interface SkillGapItem {
+  readonly skillId: string
+  readonly skillName: string
+  readonly requiredLevel: number
+  readonly actualLevel: number
+  readonly gap: number
+}
+
+interface CareerGapResult {
+  readonly currentRoleId: string | null
+  readonly desiredRoleId: string
+  readonly gaps: readonly SkillGapItem[]
+  readonly totalGap: number
+  readonly fulfillmentRate: number
+}
+
+interface SubordinateWish {
+  readonly userId: string
+  readonly userName?: string
+  readonly currentRoleId: string | null
+  readonly desiredRoleId: string
+  readonly desiredRoleName: string
+  readonly desiredAt: string
+  readonly fulfillmentRate: number
+}
+
+interface ApiEnvelope<T> {
+  readonly success?: boolean
+  readonly data?: T
+  readonly error?: string
+}
+
+type RolesState =
+  | { readonly kind: 'loading' }
+  | { readonly kind: 'error'; readonly message: string }
+  | { readonly kind: 'ready'; readonly roles: readonly RoleNode[] }
+
+type GapState =
+  | { readonly kind: 'idle' }
+  | { readonly kind: 'loading' }
+  | { readonly kind: 'error'; readonly message: string }
+  | { readonly kind: 'ready'; readonly result: CareerGapResult }
+
+type SubordinatesState =
+  | { readonly kind: 'loading' }
+  | { readonly kind: 'error'; readonly message: string }
+  | { readonly kind: 'ready'; readonly wishes: readonly SubordinateWish[] }
+  | { readonly kind: 'hidden' }
+
+const ROLES_URL = '/api/career/map/roles'
+const GAP_URL = '/api/career/map/gap'
+const SUBORDINATES_URL = '/api/career/map/subordinates/wishes'
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const res = await fetch(url, { cache: 'no-store' })
+  const envelope = (await res.json().catch(() => ({}))) as ApiEnvelope<T>
+  if (!res.ok) throw new Error(envelope.error ?? `HTTP ${res.status}`)
+  return (envelope.data ?? null) as T
+}
+
+export default function CareerMapPage(): ReactElement {
+  const [rolesState, setRolesState] = useState<RolesState>({ kind: 'loading' })
+  const [gapState, setGapState] = useState<GapState>({ kind: 'idle' })
+  const [subordinatesState, setSubordinatesState] = useState<SubordinatesState>({
+    kind: 'loading',
+  })
+  const [selectedRoleId, setSelectedRoleId] = useState('')
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const roles = await fetchJson<RoleNode[]>(ROLES_URL)
+        const safeRoles = Array.isArray(roles) ? roles : []
+        setRolesState({ kind: 'ready', roles: safeRoles })
+        if (safeRoles.length > 0) {
+          setSelectedRoleId(safeRoles[0]?.id ?? '')
+        }
+      } catch (err) {
+        setRolesState({ kind: 'error', message: readError(err) })
+      }
+
+      try {
+        const wishes = await fetchJson<SubordinateWish[]>(SUBORDINATES_URL)
+        const safeWishes = Array.isArray(wishes) ? wishes : []
+        setSubordinatesState({ kind: 'ready', wishes: safeWishes })
+      } catch (err) {
+        const msg = readError(err)
+        if (msg.includes('403') || msg.toLowerCase().includes('forbidden')) {
+          setSubordinatesState({ kind: 'hidden' })
+        } else {
+          setSubordinatesState({ kind: 'error', message: msg })
+        }
+      }
+    }
+    void load()
+  }, [])
+
+  const handleGapSubmit = useCallback(
+    async (e: FormEvent) => {
+      e.preventDefault()
+      if (!selectedRoleId) return
+      setGapState({ kind: 'loading' })
+      try {
+        const result = await fetchJson<CareerGapResult>(
+          `${GAP_URL}?desiredRoleId=${encodeURIComponent(selectedRoleId)}`,
+        )
+        setGapState({ kind: 'ready', result })
+      } catch (err) {
+        setGapState({ kind: 'error', message: readError(err) })
+      }
+    },
+    [selectedRoleId],
+  )
+
+  return (
+    <main className="mx-auto max-w-5xl space-y-10 px-6 py-10">
+      <header>
+        <p className="text-xs font-semibold tracking-widest text-indigo-600 uppercase">Career</p>
+        <h1 className="mt-1 text-3xl font-bold text-slate-900">キャリアマップ</h1>
+        <p className="mt-2 text-sm text-slate-600">
+          役職一覧を確認し、希望役職へのスキルギャップを把握できます。
+        </p>
+      </header>
+
+      {/* 役職一覧 */}
+      <section>
+        <h2 className="mb-4 text-lg font-semibold text-slate-900">役職一覧</h2>
+        <RolesSection state={rolesState} />
+      </section>
+
+      {/* ギャップ計算 */}
+      <section>
+        <h2 className="mb-4 text-lg font-semibold text-slate-900">スキルギャップ確認</h2>
+        <GapSection
+          rolesState={rolesState}
+          gapState={gapState}
+          selectedRoleId={selectedRoleId}
+          onRoleChange={setSelectedRoleId}
+          onSubmit={handleGapSubmit}
+        />
+      </section>
+
+      {/* 部下のキャリア希望（MANAGER+） */}
+      {subordinatesState.kind !== 'hidden' && (
+        <section>
+          <h2 className="mb-4 text-lg font-semibold text-slate-900">部下のキャリア希望</h2>
+          <SubordinatesSection state={subordinatesState} />
+        </section>
+      )}
+    </main>
+  )
+}
+
+function RolesSection({ state }: { readonly state: RolesState }): ReactElement {
+  if (state.kind === 'loading') {
+    return (
+      <div className="flex items-center justify-center rounded-xl border border-slate-200 bg-white py-10 text-sm text-slate-500">
+        <span className="animate-pulse">読み込み中…</span>
+      </div>
+    )
+  }
+  if (state.kind === 'error') {
+    return (
+      <div className="rounded-xl border border-rose-300 bg-rose-50 p-5 text-sm text-rose-800">
+        <p className="font-semibold">役職一覧の取得に失敗しました</p>
+        <p className="mt-1 text-xs">{state.message}</p>
+      </div>
+    )
+  }
+  if (state.roles.length === 0) {
+    return (
+      <div className="rounded-xl border border-slate-200 bg-white py-10 text-center text-sm text-slate-400">
+        役職データがありません
+      </div>
+    )
+  }
+  return (
+    <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+      {state.roles.map((role) => (
+        <div key={role.id} className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+          <p className="font-semibold text-slate-900">{role.name}</p>
+          {role.skillRequirements.length > 0 ? (
+            <ul className="mt-2 space-y-1">
+              {role.skillRequirements.map((req) => (
+                <li key={req.skillId} className="flex items-center justify-between text-xs">
+                  <span className="text-slate-600">{req.skillName}</span>
+                  <span className="ml-2 font-semibold text-indigo-600">Lv {req.requiredLevel}</span>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="mt-2 text-xs text-slate-400">スキル要件なし</p>
+          )}
+        </div>
+      ))}
+    </div>
+  )
+}
+
+interface GapSectionProps {
+  readonly rolesState: RolesState
+  readonly gapState: GapState
+  readonly selectedRoleId: string
+  readonly onRoleChange: (id: string) => void
+  readonly onSubmit: (e: FormEvent) => void
+}
+
+function GapSection({
+  rolesState,
+  gapState,
+  selectedRoleId,
+  onRoleChange,
+  onSubmit,
+}: GapSectionProps): ReactElement {
+  const roles = rolesState.kind === 'ready' ? rolesState.roles : []
+
+  return (
+    <div className="space-y-4">
+      <form
+        onSubmit={onSubmit}
+        className="flex flex-wrap items-end gap-3 rounded-xl border border-slate-200 bg-white p-5 shadow-sm"
+      >
+        <div className="flex-1 space-y-1">
+          <label className="block text-xs font-medium text-slate-700">希望役職</label>
+          <select
+            value={selectedRoleId}
+            onChange={(e) => onRoleChange(e.target.value)}
+            disabled={rolesState.kind !== 'ready'}
+            className="block w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none disabled:bg-slate-50"
+          >
+            {roles.map((r) => (
+              <option key={r.id} value={r.id}>
+                {r.name}
+              </option>
+            ))}
+          </select>
+        </div>
+        <button
+          type="submit"
+          disabled={!selectedRoleId || gapState.kind === 'loading'}
+          className="rounded-md bg-indigo-600 px-5 py-2 text-sm font-semibold text-white hover:bg-indigo-700 disabled:cursor-not-allowed disabled:bg-slate-300"
+        >
+          {gapState.kind === 'loading' ? '計算中…' : 'ギャップを確認'}
+        </button>
+      </form>
+
+      {gapState.kind === 'error' && (
+        <div className="rounded-xl border border-rose-300 bg-rose-50 p-4 text-sm text-rose-800">
+          <p className="font-semibold">ギャップの取得に失敗しました</p>
+          <p className="mt-1 text-xs">{gapState.message}</p>
+        </div>
+      )}
+
+      {gapState.kind === 'ready' && <GapResult result={gapState.result} />}
+    </div>
+  )
+}
+
+function GapResult({ result }: { readonly result: CareerGapResult }): ReactElement {
+  const pct = Math.round(result.fulfillmentRate * 100)
+  const color = pct >= 80 ? 'bg-emerald-500' : pct >= 60 ? 'bg-amber-500' : 'bg-rose-500'
+
+  return (
+    <div className="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
+      <div className="border-b border-slate-200 bg-slate-50 px-5 py-3">
+        <div className="flex items-center justify-between">
+          <p className="text-sm font-semibold text-slate-800">スキルギャップ分析</p>
+          <div className="flex items-center gap-2">
+            <div className="h-2 w-24 overflow-hidden rounded-full bg-slate-100">
+              <div className={`h-2 rounded-full ${color}`} style={{ width: `${pct}%` }} />
+            </div>
+            <span className="text-sm font-semibold text-slate-700">{pct}%</span>
+          </div>
+        </div>
+      </div>
+      {result.gaps.length === 0 ? (
+        <div className="py-10 text-center text-sm text-emerald-600">
+          ✓ スキルギャップはありません
+        </div>
+      ) : (
+        <table className="w-full text-sm">
+          <thead className="border-b border-slate-200">
+            <tr>
+              <Th>スキル</Th>
+              <Th>現在レベル</Th>
+              <Th>必要レベル</Th>
+              <Th>ギャップ</Th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-100">
+            {result.gaps.map((gap) => (
+              <tr key={gap.skillId} className="transition-colors hover:bg-slate-50">
+                <td className="px-4 py-3 font-medium text-slate-900">{gap.skillName}</td>
+                <td className="px-4 py-3 text-slate-700">{gap.actualLevel}</td>
+                <td className="px-4 py-3 text-slate-700">{gap.requiredLevel}</td>
+                <td className="px-4 py-3">
+                  {gap.gap > 0 ? (
+                    <span className="font-semibold text-rose-600">−{gap.gap}</span>
+                  ) : (
+                    <span className="font-semibold text-emerald-600">✓</span>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  )
+}
+
+function SubordinatesSection({ state }: { readonly state: SubordinatesState }): ReactElement {
+  if (state.kind === 'loading') {
+    return (
+      <div className="flex items-center justify-center rounded-xl border border-slate-200 bg-white py-10 text-sm text-slate-500">
+        <span className="animate-pulse">読み込み中…</span>
+      </div>
+    )
+  }
+  if (state.kind === 'error') {
+    return (
+      <div className="rounded-xl border border-rose-300 bg-rose-50 p-5 text-sm text-rose-800">
+        <p className="font-semibold">部下の希望一覧の取得に失敗しました</p>
+        <p className="mt-1 text-xs">{state.message}</p>
+      </div>
+    )
+  }
+  if (state.kind !== 'ready' || state.wishes.length === 0) {
+    return (
+      <div className="rounded-xl border border-slate-200 bg-white py-10 text-center text-sm text-slate-400">
+        部下のキャリア希望データがありません
+      </div>
+    )
+  }
+  return (
+    <div className="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
+      <table className="w-full text-sm">
+        <thead className="border-b border-slate-200 bg-slate-50">
+          <tr>
+            <Th>社員</Th>
+            <Th>希望役職</Th>
+            <Th>希望時期</Th>
+            <Th>充足率</Th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-slate-100">
+          {state.wishes.map((wish) => {
+            const pct = Math.round(wish.fulfillmentRate * 100)
+            const color = pct >= 80 ? 'bg-emerald-500' : pct >= 60 ? 'bg-amber-500' : 'bg-rose-500'
+            return (
+              <tr key={wish.userId} className="transition-colors hover:bg-slate-50">
+                <td className="px-4 py-3 font-mono text-xs text-slate-500">
+                  {wish.userName ?? wish.userId}
+                </td>
+                <td className="px-4 py-3 font-medium text-slate-900">{wish.desiredRoleName}</td>
+                <td className="px-4 py-3 text-slate-600">{wish.desiredAt.slice(0, 10)}</td>
+                <td className="px-4 py-3">
+                  <div className="flex items-center gap-2">
+                    <div className="h-2 w-20 overflow-hidden rounded-full bg-slate-100">
+                      <div className={`h-2 rounded-full ${color}`} style={{ width: `${pct}%` }} />
+                    </div>
+                    <span className="w-8 text-right text-xs font-semibold text-slate-700">
+                      {pct}%
+                    </span>
+                  </div>
+                </td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+function Th({ children }: { readonly children: ReactNode }): ReactElement {
+  return <th className="px-4 py-3 text-left text-xs font-semibold text-slate-700">{children}</th>
+}
+
+function readError(err: unknown): string {
+  if (err instanceof Error) return err.message
+  return '予期せぬエラーが発生しました'
+}

--- a/src/app/career/wish/page.tsx
+++ b/src/app/career/wish/page.tsx
@@ -1,0 +1,313 @@
+/**
+ * Issue #176 / Task 12.1 / Req 5.2, 5.6: キャリア希望登録・表示画面
+ *
+ * - 全ロールアクセス可能（自分の希望のみ登録・閲覧）
+ * - GET /api/career/map/roles でドロップダウン用の役職一覧を取得
+ * - GET /api/career/wishes で現在の希望を取得
+ * - POST /api/career/wishes で新規登録（旧希望は supersededAt で履歴保持）
+ */
+'use client'
+
+import {
+  useCallback,
+  useEffect,
+  useState,
+  type FormEvent,
+  type ReactElement,
+  type ReactNode,
+} from 'react'
+
+interface RoleNode {
+  readonly id: string
+  readonly name: string
+}
+
+interface CareerWish {
+  readonly id: string
+  readonly userId: string
+  readonly desiredRoleId: string
+  readonly desiredRoleName: string
+  readonly desiredAt: string
+  readonly comment: string | null
+  readonly supersededAt: string | null
+  readonly createdAt: string
+}
+
+interface ApiEnvelope<T> {
+  readonly success?: boolean
+  readonly data?: T
+  readonly error?: string
+}
+
+type LoadState =
+  | { readonly kind: 'loading' }
+  | { readonly kind: 'error'; readonly message: string }
+  | {
+      readonly kind: 'ready'
+      readonly roles: readonly RoleNode[]
+      readonly currentWish: CareerWish | null
+    }
+
+type SaveState =
+  | { readonly kind: 'idle' }
+  | { readonly kind: 'saving' }
+  | { readonly kind: 'success' }
+  | { readonly kind: 'error'; readonly message: string }
+
+const ROLES_URL = '/api/career/map/roles'
+const WISHES_URL = '/api/career/wishes'
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const res = await fetch(url, { cache: 'no-store' })
+  const envelope = (await res.json().catch(() => ({}))) as ApiEnvelope<T>
+  if (!res.ok) throw new Error(envelope.error ?? `HTTP ${res.status}`)
+  return (envelope.data ?? null) as T
+}
+
+export default function CareerWishPage(): ReactElement {
+  const [loadState, setLoadState] = useState<LoadState>({ kind: 'loading' })
+  const [saveState, setSaveState] = useState<SaveState>({ kind: 'idle' })
+
+  const [selectedRoleId, setSelectedRoleId] = useState('')
+  const [desiredAt, setDesiredAt] = useState(
+    new Date(Date.now() + 365 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10),
+  )
+  const [comment, setComment] = useState('')
+
+  const loadData = useCallback(async () => {
+    setLoadState({ kind: 'loading' })
+    try {
+      const [roles, currentWish] = await Promise.all([
+        fetchJson<RoleNode[]>(ROLES_URL),
+        fetchJson<CareerWish | null>(WISHES_URL),
+      ])
+      const safeRoles = Array.isArray(roles) ? roles : []
+      setLoadState({ kind: 'ready', roles: safeRoles, currentWish })
+      if (safeRoles.length > 0 && !selectedRoleId) {
+        setSelectedRoleId(safeRoles[0]?.id ?? '')
+      }
+    } catch (err) {
+      setLoadState({ kind: 'error', message: readError(err) })
+    }
+  }, [selectedRoleId])
+
+  useEffect(() => {
+    void loadData()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const handleSubmit = useCallback(
+    async (e: FormEvent) => {
+      e.preventDefault()
+      if (!selectedRoleId) return
+      setSaveState({ kind: 'saving' })
+      try {
+        const res = await fetch(WISHES_URL, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            desiredRoleId: selectedRoleId,
+            desiredAt,
+            comment: comment.trim() || null,
+          }),
+        })
+        const body = (await res.json().catch(() => ({}))) as ApiEnvelope<CareerWish>
+        if (!res.ok) throw new Error(body.error ?? `HTTP ${res.status}`)
+        setSaveState({ kind: 'success' })
+        const newWish = body.data ?? null
+        setLoadState((prev) => {
+          if (prev.kind !== 'ready') return prev
+          return { ...prev, currentWish: newWish }
+        })
+        setTimeout(() => setSaveState({ kind: 'idle' }), 2000)
+      } catch (err) {
+        setSaveState({ kind: 'error', message: readError(err) })
+      }
+    },
+    [selectedRoleId, desiredAt, comment],
+  )
+
+  return (
+    <main className="mx-auto max-w-2xl px-6 py-10">
+      <header className="mb-8">
+        <p className="text-xs font-semibold tracking-widest text-indigo-600 uppercase">Career</p>
+        <h1 className="mt-1 text-3xl font-bold text-slate-900">キャリア希望登録</h1>
+        <p className="mt-2 text-sm text-slate-600">
+          希望する役職と時期を登録します。更新すると旧希望は履歴として保持されます。
+        </p>
+      </header>
+
+      <PageBody
+        loadState={loadState}
+        saveState={saveState}
+        selectedRoleId={selectedRoleId}
+        desiredAt={desiredAt}
+        comment={comment}
+        onRoleChange={setSelectedRoleId}
+        onDesiredAtChange={setDesiredAt}
+        onCommentChange={setComment}
+        onSubmit={handleSubmit}
+      />
+    </main>
+  )
+}
+
+interface PageBodyProps {
+  readonly loadState: LoadState
+  readonly saveState: SaveState
+  readonly selectedRoleId: string
+  readonly desiredAt: string
+  readonly comment: string
+  readonly onRoleChange: (id: string) => void
+  readonly onDesiredAtChange: (v: string) => void
+  readonly onCommentChange: (v: string) => void
+  readonly onSubmit: (e: FormEvent) => void
+}
+
+function PageBody({
+  loadState,
+  saveState,
+  selectedRoleId,
+  desiredAt,
+  comment,
+  onRoleChange,
+  onDesiredAtChange,
+  onCommentChange,
+  onSubmit,
+}: PageBodyProps): ReactElement {
+  if (loadState.kind === 'loading') {
+    return (
+      <div className="flex items-center justify-center rounded-xl border border-slate-200 bg-white py-16 text-sm text-slate-500">
+        <span className="animate-pulse">データを読み込み中…</span>
+      </div>
+    )
+  }
+
+  if (loadState.kind === 'error') {
+    return (
+      <div className="rounded-xl border border-rose-300 bg-rose-50 p-6 text-sm text-rose-800">
+        <p className="font-semibold">データの取得に失敗しました</p>
+        <p className="mt-1 text-xs">{loadState.message}</p>
+      </div>
+    )
+  }
+
+  const { roles, currentWish } = loadState
+  const saving = saveState.kind === 'saving'
+
+  return (
+    <div className="space-y-6">
+      {/* 現在の希望 */}
+      {currentWish && (
+        <div className="rounded-xl border border-indigo-200 bg-indigo-50 p-5">
+          <p className="mb-2 text-xs font-semibold tracking-wide text-indigo-700 uppercase">
+            現在の希望
+          </p>
+          <p className="text-lg font-semibold text-indigo-900">{currentWish.desiredRoleName}</p>
+          <p className="mt-1 text-sm text-indigo-700">
+            希望時期: {currentWish.desiredAt.slice(0, 10)}
+          </p>
+          {currentWish.comment && (
+            <p className="mt-1 text-sm text-indigo-600">{currentWish.comment}</p>
+          )}
+          <p className="mt-2 text-xs text-indigo-400">
+            登録日: {currentWish.createdAt.slice(0, 10)}
+          </p>
+        </div>
+      )}
+
+      {/* 登録フォーム */}
+      <form
+        onSubmit={onSubmit}
+        className="space-y-4 rounded-xl border border-slate-200 bg-white p-6 shadow-sm"
+      >
+        <h2 className="text-sm font-semibold text-slate-800">
+          {currentWish ? '希望を更新する' : '希望を登録する'}
+        </h2>
+
+        <Field label="希望役職" required>
+          <select
+            value={selectedRoleId}
+            onChange={(e) => onRoleChange(e.target.value)}
+            required
+            className={inputCls}
+          >
+            {roles.map((r) => (
+              <option key={r.id} value={r.id}>
+                {r.name}
+              </option>
+            ))}
+          </select>
+        </Field>
+
+        <Field label="希望時期" required>
+          <input
+            type="date"
+            value={desiredAt}
+            onChange={(e) => onDesiredAtChange(e.target.value)}
+            required
+            className={inputCls}
+          />
+        </Field>
+
+        <Field label="コメント（任意）">
+          <textarea
+            value={comment}
+            onChange={(e) => onCommentChange(e.target.value)}
+            rows={3}
+            placeholder="希望の背景や意気込みを記入（任意）"
+            className={`${inputCls} resize-none`}
+          />
+        </Field>
+
+        <div className="flex items-center gap-3 border-t border-slate-100 pt-2">
+          <button
+            type="submit"
+            disabled={saving || !selectedRoleId}
+            className="rounded-md bg-indigo-600 px-5 py-2 text-sm font-semibold text-white hover:bg-indigo-700 disabled:cursor-not-allowed disabled:bg-slate-300"
+          >
+            {saving ? '登録中…' : currentWish ? '更新する' : '登録する'}
+          </button>
+          {saveState.kind === 'success' && (
+            <span className="text-sm font-medium text-emerald-600">✓ 登録しました</span>
+          )}
+          {saveState.kind === 'error' && (
+            <span className="text-sm font-medium text-rose-600">
+              登録に失敗: {saveState.message}
+            </span>
+          )}
+        </div>
+
+        {currentWish && (
+          <p className="text-xs text-slate-400">※ 更新すると現在の希望は履歴として保持されます。</p>
+        )}
+      </form>
+    </div>
+  )
+}
+
+const inputCls =
+  'block w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500'
+
+interface FieldProps {
+  readonly label: string
+  readonly required?: boolean
+  readonly children: ReactNode
+}
+
+function Field({ label, required = false, children }: FieldProps): ReactElement {
+  return (
+    <div className="space-y-1">
+      <label className="block text-xs font-medium text-slate-700">
+        {label}
+        {required && <span className="ml-1 text-rose-500">*</span>}
+      </label>
+      {children}
+    </div>
+  )
+}
+
+function readError(err: unknown): string {
+  if (err instanceof Error) return err.message
+  return '予期せぬエラーが発生しました'
+}


### PR DESCRIPTION
## Summary

- `src/app/career/wish/page.tsx` — キャリア希望登録画面（Task 12.1 / Req 5.2, 5.6）: 現在の希望表示 + 希望役職・時期・コメントを登録、更新時は旧希望を履歴保持
- `src/app/career/map/page.tsx` — キャリアマップ/ギャップ表示画面（Task 12.2 / Req 5.1, 5.3, 5.4）: 役職一覧カード表示、希望役職選択によるスキルギャップ計算、MANAGER+向け部下の希望一覧
- `src/app/career/aggregate/page.tsx` — 組織全体キャリア希望集計画面（Task 12.3 / Req 5.5）: HR_MANAGER向け総希望件数・希望分布テーブル・充足率不足ロール TOP 表示

## Related Issue

Closes #176

## Test plan

- [ ] `/career/wish` にアクセスし、希望登録フォームが表示されること
- [ ] 役職ドロップダウンに全役職が表示されること
- [ ] 希望を登録後、「現在の希望」カードが更新されること
- [ ] `/career/map` にアクセスし、役職一覧カードが表示されること
- [ ] 希望役職を選択して「ギャップを確認」押下でスキルギャップ表が表示されること
- [ ] EMPLOYEE ロールで「部下のキャリア希望」セクションが非表示になること（403 → hidden）
- [ ] MANAGER ロールで部下の希望一覧が表示されること
- [ ] `/career/aggregate` にアクセスし、サマリーカード・充足率不足 TOP・分布テーブルが表示されること
- [ ] `pnpm tsc --noEmit` がエラーなしで完了すること