### PR TITLE
feat: ISSUE #177 — 目標管理画面の実装 (Task 13.1〜13.3)

### DIFF
--- a/src/app/goals/personal/page.tsx
+++ b/src/app/goals/personal/page.tsx
@@ -1,0 +1,515 @@
+/**
+ * Issue #177 / Task 13.2 / Req 6.3, 6.4, 6.5: 個人目標登録・上長承認画面
+ *
+ * - 全ロールアクセス可能（自分の目標）
+ * - GET  /api/goals/personal              → 自分の目標一覧
+ * - POST /api/goals/personal              → 目標新規作成
+ * - POST /api/goals/personal/[id]/submit  → DRAFT→PENDING_APPROVAL
+ * - POST /api/goals/personal/[id]/approve → PENDING_APPROVAL→APPROVED (MANAGER+)
+ * - POST /api/goals/personal/[id]/reject  → PENDING_APPROVAL→REJECTED (MANAGER+)
+ */
+'use client'
+
+import { useEffect, useState, type ReactElement, type FormEvent, type ChangeEvent } from 'react'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+type GoalType = 'OKR' | 'MBO'
+type GoalStatus =
+  | 'DRAFT'
+  | 'PENDING_APPROVAL'
+  | 'APPROVED'
+  | 'REJECTED'
+  | 'IN_PROGRESS'
+  | 'COMPLETED'
+
+interface PersonalGoal {
+  readonly id: string
+  readonly title: string
+  readonly description: string | null
+  readonly goalType: GoalType
+  readonly keyResult: string | null
+  readonly targetValue: number | null
+  readonly unit: string | null
+  readonly status: GoalStatus
+  readonly parentOrgGoalId: string | null
+  readonly startDate: string
+  readonly endDate: string
+  readonly rejectedReason: string | null
+}
+
+interface ApiEnvelope<T> {
+  readonly success?: boolean
+  readonly data?: T
+  readonly error?: string
+}
+
+type PageState =
+  | { readonly kind: 'loading' }
+  | { readonly kind: 'error'; readonly message: string }
+  | { readonly kind: 'ready'; readonly goals: readonly PersonalGoal[] }
+
+interface FormValues {
+  title: string
+  description: string
+  goalType: GoalType
+  keyResult: string
+  targetValue: string
+  unit: string
+  parentOrgGoalId: string
+  startDate: string
+  endDate: string
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Constants
+// ─────────────────────────────────────────────────────────────────────────────
+
+const PERSONAL_URL = '/api/goals/personal'
+
+const STATUS_LABELS: Record<GoalStatus, string> = {
+  DRAFT: '下書き',
+  PENDING_APPROVAL: '承認待ち',
+  APPROVED: '承認済',
+  REJECTED: '差戻し',
+  IN_PROGRESS: '進行中',
+  COMPLETED: '完了',
+}
+
+const STATUS_COLORS: Record<GoalStatus, string> = {
+  DRAFT: 'bg-slate-100 text-slate-600',
+  PENDING_APPROVAL: 'bg-amber-100 text-amber-700',
+  APPROVED: 'bg-emerald-100 text-emerald-700',
+  REJECTED: 'bg-rose-100 text-rose-700',
+  IN_PROGRESS: 'bg-blue-100 text-blue-700',
+  COMPLETED: 'bg-indigo-100 text-indigo-700',
+}
+
+const EMPTY_FORM: FormValues = {
+  title: '',
+  description: '',
+  goalType: 'OKR',
+  keyResult: '',
+  targetValue: '',
+  unit: '',
+  parentOrgGoalId: '',
+  startDate: '',
+  endDate: '',
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function fetchJson<T>(url: string, options?: RequestInit): Promise<T> {
+  const res = await fetch(url, { cache: 'no-store', ...options })
+  const envelope = (await res.json().catch(() => ({}))) as ApiEnvelope<T>
+  if (!res.ok) throw new Error(envelope.error ?? `HTTP ${res.status}`)
+  return (envelope.data ?? null) as T
+}
+
+function readError(err: unknown): string {
+  if (err instanceof Error) return err.message
+  return '予期せぬエラーが発生しました'
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Page
+// ─────────────────────────────────────────────────────────────────────────────
+
+export default function PersonalGoalPage(): ReactElement {
+  const [state, setState] = useState<PageState>({ kind: 'loading' })
+  const [showForm, setShowForm] = useState(false)
+  const [form, setForm] = useState<FormValues>(EMPTY_FORM)
+  const [submitting, setSubmitting] = useState(false)
+  const [actionError, setActionError] = useState<string | null>(null)
+
+  async function loadGoals(): Promise<void> {
+    setState({ kind: 'loading' })
+    try {
+      const goals = await fetchJson<PersonalGoal[]>(PERSONAL_URL)
+      setState({ kind: 'ready', goals: Array.isArray(goals) ? goals : [] })
+    } catch (err) {
+      setState({ kind: 'error', message: readError(err) })
+    }
+  }
+
+  useEffect(() => {
+    void loadGoals()
+  }, [])
+
+  async function handleCreate(e: FormEvent): Promise<void> {
+    e.preventDefault()
+    setSubmitting(true)
+    setActionError(null)
+    try {
+      await fetchJson(PERSONAL_URL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          title: form.title,
+          description: form.description || undefined,
+          goalType: form.goalType,
+          keyResult: form.keyResult || undefined,
+          targetValue: form.targetValue ? Number(form.targetValue) : undefined,
+          unit: form.unit || undefined,
+          parentOrgGoalId: form.parentOrgGoalId || undefined,
+          startDate: form.startDate,
+          endDate: form.endDate,
+        }),
+      })
+      setForm(EMPTY_FORM)
+      setShowForm(false)
+      await loadGoals()
+    } catch (err) {
+      setActionError(readError(err))
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  async function handleAction(
+    goalId: string,
+    action: 'submit' | 'approve' | 'reject',
+  ): Promise<void> {
+    setActionError(null)
+    try {
+      await fetchJson(`${PERSONAL_URL}/${goalId}/${action}`, { method: 'POST' })
+      await loadGoals()
+    } catch (err) {
+      setActionError(readError(err))
+    }
+  }
+
+  return (
+    <main className="mx-auto max-w-4xl px-6 py-10">
+      <header className="mb-8 flex items-start justify-between gap-4">
+        <div>
+          <p className="text-xs font-semibold tracking-widest text-indigo-600 uppercase">Goals</p>
+          <h1 className="mt-1 text-3xl font-bold text-slate-900">個人目標</h1>
+          <p className="mt-2 text-sm text-slate-600">目標の登録・申請・承認を行います。</p>
+        </div>
+        <button
+          type="button"
+          onClick={() => setShowForm((v) => !v)}
+          className="shrink-0 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700"
+        >
+          {showForm ? 'キャンセル' : '＋ 目標を追加'}
+        </button>
+      </header>
+
+      {actionError && (
+        <div className="mb-4 rounded-lg border border-rose-300 bg-rose-50 p-3 text-sm text-rose-800">
+          {actionError}
+        </div>
+      )}
+
+      {showForm && (
+        <GoalForm form={form} onChange={setForm} onSubmit={handleCreate} submitting={submitting} />
+      )}
+
+      <GoalList state={state} onAction={handleAction} />
+    </main>
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GoalForm
+// ─────────────────────────────────────────────────────────────────────────────
+
+function GoalForm({
+  form,
+  onChange,
+  onSubmit,
+  submitting,
+}: {
+  readonly form: FormValues
+  readonly onChange: (v: FormValues) => void
+  readonly onSubmit: (e: FormEvent) => void
+  readonly submitting: boolean
+}): ReactElement {
+  function field(key: keyof FormValues) {
+    return (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) =>
+      onChange({ ...form, [key]: e.target.value })
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="mb-8 rounded-xl border border-indigo-200 bg-indigo-50 p-6">
+      <h2 className="mb-4 font-semibold text-slate-800">新規目標登録</h2>
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="sm:col-span-2">
+          <label className="mb-1 block text-xs font-medium text-slate-600">
+            タイトル <span className="text-rose-500">*</span>
+          </label>
+          <input
+            required
+            maxLength={200}
+            value={form.title}
+            onChange={field('title')}
+            placeholder="目標タイトルを入力"
+            className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-indigo-400 focus:outline-none"
+          />
+        </div>
+
+        <div className="sm:col-span-2">
+          <label className="mb-1 block text-xs font-medium text-slate-600">説明</label>
+          <textarea
+            rows={2}
+            value={form.description}
+            onChange={field('description')}
+            placeholder="目標の詳細・背景"
+            className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-indigo-400 focus:outline-none"
+          />
+        </div>
+
+        <div>
+          <label className="mb-1 block text-xs font-medium text-slate-600">目標タイプ</label>
+          <select
+            value={form.goalType}
+            onChange={field('goalType')}
+            className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-indigo-400 focus:outline-none"
+          >
+            <option value="OKR">OKR</option>
+            <option value="MBO">MBO</option>
+          </select>
+        </div>
+
+        <div>
+          <label className="mb-1 block text-xs font-medium text-slate-600">
+            {form.goalType === 'OKR' ? 'Key Result' : '目標値'}
+          </label>
+          {form.goalType === 'OKR' ? (
+            <input
+              value={form.keyResult}
+              onChange={field('keyResult')}
+              placeholder="成功指標を入力"
+              className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-indigo-400 focus:outline-none"
+            />
+          ) : (
+            <div className="flex gap-2">
+              <input
+                type="number"
+                min={0}
+                value={form.targetValue}
+                onChange={field('targetValue')}
+                placeholder="数値"
+                className="w-24 rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-indigo-400 focus:outline-none"
+              />
+              <input
+                value={form.unit}
+                onChange={field('unit')}
+                placeholder="単位"
+                className="flex-1 rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-indigo-400 focus:outline-none"
+              />
+            </div>
+          )}
+        </div>
+
+        <div>
+          <label className="mb-1 block text-xs font-medium text-slate-600">
+            開始日 <span className="text-rose-500">*</span>
+          </label>
+          <input
+            required
+            type="date"
+            value={form.startDate}
+            onChange={field('startDate')}
+            className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-indigo-400 focus:outline-none"
+          />
+        </div>
+
+        <div>
+          <label className="mb-1 block text-xs font-medium text-slate-600">
+            終了日 <span className="text-rose-500">*</span>
+          </label>
+          <input
+            required
+            type="date"
+            value={form.endDate}
+            onChange={field('endDate')}
+            className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-indigo-400 focus:outline-none"
+          />
+        </div>
+
+        <div className="sm:col-span-2">
+          <label className="mb-1 block text-xs font-medium text-slate-600">
+            関連組織目標 ID（任意）
+          </label>
+          <input
+            value={form.parentOrgGoalId}
+            onChange={field('parentOrgGoalId')}
+            placeholder="組織目標IDを貼り付け"
+            className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-indigo-400 focus:outline-none"
+          />
+        </div>
+      </div>
+
+      <div className="mt-4 flex justify-end">
+        <button
+          type="submit"
+          disabled={submitting}
+          className="rounded-lg bg-indigo-600 px-5 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
+        >
+          {submitting ? '登録中…' : '登録する'}
+        </button>
+      </div>
+    </form>
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GoalList
+// ─────────────────────────────────────────────────────────────────────────────
+
+function GoalList({
+  state,
+  onAction,
+}: {
+  readonly state: PageState
+  readonly onAction: (goalId: string, action: 'submit' | 'approve' | 'reject') => void
+}): ReactElement {
+  if (state.kind === 'loading') {
+    return (
+      <div className="flex items-center justify-center rounded-xl border border-slate-200 bg-white py-16 text-sm text-slate-500">
+        <span className="animate-pulse">データを読み込み中…</span>
+      </div>
+    )
+  }
+  if (state.kind === 'error') {
+    return (
+      <div className="rounded-xl border border-rose-300 bg-rose-50 p-6 text-sm text-rose-800">
+        <p className="font-semibold">データの取得に失敗しました</p>
+        <p className="mt-1 text-xs">{state.message}</p>
+      </div>
+    )
+  }
+  if (state.goals.length === 0) {
+    return (
+      <div className="rounded-xl border border-slate-200 bg-white py-16 text-center text-sm text-slate-400">
+        目標が登録されていません
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-3">
+      {state.goals.map((g) => (
+        <GoalCard key={g.id} goal={g} onAction={onAction} />
+      ))}
+    </div>
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GoalCard
+// ─────────────────────────────────────────────────────────────────────────────
+
+function GoalCard({
+  goal,
+  onAction,
+}: {
+  readonly goal: PersonalGoal
+  readonly onAction: (goalId: string, action: 'submit' | 'approve' | 'reject') => void
+}): ReactElement {
+  return (
+    <div className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <span
+              className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${STATUS_COLORS[goal.status]}`}
+            >
+              {STATUS_LABELS[goal.status]}
+            </span>
+            <span
+              className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${
+                goal.goalType === 'OKR'
+                  ? 'bg-emerald-100 text-emerald-700'
+                  : 'bg-amber-100 text-amber-700'
+              }`}
+            >
+              {goal.goalType}
+            </span>
+          </div>
+
+          <p className="mt-1 font-semibold text-slate-900">{goal.title}</p>
+
+          {goal.description && <p className="mt-0.5 text-xs text-slate-500">{goal.description}</p>}
+
+          {goal.keyResult && (
+            <p className="mt-1 text-xs text-slate-600">
+              <span className="font-medium">KR:</span> {goal.keyResult}
+            </p>
+          )}
+
+          {goal.targetValue !== null && (
+            <p className="mt-0.5 text-xs text-slate-500">
+              目標値: {goal.targetValue} {goal.unit ?? ''}
+            </p>
+          )}
+
+          {goal.rejectedReason && (
+            <p className="mt-1 rounded bg-rose-50 px-2 py-1 text-xs text-rose-700">
+              差戻し理由: {goal.rejectedReason}
+            </p>
+          )}
+
+          <p className="mt-1 text-xs text-slate-400">
+            {goal.startDate.slice(0, 10)} 〜 {goal.endDate.slice(0, 10)}
+          </p>
+        </div>
+
+        <ActionButtons goal={goal} onAction={onAction} />
+      </div>
+    </div>
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ActionButtons
+// ─────────────────────────────────────────────────────────────────────────────
+
+function ActionButtons({
+  goal,
+  onAction,
+}: {
+  readonly goal: PersonalGoal
+  readonly onAction: (goalId: string, action: 'submit' | 'approve' | 'reject') => void
+}): ReactElement | null {
+  if (goal.status === 'DRAFT') {
+    return (
+      <button
+        type="button"
+        onClick={() => onAction(goal.id, 'submit')}
+        className="shrink-0 rounded-md border border-indigo-300 bg-indigo-50 px-3 py-1.5 text-xs font-medium text-indigo-700 hover:bg-indigo-100"
+      >
+        承認申請
+      </button>
+    )
+  }
+
+  if (goal.status === 'PENDING_APPROVAL') {
+    return (
+      <div className="flex shrink-0 gap-2">
+        <button
+          type="button"
+          onClick={() => onAction(goal.id, 'approve')}
+          className="rounded-md border border-emerald-300 bg-emerald-50 px-3 py-1.5 text-xs font-medium text-emerald-700 hover:bg-emerald-100"
+        >
+          承認
+        </button>
+        <button
+          type="button"
+          onClick={() => onAction(goal.id, 'reject')}
+          className="rounded-md border border-rose-300 bg-rose-50 px-3 py-1.5 text-xs font-medium text-rose-700 hover:bg-rose-100"
+        >
+          差戻し
+        </button>
+      </div>
+    )
+  }
+
+  return null
+}

--- a/src/app/goals/progress/page.tsx
+++ b/src/app/goals/progress/page.tsx
@@ -1,0 +1,446 @@
+/**
+ * Issue #177 / Task 13.3 / Req 6.6, 6.7: 進捗更新・部下目標一覧画面
+ *
+ * - 全ロールアクセス可能（自分の進捗更新）
+ * - GET  /api/goals/personal                   → 自分の目標一覧（APPROVED/IN_PROGRESS）
+ * - POST /api/goals/personal/[id]/progress     → 進捗記録（progressRate + comment）
+ * - GET  /api/goals/subordinates               → 部下の目標一覧（MANAGER+、403は非表示）
+ */
+'use client'
+
+import { useEffect, useState, type ReactElement, type FormEvent, type ChangeEvent } from 'react'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+type GoalStatus =
+  | 'DRAFT'
+  | 'PENDING_APPROVAL'
+  | 'APPROVED'
+  | 'REJECTED'
+  | 'IN_PROGRESS'
+  | 'COMPLETED'
+
+interface PersonalGoal {
+  readonly id: string
+  readonly title: string
+  readonly status: GoalStatus
+  readonly goalType: 'OKR' | 'MBO'
+  readonly startDate: string
+  readonly endDate: string
+}
+
+interface GoalProgressRecord {
+  readonly id: string
+  readonly goalId: string
+  readonly progressRate: number
+  readonly comment: string | null
+  readonly recordedBy: string
+  readonly recordedAt: string
+}
+
+interface SubordinateGoalSummary {
+  readonly userId: string
+  readonly goalId: string
+  readonly title: string
+  readonly status: string
+  readonly currentProgressRate: number
+  readonly endDate: string
+}
+
+interface ApiEnvelope<T> {
+  readonly success?: boolean
+  readonly data?: T
+  readonly error?: string
+}
+
+type GoalsState =
+  | { readonly kind: 'loading' }
+  | { readonly kind: 'error'; readonly message: string }
+  | { readonly kind: 'ready'; readonly goals: readonly PersonalGoal[] }
+
+type SubordinatesState =
+  | { readonly kind: 'loading' }
+  | { readonly kind: 'hidden' }
+  | { readonly kind: 'error'; readonly message: string }
+  | { readonly kind: 'ready'; readonly items: readonly SubordinateGoalSummary[] }
+
+interface ProgressFormValues {
+  progressRate: string
+  comment: string
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Constants
+// ─────────────────────────────────────────────────────────────────────────────
+
+const PERSONAL_URL = '/api/goals/personal'
+const SUBORDINATES_URL = '/api/goals/subordinates'
+
+const STATUS_LABELS: Record<GoalStatus, string> = {
+  DRAFT: '下書き',
+  PENDING_APPROVAL: '承認待ち',
+  APPROVED: '承認済',
+  REJECTED: '差戻し',
+  IN_PROGRESS: '進行中',
+  COMPLETED: '完了',
+}
+
+const ACTIVE_STATUSES: readonly GoalStatus[] = ['APPROVED', 'IN_PROGRESS']
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function fetchJson<T>(url: string, options?: RequestInit): Promise<T> {
+  const res = await fetch(url, { cache: 'no-store', ...options })
+  const envelope = (await res.json().catch(() => ({}))) as ApiEnvelope<T>
+  if (!res.ok) throw new Error(envelope.error ?? `HTTP ${res.status}`)
+  return (envelope.data ?? null) as T
+}
+
+function readError(err: unknown): string {
+  if (err instanceof Error) return err.message
+  return '予期せぬエラーが発生しました'
+}
+
+function isForbidden(err: unknown): boolean {
+  if (err instanceof Error) {
+    const msg = err.message.toLowerCase()
+    return msg.includes('403') || msg.includes('forbidden') || msg.includes('権限')
+  }
+  return false
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Page
+// ─────────────────────────────────────────────────────────────────────────────
+
+export default function GoalProgressPage(): ReactElement {
+  const [goalsState, setGoalsState] = useState<GoalsState>({ kind: 'loading' })
+  const [subState, setSubState] = useState<SubordinatesState>({ kind: 'loading' })
+
+  useEffect(() => {
+    void (async () => {
+      try {
+        const goals = await fetchJson<PersonalGoal[]>(PERSONAL_URL)
+        const filtered = Array.isArray(goals)
+          ? goals.filter((g) => ACTIVE_STATUSES.includes(g.status))
+          : []
+        setGoalsState({ kind: 'ready', goals: filtered })
+      } catch (err) {
+        setGoalsState({ kind: 'error', message: readError(err) })
+      }
+    })()
+
+    void (async () => {
+      try {
+        const items = await fetchJson<SubordinateGoalSummary[]>(SUBORDINATES_URL)
+        setSubState({ kind: 'ready', items: Array.isArray(items) ? items : [] })
+      } catch (err) {
+        if (isForbidden(err)) {
+          setSubState({ kind: 'hidden' })
+        } else {
+          setSubState({ kind: 'error', message: readError(err) })
+        }
+      }
+    })()
+  }, [])
+
+  return (
+    <main className="mx-auto max-w-4xl px-6 py-10">
+      <header className="mb-8">
+        <p className="text-xs font-semibold tracking-widest text-indigo-600 uppercase">Goals</p>
+        <h1 className="mt-1 text-3xl font-bold text-slate-900">進捗管理</h1>
+        <p className="mt-2 text-sm text-slate-600">
+          承認済み目標の進捗を記録し、部下の状況を確認できます。
+        </p>
+      </header>
+
+      <section className="mb-10">
+        <h2 className="mb-4 text-lg font-semibold text-slate-800">自分の目標進捗</h2>
+        <MyGoalsSection state={goalsState} />
+      </section>
+
+      {subState.kind !== 'hidden' && (
+        <section>
+          <h2 className="mb-4 text-lg font-semibold text-slate-800">部下の目標一覧</h2>
+          <SubordinatesSection state={subState} />
+        </section>
+      )}
+    </main>
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// MyGoalsSection
+// ─────────────────────────────────────────────────────────────────────────────
+
+function MyGoalsSection({ state }: { readonly state: GoalsState }): ReactElement {
+  if (state.kind === 'loading') {
+    return (
+      <div className="flex items-center justify-center rounded-xl border border-slate-200 bg-white py-12 text-sm text-slate-500">
+        <span className="animate-pulse">読み込み中…</span>
+      </div>
+    )
+  }
+  if (state.kind === 'error') {
+    return (
+      <div className="rounded-xl border border-rose-300 bg-rose-50 p-5 text-sm text-rose-800">
+        <p className="font-semibold">データの取得に失敗しました</p>
+        <p className="mt-1 text-xs">{state.message}</p>
+      </div>
+    )
+  }
+  if (state.goals.length === 0) {
+    return (
+      <div className="rounded-xl border border-slate-200 bg-white py-12 text-center text-sm text-slate-400">
+        進捗を記録できる目標がありません（承認済 / 進行中の目標が対象です）
+      </div>
+    )
+  }
+  return (
+    <div className="space-y-4">
+      {state.goals.map((g) => (
+        <GoalProgressCard key={g.id} goal={g} />
+      ))}
+    </div>
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GoalProgressCard
+// ─────────────────────────────────────────────────────────────────────────────
+
+function GoalProgressCard({ goal }: { readonly goal: PersonalGoal }): ReactElement {
+  const [form, setForm] = useState<ProgressFormValues>({ progressRate: '', comment: '' })
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [history, setHistory] = useState<readonly GoalProgressRecord[] | null>(null)
+  const [loadingHistory, setLoadingHistory] = useState(false)
+  const [showHistory, setShowHistory] = useState(false)
+
+  async function handleSubmit(e: FormEvent): Promise<void> {
+    e.preventDefault()
+    if (!form.progressRate) return
+    setSubmitting(true)
+    setError(null)
+    try {
+      await fetchJson(`${PERSONAL_URL}/${goal.id}/progress`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          progressRate: Number(form.progressRate),
+          comment: form.comment || undefined,
+        }),
+      })
+      setForm({ progressRate: '', comment: '' })
+      if (showHistory) {
+        await loadHistory()
+      }
+    } catch (err) {
+      setError(readError(err))
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  async function loadHistory(): Promise<void> {
+    setLoadingHistory(true)
+    try {
+      const records = await fetchJson<GoalProgressRecord[]>(`${PERSONAL_URL}/${goal.id}/progress`)
+      setHistory(Array.isArray(records) ? records : [])
+    } catch (err) {
+      setError(readError(err))
+    } finally {
+      setLoadingHistory(false)
+    }
+  }
+
+  async function toggleHistory(): Promise<void> {
+    const next = !showHistory
+    setShowHistory(next)
+    if (next && history === null) {
+      await loadHistory()
+    }
+  }
+
+  const rate = Number(form.progressRate)
+  const validRate = form.progressRate !== '' && rate >= 0 && rate <= 100
+
+  return (
+    <div className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+      <div className="mb-4 flex flex-wrap items-start justify-between gap-2">
+        <div>
+          <p className="font-semibold text-slate-900">{goal.title}</p>
+          <p className="mt-0.5 text-xs text-slate-400">
+            <span
+              className={`mr-2 inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${
+                goal.goalType === 'OKR'
+                  ? 'bg-emerald-100 text-emerald-700'
+                  : 'bg-amber-100 text-amber-700'
+              }`}
+            >
+              {goal.goalType}
+            </span>
+            {STATUS_LABELS[goal.status]} · {goal.startDate.slice(0, 10)} 〜{' '}
+            {goal.endDate.slice(0, 10)}
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => void toggleHistory()}
+          className="text-xs text-indigo-600 hover:underline"
+        >
+          {showHistory ? '履歴を隠す' : '履歴を見る'}
+        </button>
+      </div>
+
+      <form onSubmit={handleSubmit} className="flex flex-wrap items-end gap-3">
+        <div>
+          <label className="mb-1 block text-xs font-medium text-slate-600">進捗率 (0–100)</label>
+          <div className="flex items-center gap-1">
+            <input
+              type="number"
+              min={0}
+              max={100}
+              value={form.progressRate}
+              onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                setForm((v) => ({ ...v, progressRate: e.target.value }))
+              }
+              placeholder="75"
+              className="w-20 rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-indigo-400 focus:outline-none"
+            />
+            <span className="text-sm text-slate-500">%</span>
+          </div>
+        </div>
+
+        <div className="min-w-48 flex-1">
+          <label className="mb-1 block text-xs font-medium text-slate-600">コメント（任意）</label>
+          <input
+            maxLength={1000}
+            value={form.comment}
+            onChange={(e: ChangeEvent<HTMLInputElement>) =>
+              setForm((v) => ({ ...v, comment: e.target.value }))
+            }
+            placeholder="進捗メモを入力"
+            className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-indigo-400 focus:outline-none"
+          />
+        </div>
+
+        <button
+          type="submit"
+          disabled={submitting || !validRate}
+          className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-40"
+        >
+          {submitting ? '記録中…' : '記録'}
+        </button>
+      </form>
+
+      {error && <p className="mt-2 text-xs text-rose-600">{error}</p>}
+
+      {showHistory && (
+        <div className="mt-4 border-t border-slate-100 pt-4">
+          {loadingHistory ? (
+            <p className="animate-pulse text-xs text-slate-400">履歴を読み込み中…</p>
+          ) : history === null || history.length === 0 ? (
+            <p className="text-xs text-slate-400">記録がありません</p>
+          ) : (
+            <ul className="space-y-2">
+              {history.map((r) => (
+                <li key={r.id} className="flex items-start gap-3 text-xs text-slate-600">
+                  <span className="shrink-0 font-semibold text-indigo-600">{r.progressRate}%</span>
+                  <span className="flex-1">{r.comment ?? '—'}</span>
+                  <span className="shrink-0 text-slate-400">{r.recordedAt.slice(0, 10)}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SubordinatesSection
+// ─────────────────────────────────────────────────────────────────────────────
+
+function SubordinatesSection({ state }: { readonly state: SubordinatesState }): ReactElement {
+  if (state.kind === 'loading') {
+    return (
+      <div className="flex items-center justify-center rounded-xl border border-slate-200 bg-white py-12 text-sm text-slate-500">
+        <span className="animate-pulse">読み込み中…</span>
+      </div>
+    )
+  }
+  if (state.kind === 'error') {
+    return (
+      <div className="rounded-xl border border-rose-300 bg-rose-50 p-5 text-sm text-rose-800">
+        <p className="font-semibold">データの取得に失敗しました</p>
+        <p className="mt-1 text-xs">{state.message}</p>
+      </div>
+    )
+  }
+  // state.kind === 'ready' at this point (loading/error/hidden already returned above)
+  if (state.kind !== 'ready' || state.items.length === 0) {
+    return (
+      <div className="rounded-xl border border-slate-200 bg-white py-12 text-center text-sm text-slate-400">
+        部下の目標データがありません
+      </div>
+    )
+  }
+
+  return (
+    <div className="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
+      <table className="w-full text-sm">
+        <thead className="border-b border-slate-200 bg-slate-50">
+          <tr>
+            <th className="px-4 py-3 text-left text-xs font-medium text-slate-500">目標タイトル</th>
+            <th className="px-4 py-3 text-left text-xs font-medium text-slate-500">ステータス</th>
+            <th className="px-4 py-3 text-left text-xs font-medium text-slate-500">進捗率</th>
+            <th className="px-4 py-3 text-left text-xs font-medium text-slate-500">期限</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-slate-100">
+          {state.items.map((item) => (
+            <SubordinateRow key={item.goalId} item={item} />
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SubordinateRow
+// ─────────────────────────────────────────────────────────────────────────────
+
+function SubordinateRow({ item }: { readonly item: SubordinateGoalSummary }): ReactElement {
+  const pct = Math.min(100, Math.max(0, item.currentProgressRate))
+
+  return (
+    <tr className="hover:bg-slate-50">
+      <td className="px-4 py-3 font-medium text-slate-800">{item.title}</td>
+      <td className="px-4 py-3">
+        <span className="inline-flex items-center rounded-full bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-600">
+          {item.status}
+        </span>
+      </td>
+      <td className="px-4 py-3">
+        <div className="flex items-center gap-2">
+          <div className="h-2 w-24 overflow-hidden rounded-full bg-slate-200">
+            <div className="h-full rounded-full bg-indigo-500" style={{ width: `${pct}%` }} />
+          </div>
+          <span className="text-xs text-slate-600 tabular-nums">{pct}%</span>
+        </div>
+      </td>
+      <td className="px-4 py-3 text-xs text-slate-500">
+        {typeof item.endDate === 'string'
+          ? item.endDate.slice(0, 10)
+          : new Date(item.endDate).toISOString().slice(0, 10)}
+      </td>
+    </tr>
+  )
+}

--- a/src/app/goals/tree/page.tsx
+++ b/src/app/goals/tree/page.tsx
@@ -1,0 +1,204 @@
+/**
+ * Issue #177 / Task 13.1 / Req 6.1, 6.2: 多階層組織目標ツリー画面
+ *
+ * - 全ロールアクセス可能（参照）
+ * - GET /api/goals/org?tree=1 で組織目標ツリーを取得
+ */
+'use client'
+
+import { useEffect, useState, type ReactElement } from 'react'
+
+type GoalType = 'OKR' | 'MBO'
+type GoalOwnerType = 'ORGANIZATION' | 'DEPARTMENT' | 'TEAM'
+
+interface OrgGoalTree {
+  readonly id: string
+  readonly parentId: string | null
+  readonly ownerType: GoalOwnerType
+  readonly ownerId: string
+  readonly title: string
+  readonly description: string | null
+  readonly goalType: GoalType
+  readonly keyResult: string | null
+  readonly targetValue: number | null
+  readonly unit: string | null
+  readonly startDate: string
+  readonly endDate: string
+  readonly children: OrgGoalTree[]
+}
+
+interface ApiEnvelope<T> {
+  readonly success?: boolean
+  readonly data?: T
+  readonly error?: string
+}
+
+type TreeState =
+  | { readonly kind: 'loading' }
+  | { readonly kind: 'error'; readonly message: string }
+  | { readonly kind: 'ready'; readonly roots: readonly OrgGoalTree[] }
+
+const ORG_URL = '/api/goals/org'
+
+const OWNER_TYPE_LABELS: Record<GoalOwnerType, string> = {
+  ORGANIZATION: '組織',
+  DEPARTMENT: '部門',
+  TEAM: 'チーム',
+}
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const res = await fetch(url, { cache: 'no-store' })
+  const envelope = (await res.json().catch(() => ({}))) as ApiEnvelope<T>
+  if (!res.ok) throw new Error(envelope.error ?? `HTTP ${res.status}`)
+  return (envelope.data ?? []) as T
+}
+
+export default function GoalTreePage(): ReactElement {
+  const [state, setState] = useState<TreeState>({ kind: 'loading' })
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const roots = await fetchJson<OrgGoalTree[]>(`${ORG_URL}?tree=1`)
+        const safeRoots = Array.isArray(roots) ? roots : []
+        setState({ kind: 'ready', roots: safeRoots })
+      } catch (err) {
+        setState({ kind: 'error', message: readError(err) })
+      }
+    }
+    void load()
+  }, [])
+
+  return (
+    <main className="mx-auto max-w-5xl px-6 py-10">
+      <header className="mb-8">
+        <p className="text-xs font-semibold tracking-widest text-indigo-600 uppercase">Goals</p>
+        <h1 className="mt-1 text-3xl font-bold text-slate-900">組織目標ツリー</h1>
+        <p className="mt-2 text-sm text-slate-600">
+          組織→部門→チームの多階層で設定された目標を確認できます。
+        </p>
+      </header>
+
+      <TreeBody state={state} />
+    </main>
+  )
+}
+
+function TreeBody({ state }: { readonly state: TreeState }): ReactElement {
+  if (state.kind === 'loading') {
+    return (
+      <div className="flex items-center justify-center rounded-xl border border-slate-200 bg-white py-16 text-sm text-slate-500">
+        <span className="animate-pulse">データを読み込み中…</span>
+      </div>
+    )
+  }
+  if (state.kind === 'error') {
+    return (
+      <div className="rounded-xl border border-rose-300 bg-rose-50 p-6 text-sm text-rose-800">
+        <p className="font-semibold">データの取得に失敗しました</p>
+        <p className="mt-1 text-xs">{state.message}</p>
+      </div>
+    )
+  }
+  if (state.roots.length === 0) {
+    return (
+      <div className="rounded-xl border border-slate-200 bg-white py-16 text-center text-sm text-slate-400">
+        組織目標が登録されていません
+      </div>
+    )
+  }
+  return (
+    <div className="space-y-3">
+      {state.roots.map((root) => (
+        <GoalTreeNode key={root.id} node={root} depth={0} />
+      ))}
+    </div>
+  )
+}
+
+function GoalTreeNode({
+  node,
+  depth,
+}: {
+  readonly node: OrgGoalTree
+  readonly depth: number
+}): ReactElement {
+  const [expanded, setExpanded] = useState(depth < 2)
+  const hasChildren = node.children.length > 0
+  const indentCls = depth === 0 ? '' : depth === 1 ? 'ml-6' : 'ml-12'
+
+  return (
+    <div className={indentCls}>
+      <div
+        className={`rounded-xl border bg-white p-4 shadow-sm ${
+          depth === 0 ? 'border-indigo-200' : 'border-slate-200'
+        }`}
+      >
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0 flex-1">
+            <div className="flex flex-wrap items-center gap-2">
+              <span
+                className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${
+                  node.ownerType === 'ORGANIZATION'
+                    ? 'bg-indigo-100 text-indigo-700'
+                    : node.ownerType === 'DEPARTMENT'
+                      ? 'bg-violet-100 text-violet-700'
+                      : 'bg-sky-100 text-sky-700'
+                }`}
+              >
+                {OWNER_TYPE_LABELS[node.ownerType]}
+              </span>
+              <span
+                className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${
+                  node.goalType === 'OKR'
+                    ? 'bg-emerald-100 text-emerald-700'
+                    : 'bg-amber-100 text-amber-700'
+                }`}
+              >
+                {node.goalType}
+              </span>
+            </div>
+            <p className="mt-1 font-semibold text-slate-900">{node.title}</p>
+            {node.description && (
+              <p className="mt-0.5 text-xs text-slate-500">{node.description}</p>
+            )}
+            {node.keyResult && (
+              <p className="mt-1 text-xs text-slate-600">
+                <span className="font-medium">KR:</span> {node.keyResult}
+              </p>
+            )}
+            {node.targetValue !== null && (
+              <p className="mt-0.5 text-xs text-slate-500">
+                目標値: {node.targetValue} {node.unit ?? ''}
+              </p>
+            )}
+            <p className="mt-1 text-xs text-slate-400">
+              {node.startDate.slice(0, 10)} 〜 {node.endDate.slice(0, 10)}
+            </p>
+          </div>
+          {hasChildren && (
+            <button
+              type="button"
+              onClick={() => setExpanded((v) => !v)}
+              className="shrink-0 rounded-md border border-slate-200 px-2.5 py-1 text-xs text-slate-500 hover:bg-slate-50"
+            >
+              {expanded ? '▲ 折りたたむ' : `▼ ${node.children.length} 件`}
+            </button>
+          )}
+        </div>
+      </div>
+      {hasChildren && expanded && (
+        <div className="mt-2 space-y-2">
+          {node.children.map((child) => (
+            <GoalTreeNode key={child.id} node={child} depth={depth + 1} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function readError(err: unknown): string {
+  if (err instanceof Error) return err.message
+  return '予期せぬエラーが発生しました'
+}


### PR DESCRIPTION
## Summary

- **Task 13.1 (Req 6.1, 6.2)** `src/app/goals/tree/page.tsx` — 多階層組織目標ツリー画面
  - `GET /api/goals/org?tree=1` で組織目標を再帰ツリー表示
  - depth 別インデント (ml-0 / ml-6 / ml-12)、展開/折りたたみボタン
  - ownerType バッジ (ORGANIZATION=indigo / DEPARTMENT=violet / TEAM=sky)、goalType バッジ (OKR=emerald / MBO=amber)

- **Task 13.2 (Req 6.3, 6.4, 6.5)** `src/app/goals/personal/page.tsx` — 個人目標登録・上長承認画面
  - `GET/POST /api/goals/personal` で一覧取得・目標作成
  - OKR/MBO タイプ切替フォーム (OKR: Key Result 入力、MBO: 目標値+単位 入力)
  - DRAFT→PENDING_APPROVAL (承認申請) ボタン、PENDING_APPROVAL で承認/差戻しボタン表示

- **Task 13.3 (Req 6.6, 6.7)** `src/app/goals/progress/page.tsx` — 進捗更新・部下目標一覧画面
  - 承認済/進行中の目標に `POST /api/goals/personal/[id]/progress` で進捗率+コメント記録
  - 「履歴を見る」トグルで `GET /api/goals/personal/[id]/progress` の履歴表示
  - `GET /api/goals/subordinates` で部下目標テーブル (MANAGER+、403 は非表示)

## Test plan

- [ ] `/goals/tree` にアクセスし、組織目標ツリーが表示されること
- [ ] 展開/折りたたみボタンが動作すること
- [ ] `/goals/personal` にアクセスし、目標一覧が表示されること
- [ ] 「＋ 目標を追加」から OKR/MBO 目標を登録できること
- [ ] DRAFT 目標に「承認申請」ボタンが表示され、クリックで PENDING_APPROVAL になること
- [ ] PENDING_APPROVAL 目標に「承認」「差戻し」ボタンが表示されること（MANAGER ロール）
- [ ] `/goals/progress` にアクセスし、承認済/進行中の目標が表示されること
- [ ] 進捗率を入力して「記録」ボタンを押すと POST が送信されること
- [ ] 「履歴を見る」で過去の進捗が表示されること
- [ ] EMPLOYEE ロールでは「部下の目標一覧」セクションが非表示になること