### PR TITLE
feat: ISSUE #178 — 1on1 スケジュール・タイムライン画面の実装 (Task 14.1〜14.3)

### DIFF
--- a/src/app/one-on-one/reminder/page.tsx
+++ b/src/app/one-on-one/reminder/page.tsx
@@ -1,0 +1,436 @@
+/**
+ * Issue #178 / Task 14.3 / Req 7.6, 7.7, 7.8: ログ未入力リマインダー / 評価フォーム連携画面
+ *
+ * - POST /api/one-on-one/reminder/scan                              → スキャン実行（ADMIN のみ）
+ * - GET  /api/one-on-one/evaluation-links?employeeId=...&from=...&to=... → 評価フォームリンク
+ * - GET  /api/one-on-one/admin/logs?page=1&limit=20                 → 全ログ一覧（HR_MANAGER+、403 は非表示）
+ */
+'use client'
+
+import { useEffect, useState, type ReactElement, type ChangeEvent } from 'react'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface AllLogEntry {
+  readonly logId: string
+  readonly sessionId: string
+  readonly managerId: string
+  readonly employeeId: string
+  readonly scheduledAt: string
+  readonly content: string
+  readonly visibility: 'MANAGER_ONLY' | 'BOTH'
+  readonly recordedAt: string
+}
+
+interface EvaluationLogLink {
+  readonly sessionId: string
+  readonly scheduledAt: string
+  readonly logId: string | null
+  readonly hasLog: boolean
+}
+
+interface ScanResult {
+  readonly notified: number
+  readonly skipped: number
+}
+
+interface ApiEnvelope<T> {
+  readonly success?: boolean
+  readonly data?: T
+  readonly error?: string
+}
+
+interface PaginatedData {
+  readonly data: readonly AllLogEntry[]
+  readonly total: number
+}
+
+type AdminLogsState =
+  | { readonly kind: 'loading' }
+  | { readonly kind: 'hidden' }
+  | { readonly kind: 'error'; readonly message: string }
+  | { readonly kind: 'ready'; readonly logs: readonly AllLogEntry[]; readonly total: number }
+
+type EvalLinksState =
+  | { readonly kind: 'idle' }
+  | { readonly kind: 'loading' }
+  | { readonly kind: 'error'; readonly message: string }
+  | { readonly kind: 'ready'; readonly links: readonly EvaluationLogLink[] }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function fetchJson<T>(url: string, options?: RequestInit): Promise<T> {
+  const res = await fetch(url, { cache: 'no-store', ...options })
+  const envelope = (await res.json().catch(() => ({}))) as ApiEnvelope<T>
+  if (!res.ok) throw new Error(envelope.error ?? `HTTP ${res.status}`)
+  return (envelope.data ?? null) as T
+}
+
+function readError(err: unknown): string {
+  if (err instanceof Error) return err.message
+  return '予期せぬエラーが発生しました'
+}
+
+function isForbidden(err: unknown): boolean {
+  if (err instanceof Error) {
+    const msg = err.message.toLowerCase()
+    return msg.includes('403') || msg.includes('forbidden')
+  }
+  return false
+}
+
+function formatDateTime(iso: string): string {
+  return iso.slice(0, 16).replace('T', ' ')
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Page
+// ─────────────────────────────────────────────────────────────────────────────
+
+export default function ReminderPage(): ReactElement {
+  const [adminLogsState, setAdminLogsState] = useState<AdminLogsState>({ kind: 'loading' })
+  const [page, setPage] = useState(1)
+  const limit = 20
+
+  const [evalEmployeeId, setEvalEmployeeId] = useState('')
+  const [evalFrom, setEvalFrom] = useState('')
+  const [evalTo, setEvalTo] = useState('')
+  const [evalLinksState, setEvalLinksState] = useState<EvalLinksState>({ kind: 'idle' })
+
+  const [scanning, setScanning] = useState(false)
+  const [scanResult, setScanResult] = useState<ScanResult | null>(null)
+  const [scanError, setScanError] = useState<string | null>(null)
+
+  useEffect(() => {
+    void loadAdminLogs(page)
+  }, [page])
+
+  async function loadAdminLogs(p: number): Promise<void> {
+    setAdminLogsState({ kind: 'loading' })
+    try {
+      const result = await fetchJson<PaginatedData>(
+        `/api/one-on-one/admin/logs?page=${p}&limit=${limit}`,
+      )
+      setAdminLogsState({
+        kind: 'ready',
+        logs: result?.data ?? [],
+        total: result?.total ?? 0,
+      })
+    } catch (err) {
+      if (isForbidden(err)) {
+        setAdminLogsState({ kind: 'hidden' })
+      } else {
+        setAdminLogsState({ kind: 'error', message: readError(err) })
+      }
+    }
+  }
+
+  async function handleScan(): Promise<void> {
+    setScanning(true)
+    setScanError(null)
+    setScanResult(null)
+    try {
+      const result = await fetchJson<ScanResult>('/api/one-on-one/reminder/scan', {
+        method: 'POST',
+      })
+      setScanResult(result)
+    } catch (err) {
+      if (isForbidden(err)) {
+        setScanError('リマインダースキャンには ADMIN 権限が必要です')
+      } else {
+        setScanError(readError(err))
+      }
+    } finally {
+      setScanning(false)
+    }
+  }
+
+  async function handleEvalLinksSearch(): Promise<void> {
+    if (!evalEmployeeId) return
+    setEvalLinksState({ kind: 'loading' })
+    try {
+      const params = new URLSearchParams({ employeeId: evalEmployeeId })
+      if (evalFrom) params.set('from', evalFrom)
+      if (evalTo) params.set('to', evalTo)
+      const links = await fetchJson<EvaluationLogLink[]>(
+        `/api/one-on-one/evaluation-links?${params.toString()}`,
+      )
+      setEvalLinksState({ kind: 'ready', links: Array.isArray(links) ? links : [] })
+    } catch (err) {
+      setEvalLinksState({ kind: 'error', message: readError(err) })
+    }
+  }
+
+  return (
+    <main className="mx-auto max-w-4xl px-6 py-10">
+      <header className="mb-8">
+        <p className="text-xs font-semibold tracking-widest text-indigo-600 uppercase">1on1</p>
+        <h1 className="mt-1 text-3xl font-bold text-slate-900">リマインダー / 評価連携</h1>
+        <p className="mt-2 text-sm text-slate-600">
+          ログ未入力の確認、リマインダー送信、評価フォームへの 1on1 記録参照を行います。
+        </p>
+      </header>
+
+      {/* ── Reminder scan (ADMIN) ── */}
+      <section className="mb-10 rounded-xl border border-amber-200 bg-amber-50 p-6">
+        <h2 className="mb-1 font-semibold text-slate-800">リマインダースキャン</h2>
+        <p className="mb-4 text-xs text-slate-500">
+          30 日以上 1on1 ログがない部下を検出し、担当マネージャーへ通知します（ADMIN 専用）。
+        </p>
+        <div className="flex flex-wrap items-center gap-4">
+          <button
+            type="button"
+            onClick={() => void handleScan()}
+            disabled={scanning}
+            className="rounded-lg bg-amber-500 px-5 py-2 text-sm font-medium text-white hover:bg-amber-600 disabled:opacity-50"
+          >
+            {scanning ? 'スキャン中…' : 'スキャン実行'}
+          </button>
+          {scanResult && (
+            <p className="text-sm text-slate-700">
+              通知済み:{' '}
+              <span className="font-semibold text-emerald-600">{scanResult.notified}</span> 件 /
+              スキップ: <span className="font-semibold text-slate-500">{scanResult.skipped}</span>{' '}
+              件
+            </p>
+          )}
+          {scanError && <p className="text-sm text-rose-600">{scanError}</p>}
+        </div>
+      </section>
+
+      {/* ── Evaluation links ── */}
+      <section className="mb-10">
+        <h2 className="mb-4 font-semibold text-slate-800">評価フォーム用 1on1 ログ参照</h2>
+        <div className="mb-4 flex flex-wrap items-end gap-3 rounded-xl border border-slate-200 bg-white p-4">
+          <div className="min-w-40 flex-1">
+            <label className="mb-1 block text-xs font-medium text-slate-600">
+              社員 ID <span className="text-rose-500">*</span>
+            </label>
+            <input
+              value={evalEmployeeId}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => setEvalEmployeeId(e.target.value)}
+              placeholder="社員 ID を入力"
+              className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-indigo-400 focus:outline-none"
+            />
+          </div>
+          <div>
+            <label className="mb-1 block text-xs font-medium text-slate-600">開始日（任意）</label>
+            <input
+              type="date"
+              value={evalFrom}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => setEvalFrom(e.target.value)}
+              className="rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-indigo-400 focus:outline-none"
+            />
+          </div>
+          <div>
+            <label className="mb-1 block text-xs font-medium text-slate-600">終了日（任意）</label>
+            <input
+              type="date"
+              value={evalTo}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => setEvalTo(e.target.value)}
+              className="rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-indigo-400 focus:outline-none"
+            />
+          </div>
+          <button
+            type="button"
+            onClick={() => void handleEvalLinksSearch()}
+            disabled={!evalEmployeeId}
+            className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-40"
+          >
+            参照
+          </button>
+        </div>
+
+        <EvalLinksResult state={evalLinksState} />
+      </section>
+
+      {/* ── Admin all logs (HR_MANAGER+) ── */}
+      {adminLogsState.kind !== 'hidden' && (
+        <section>
+          <h2 className="mb-4 font-semibold text-slate-800">全 1on1 ログ一覧</h2>
+          <AdminLogsSection
+            state={adminLogsState}
+            page={page}
+            limit={limit}
+            onPageChange={setPage}
+          />
+        </section>
+      )}
+    </main>
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// EvalLinksResult
+// ─────────────────────────────────────────────────────────────────────────────
+
+function EvalLinksResult({ state }: { readonly state: EvalLinksState }): ReactElement {
+  if (state.kind === 'idle') return <></>
+  if (state.kind === 'loading') {
+    return (
+      <div className="flex items-center justify-center rounded-xl border border-slate-200 bg-white py-8 text-sm text-slate-500">
+        <span className="animate-pulse">読み込み中…</span>
+      </div>
+    )
+  }
+  if (state.kind === 'error') {
+    return (
+      <div className="rounded-xl border border-rose-300 bg-rose-50 p-4 text-sm text-rose-800">
+        <p className="font-semibold">取得に失敗しました</p>
+        <p className="mt-1 text-xs">{state.message}</p>
+      </div>
+    )
+  }
+  if (state.links.length === 0) {
+    return (
+      <div className="rounded-xl border border-slate-200 bg-white py-8 text-center text-sm text-slate-400">
+        該当期間のセッションが見つかりません
+      </div>
+    )
+  }
+
+  return (
+    <div className="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
+      <table className="w-full text-sm">
+        <thead className="border-b border-slate-200 bg-slate-50">
+          <tr>
+            <th className="px-4 py-3 text-left text-xs font-medium text-slate-500">予定日時</th>
+            <th className="px-4 py-3 text-left text-xs font-medium text-slate-500">ログ状態</th>
+            <th className="px-4 py-3 text-left text-xs font-medium text-slate-500">
+              セッション ID
+            </th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-slate-100">
+          {state.links.map((link) => (
+            <tr key={link.sessionId} className="hover:bg-slate-50">
+              <td className="px-4 py-3 text-slate-700">{formatDateTime(link.scheduledAt)}</td>
+              <td className="px-4 py-3">
+                <span
+                  className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${
+                    link.hasLog ? 'bg-emerald-100 text-emerald-700' : 'bg-rose-100 text-rose-600'
+                  }`}
+                >
+                  {link.hasLog ? '記録あり' : '未記録'}
+                </span>
+              </td>
+              <td className="px-4 py-3 font-mono text-xs text-slate-400">{link.sessionId}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// AdminLogsSection
+// ─────────────────────────────────────────────────────────────────────────────
+
+function AdminLogsSection({
+  state,
+  page,
+  limit,
+  onPageChange,
+}: {
+  readonly state: AdminLogsState
+  readonly page: number
+  readonly limit: number
+  readonly onPageChange: (p: number) => void
+}): ReactElement {
+  if (state.kind === 'loading') {
+    return (
+      <div className="flex items-center justify-center rounded-xl border border-slate-200 bg-white py-12 text-sm text-slate-500">
+        <span className="animate-pulse">読み込み中…</span>
+      </div>
+    )
+  }
+  if (state.kind === 'error') {
+    return (
+      <div className="rounded-xl border border-rose-300 bg-rose-50 p-5 text-sm text-rose-800">
+        <p className="font-semibold">データの取得に失敗しました</p>
+        <p className="mt-1 text-xs">{state.message}</p>
+      </div>
+    )
+  }
+  if (state.kind !== 'ready' || state.logs.length === 0) {
+    return (
+      <div className="rounded-xl border border-slate-200 bg-white py-12 text-center text-sm text-slate-400">
+        ログデータがありません
+      </div>
+    )
+  }
+
+  const totalPages = Math.ceil(state.total / limit)
+
+  return (
+    <div>
+      <div className="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
+        <table className="w-full text-sm">
+          <thead className="border-b border-slate-200 bg-slate-50">
+            <tr>
+              <th className="px-4 py-3 text-left text-xs font-medium text-slate-500">予定日時</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-slate-500">
+                マネージャー
+              </th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-slate-500">部下</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-slate-500">公開範囲</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-slate-500">記録日</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-100">
+            {state.logs.map((log) => (
+              <tr key={log.logId} className="hover:bg-slate-50">
+                <td className="px-4 py-3 text-slate-700">{formatDateTime(log.scheduledAt)}</td>
+                <td className="px-4 py-3 text-xs text-slate-600">{log.managerId}</td>
+                <td className="px-4 py-3 text-xs text-slate-600">{log.employeeId}</td>
+                <td className="px-4 py-3">
+                  <span
+                    className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${
+                      log.visibility === 'BOTH'
+                        ? 'bg-emerald-100 text-emerald-700'
+                        : 'bg-slate-100 text-slate-600'
+                    }`}
+                  >
+                    {log.visibility === 'BOTH' ? '本人にも公開' : 'マネージャーのみ'}
+                  </span>
+                </td>
+                <td className="px-4 py-3 text-xs text-slate-400">{log.recordedAt.slice(0, 10)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {totalPages > 1 && (
+        <div className="mt-4 flex items-center justify-between text-sm text-slate-600">
+          <span>
+            {state.total} 件中 {(page - 1) * limit + 1}–{Math.min(page * limit, state.total)} 件
+          </span>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={() => onPageChange(page - 1)}
+              disabled={page <= 1}
+              className="rounded-md border border-slate-200 px-3 py-1.5 text-xs hover:bg-slate-50 disabled:opacity-40"
+            >
+              ← 前へ
+            </button>
+            <button
+              type="button"
+              onClick={() => onPageChange(page + 1)}
+              disabled={page >= totalPages}
+              className="rounded-md border border-slate-200 px-3 py-1.5 text-xs hover:bg-slate-50 disabled:opacity-40"
+            >
+              次へ →
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/app/one-on-one/schedule/page.tsx
+++ b/src/app/one-on-one/schedule/page.tsx
@@ -1,0 +1,326 @@
+/**
+ * Issue #178 / Task 14.1 / Req 7.1, 7.2: 1on1 予定登録画面
+ *
+ * - 全ロールアクセス可能（一覧閲覧）
+ * - MANAGER 以上のみ予定登録可能
+ * - GET  /api/one-on-one/sessions — 自分のセッション一覧
+ * - POST /api/one-on-one/sessions — セッション作成（MANAGER+）
+ */
+'use client'
+
+import { useEffect, useState, type ReactElement, type FormEvent, type ChangeEvent } from 'react'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface OneOnOneSession {
+  readonly id: string
+  readonly managerId: string
+  readonly employeeId: string
+  readonly scheduledAt: string
+  readonly durationMin: number
+  readonly agenda: string | null
+  readonly createdAt: string
+}
+
+interface ApiEnvelope<T> {
+  readonly success?: boolean
+  readonly data?: T
+  readonly error?: string
+}
+
+type PageState =
+  | { readonly kind: 'loading' }
+  | { readonly kind: 'error'; readonly message: string }
+  | { readonly kind: 'ready'; readonly sessions: readonly OneOnOneSession[] }
+
+interface FormValues {
+  employeeId: string
+  scheduledAt: string
+  durationMin: string
+  agenda: string
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Constants
+// ─────────────────────────────────────────────────────────────────────────────
+
+const SESSIONS_URL = '/api/one-on-one/sessions'
+
+const EMPTY_FORM: FormValues = {
+  employeeId: '',
+  scheduledAt: '',
+  durationMin: '30',
+  agenda: '',
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function fetchJson<T>(url: string, options?: RequestInit): Promise<T> {
+  const res = await fetch(url, { cache: 'no-store', ...options })
+  const envelope = (await res.json().catch(() => ({}))) as ApiEnvelope<T>
+  if (!res.ok) throw new Error(envelope.error ?? `HTTP ${res.status}`)
+  return (envelope.data ?? null) as T
+}
+
+function readError(err: unknown): string {
+  if (err instanceof Error) return err.message
+  return '予期せぬエラーが発生しました'
+}
+
+function formatDateTime(iso: string): string {
+  return iso.slice(0, 16).replace('T', ' ')
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Page
+// ─────────────────────────────────────────────────────────────────────────────
+
+export default function OneOnOneSchedulePage(): ReactElement {
+  const [state, setState] = useState<PageState>({ kind: 'loading' })
+  const [showForm, setShowForm] = useState(false)
+  const [form, setForm] = useState<FormValues>(EMPTY_FORM)
+  const [submitting, setSubmitting] = useState(false)
+  const [actionError, setActionError] = useState<string | null>(null)
+
+  async function loadSessions(): Promise<void> {
+    setState({ kind: 'loading' })
+    try {
+      const sessions = await fetchJson<OneOnOneSession[]>(SESSIONS_URL)
+      setState({ kind: 'ready', sessions: Array.isArray(sessions) ? sessions : [] })
+    } catch (err) {
+      setState({ kind: 'error', message: readError(err) })
+    }
+  }
+
+  useEffect(() => {
+    void loadSessions()
+  }, [])
+
+  async function handleCreate(e: FormEvent): Promise<void> {
+    e.preventDefault()
+    setSubmitting(true)
+    setActionError(null)
+    try {
+      await fetchJson(SESSIONS_URL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          employeeId: form.employeeId,
+          scheduledAt: form.scheduledAt,
+          durationMin: Number(form.durationMin),
+          agenda: form.agenda || undefined,
+        }),
+      })
+      setForm(EMPTY_FORM)
+      setShowForm(false)
+      await loadSessions()
+    } catch (err) {
+      const msg = readError(err)
+      if (msg.toLowerCase().includes('403') || msg.toLowerCase().includes('forbidden')) {
+        setActionError('予定の登録にはマネージャー以上の権限が必要です')
+      } else {
+        setActionError(msg)
+      }
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  function field(key: keyof FormValues) {
+    return (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) =>
+      setForm((v) => ({ ...v, [key]: e.target.value }))
+  }
+
+  return (
+    <main className="mx-auto max-w-3xl px-6 py-10">
+      <header className="mb-8 flex items-start justify-between gap-4">
+        <div>
+          <p className="text-xs font-semibold tracking-widest text-indigo-600 uppercase">1on1</p>
+          <h1 className="mt-1 text-3xl font-bold text-slate-900">1on1 予定</h1>
+          <p className="mt-2 text-sm text-slate-600">1on1 セッションの予定を登録・確認します。</p>
+        </div>
+        <button
+          type="button"
+          onClick={() => setShowForm((v) => !v)}
+          className="shrink-0 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700"
+        >
+          {showForm ? 'キャンセル' : '＋ 予定を追加'}
+        </button>
+      </header>
+
+      {actionError && (
+        <div className="mb-4 rounded-lg border border-rose-300 bg-rose-50 p-3 text-sm text-rose-800">
+          {actionError}
+        </div>
+      )}
+
+      {showForm && (
+        <form
+          onSubmit={handleCreate}
+          className="mb-8 rounded-xl border border-indigo-200 bg-indigo-50 p-6"
+        >
+          <h2 className="mb-4 font-semibold text-slate-800">1on1 予定を登録</h2>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="sm:col-span-2">
+              <label className="mb-1 block text-xs font-medium text-slate-600">
+                対象社員 ID <span className="text-rose-500">*</span>
+              </label>
+              <input
+                required
+                value={form.employeeId}
+                onChange={field('employeeId')}
+                placeholder="社員 ID を入力"
+                className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-indigo-400 focus:outline-none"
+              />
+            </div>
+
+            <div>
+              <label className="mb-1 block text-xs font-medium text-slate-600">
+                予定日時 <span className="text-rose-500">*</span>
+              </label>
+              <input
+                required
+                type="datetime-local"
+                value={form.scheduledAt}
+                onChange={field('scheduledAt')}
+                className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-indigo-400 focus:outline-none"
+              />
+            </div>
+
+            <div>
+              <label className="mb-1 block text-xs font-medium text-slate-600">
+                所要時間（分）<span className="text-rose-500">*</span>
+              </label>
+              <input
+                required
+                type="number"
+                min={15}
+                max={240}
+                value={form.durationMin}
+                onChange={field('durationMin')}
+                className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-indigo-400 focus:outline-none"
+              />
+            </div>
+
+            <div className="sm:col-span-2">
+              <label className="mb-1 block text-xs font-medium text-slate-600">
+                アジェンダ（任意）
+              </label>
+              <textarea
+                rows={3}
+                maxLength={1000}
+                value={form.agenda}
+                onChange={field('agenda')}
+                placeholder="話し合いたいテーマ・議題"
+                className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-indigo-400 focus:outline-none"
+              />
+            </div>
+          </div>
+
+          <div className="mt-4 flex justify-end">
+            <button
+              type="submit"
+              disabled={submitting}
+              className="rounded-lg bg-indigo-600 px-5 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
+            >
+              {submitting ? '登録中…' : '登録する'}
+            </button>
+          </div>
+        </form>
+      )}
+
+      <SessionList state={state} />
+    </main>
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SessionList
+// ─────────────────────────────────────────────────────────────────────────────
+
+function SessionList({ state }: { readonly state: PageState }): ReactElement {
+  if (state.kind === 'loading') {
+    return (
+      <div className="flex items-center justify-center rounded-xl border border-slate-200 bg-white py-16 text-sm text-slate-500">
+        <span className="animate-pulse">読み込み中…</span>
+      </div>
+    )
+  }
+  if (state.kind === 'error') {
+    return (
+      <div className="rounded-xl border border-rose-300 bg-rose-50 p-6 text-sm text-rose-800">
+        <p className="font-semibold">データの取得に失敗しました</p>
+        <p className="mt-1 text-xs">{state.message}</p>
+      </div>
+    )
+  }
+  if (state.sessions.length === 0) {
+    return (
+      <div className="rounded-xl border border-slate-200 bg-white py-16 text-center text-sm text-slate-400">
+        1on1 予定が登録されていません
+      </div>
+    )
+  }
+
+  const sorted = [...state.sessions].sort(
+    (a, b) => new Date(b.scheduledAt).getTime() - new Date(a.scheduledAt).getTime(),
+  )
+
+  return (
+    <div className="space-y-3">
+      {sorted.map((s) => (
+        <SessionCard key={s.id} session={s} />
+      ))}
+    </div>
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SessionCard
+// ─────────────────────────────────────────────────────────────────────────────
+
+function SessionCard({ session }: { readonly session: OneOnOneSession }): ReactElement {
+  const isPast = new Date(session.scheduledAt) < new Date()
+
+  return (
+    <div className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <span
+              className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${
+                isPast ? 'bg-slate-100 text-slate-500' : 'bg-indigo-100 text-indigo-700'
+              }`}
+            >
+              {isPast ? '実施済み' : '予定'}
+            </span>
+            <span className="text-xs text-slate-500">{session.durationMin} 分</span>
+          </div>
+
+          <p className="mt-1 font-semibold text-slate-900">{formatDateTime(session.scheduledAt)}</p>
+
+          <p className="mt-0.5 text-xs text-slate-500">
+            マネージャー: {session.managerId} / 部下: {session.employeeId}
+          </p>
+
+          {session.agenda && (
+            <p className="mt-2 rounded-lg bg-slate-50 px-3 py-2 text-xs text-slate-600">
+              <span className="font-medium">アジェンダ:</span> {session.agenda}
+            </p>
+          )}
+        </div>
+
+        <a
+          href={`/one-on-one/timeline?employeeId=${session.employeeId}&managerId=${session.managerId}`}
+          className="shrink-0 rounded-md border border-indigo-200 px-3 py-1.5 text-xs font-medium text-indigo-600 hover:bg-indigo-50"
+        >
+          ログを見る →
+        </a>
+      </div>
+    </div>
+  )
+}

--- a/src/app/one-on-one/timeline/page.tsx
+++ b/src/app/one-on-one/timeline/page.tsx
@@ -1,0 +1,428 @@
+/**
+ * Issue #178 / Task 14.2 / Req 7.3, 7.4, 7.5: 1on1 ログ タイムライン画面
+ *
+ * - employeeId + managerId をクエリパラメータで受け取る
+ * - GET /api/one-on-one/timeline?employeeId=...&managerId=... → タイムライン取得
+ *   MANAGER: 全ログ表示、EMPLOYEE: visibility=BOTH のみ
+ * - POST /api/one-on-one/sessions/[sessionId]/log → ログ記録（MANAGER のみ）
+ */
+'use client'
+
+import { useEffect, useState, type ReactElement, type FormEvent, type ChangeEvent } from 'react'
+import { useSearchParams } from 'next/navigation'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+type LogVisibility = 'MANAGER_ONLY' | 'BOTH'
+
+interface OneOnOneLogRecord {
+  readonly id: string
+  readonly sessionId: string
+  readonly agenda: string | null
+  readonly content: string
+  readonly nextActions: string | null
+  readonly visibility: LogVisibility
+  readonly recordedBy: string
+  readonly recordedAt: string
+}
+
+interface TimelineEntry {
+  readonly sessionId: string
+  readonly scheduledAt: string
+  readonly durationMin: number
+  readonly log: OneOnOneLogRecord | null
+}
+
+interface ApiEnvelope<T> {
+  readonly success?: boolean
+  readonly data?: T
+  readonly error?: string
+}
+
+type TimelineState =
+  | { readonly kind: 'idle' }
+  | { readonly kind: 'loading' }
+  | { readonly kind: 'error'; readonly message: string }
+  | { readonly kind: 'ready'; readonly entries: readonly TimelineEntry[] }
+
+interface LogFormValues {
+  agenda: string
+  content: string
+  nextActions: string
+  visibility: LogVisibility
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function fetchJson<T>(url: string, options?: RequestInit): Promise<T> {
+  const res = await fetch(url, { cache: 'no-store', ...options })
+  const envelope = (await res.json().catch(() => ({}))) as ApiEnvelope<T>
+  if (!res.ok) throw new Error(envelope.error ?? `HTTP ${res.status}`)
+  return (envelope.data ?? null) as T
+}
+
+function readError(err: unknown): string {
+  if (err instanceof Error) return err.message
+  return '予期せぬエラーが発生しました'
+}
+
+function formatDateTime(iso: string): string {
+  return iso.slice(0, 16).replace('T', ' ')
+}
+
+function formatDate(iso: string): string {
+  return iso.slice(0, 10)
+}
+
+const EMPTY_LOG_FORM: LogFormValues = {
+  agenda: '',
+  content: '',
+  nextActions: '',
+  visibility: 'MANAGER_ONLY',
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Page
+// ─────────────────────────────────────────────────────────────────────────────
+
+export default function TimelinePage(): ReactElement {
+  const searchParams = useSearchParams()
+  const initialEmployee = searchParams.get('employeeId') ?? ''
+  const initialManager = searchParams.get('managerId') ?? ''
+
+  const [qEmployee, setQEmployee] = useState(initialEmployee)
+  const [qManager, setQManager] = useState(initialManager)
+  const [state, setState] = useState<TimelineState>(
+    initialEmployee && initialManager ? { kind: 'loading' } : { kind: 'idle' },
+  )
+
+  async function load(eid: string, mid: string): Promise<void> {
+    if (!eid || !mid) return
+    setState({ kind: 'loading' })
+    try {
+      const entries = await fetchJson<TimelineEntry[]>(
+        `/api/one-on-one/timeline?employeeId=${encodeURIComponent(eid)}&managerId=${encodeURIComponent(mid)}`,
+      )
+      setState({ kind: 'ready', entries: Array.isArray(entries) ? entries : [] })
+    } catch (err) {
+      setState({ kind: 'error', message: readError(err) })
+    }
+  }
+
+  useEffect(() => {
+    if (initialEmployee && initialManager) {
+      void load(initialEmployee, initialManager)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  function handleSearch(e: FormEvent): void {
+    e.preventDefault()
+    void load(qEmployee, qManager)
+  }
+
+  return (
+    <main className="mx-auto max-w-3xl px-6 py-10">
+      <header className="mb-8">
+        <p className="text-xs font-semibold tracking-widest text-indigo-600 uppercase">1on1</p>
+        <h1 className="mt-1 text-3xl font-bold text-slate-900">タイムライン</h1>
+        <p className="mt-2 text-sm text-slate-600">
+          1on1 の記録を時系列で確認します。マネージャーはログを追加できます。
+        </p>
+      </header>
+
+      {/* Search filter */}
+      <form
+        onSubmit={handleSearch}
+        className="mb-8 flex flex-wrap items-end gap-3 rounded-xl border border-slate-200 bg-white p-4"
+      >
+        <div className="min-w-40 flex-1">
+          <label className="mb-1 block text-xs font-medium text-slate-600">
+            社員 ID <span className="text-rose-500">*</span>
+          </label>
+          <input
+            required
+            value={qEmployee}
+            onChange={(e: ChangeEvent<HTMLInputElement>) => setQEmployee(e.target.value)}
+            placeholder="部下の社員 ID"
+            className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-indigo-400 focus:outline-none"
+          />
+        </div>
+        <div className="min-w-40 flex-1">
+          <label className="mb-1 block text-xs font-medium text-slate-600">
+            マネージャー ID <span className="text-rose-500">*</span>
+          </label>
+          <input
+            required
+            value={qManager}
+            onChange={(e: ChangeEvent<HTMLInputElement>) => setQManager(e.target.value)}
+            placeholder="マネージャーの社員 ID"
+            className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-indigo-400 focus:outline-none"
+          />
+        </div>
+        <button
+          type="submit"
+          className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700"
+        >
+          表示
+        </button>
+      </form>
+
+      <TimelineBody state={state} onLogAdded={() => void load(qEmployee, qManager)} />
+    </main>
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TimelineBody
+// ─────────────────────────────────────────────────────────────────────────────
+
+function TimelineBody({
+  state,
+  onLogAdded,
+}: {
+  readonly state: TimelineState
+  readonly onLogAdded: () => void
+}): ReactElement {
+  if (state.kind === 'idle') {
+    return (
+      <div className="rounded-xl border border-slate-200 bg-white py-16 text-center text-sm text-slate-400">
+        社員 ID とマネージャー ID を入力して「表示」を押してください
+      </div>
+    )
+  }
+  if (state.kind === 'loading') {
+    return (
+      <div className="flex items-center justify-center rounded-xl border border-slate-200 bg-white py-16 text-sm text-slate-500">
+        <span className="animate-pulse">読み込み中…</span>
+      </div>
+    )
+  }
+  if (state.kind === 'error') {
+    return (
+      <div className="rounded-xl border border-rose-300 bg-rose-50 p-6 text-sm text-rose-800">
+        <p className="font-semibold">データの取得に失敗しました</p>
+        <p className="mt-1 text-xs">{state.message}</p>
+      </div>
+    )
+  }
+  if (state.entries.length === 0) {
+    return (
+      <div className="rounded-xl border border-slate-200 bg-white py-16 text-center text-sm text-slate-400">
+        タイムラインの記録がありません
+      </div>
+    )
+  }
+
+  const sorted = [...state.entries].sort(
+    (a, b) => new Date(b.scheduledAt).getTime() - new Date(a.scheduledAt).getTime(),
+  )
+
+  return (
+    <div className="relative space-y-6">
+      <div className="absolute top-0 left-4 h-full w-0.5 bg-slate-200" />
+      {sorted.map((entry) => (
+        <TimelineItem key={entry.sessionId} entry={entry} onLogAdded={onLogAdded} />
+      ))}
+    </div>
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TimelineItem
+// ─────────────────────────────────────────────────────────────────────────────
+
+function TimelineItem({
+  entry,
+  onLogAdded,
+}: {
+  readonly entry: TimelineEntry
+  readonly onLogAdded: () => void
+}): ReactElement {
+  const [showLogForm, setShowLogForm] = useState(false)
+  const [logForm, setLogForm] = useState<LogFormValues>(EMPTY_LOG_FORM)
+  const [submitting, setSubmitting] = useState(false)
+  const [logError, setLogError] = useState<string | null>(null)
+
+  async function handleLogSubmit(e: FormEvent): Promise<void> {
+    e.preventDefault()
+    setSubmitting(true)
+    setLogError(null)
+    try {
+      await fetchJson(`/api/one-on-one/sessions/${entry.sessionId}/log`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          agenda: logForm.agenda || undefined,
+          content: logForm.content,
+          nextActions: logForm.nextActions || undefined,
+          visibility: logForm.visibility,
+        }),
+      })
+      setLogForm(EMPTY_LOG_FORM)
+      setShowLogForm(false)
+      onLogAdded()
+    } catch (err) {
+      const msg = readError(err)
+      if (msg.toLowerCase().includes('403') || msg.toLowerCase().includes('forbidden')) {
+        setLogError('ログの記録にはマネージャー以上の権限が必要です')
+      } else {
+        setLogError(msg)
+      }
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  function logField(key: keyof LogFormValues) {
+    return (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) =>
+      setLogForm((v) => ({ ...v, [key]: e.target.value }))
+  }
+
+  const hasLog = entry.log !== null
+
+  return (
+    <div className="relative pl-10">
+      <div
+        className={`absolute top-5 left-2.5 h-3 w-3 -translate-x-1/2 rounded-full border-2 border-white ${
+          hasLog ? 'bg-indigo-500' : 'bg-slate-300'
+        }`}
+      />
+
+      <div
+        className={`rounded-xl border bg-white p-5 shadow-sm ${
+          hasLog ? 'border-indigo-100' : 'border-slate-200'
+        }`}
+      >
+        <div className="mb-3 flex flex-wrap items-start justify-between gap-2">
+          <div>
+            <p className="font-semibold text-slate-900">{formatDateTime(entry.scheduledAt)}</p>
+            <p className="text-xs text-slate-500">{entry.durationMin} 分</p>
+          </div>
+          {!hasLog && (
+            <button
+              type="button"
+              onClick={() => setShowLogForm((v) => !v)}
+              className="rounded-md border border-indigo-300 bg-indigo-50 px-3 py-1.5 text-xs font-medium text-indigo-700 hover:bg-indigo-100"
+            >
+              {showLogForm ? 'キャンセル' : '＋ ログを記録'}
+            </button>
+          )}
+        </div>
+
+        {hasLog && entry.log !== null && <LogContent log={entry.log} />}
+
+        {!hasLog && !showLogForm && <p className="text-xs text-slate-400 italic">ログ未入力</p>}
+
+        {showLogForm && (
+          <form
+            onSubmit={handleLogSubmit}
+            className="mt-3 space-y-3 border-t border-slate-100 pt-3"
+          >
+            <div>
+              <label className="mb-1 block text-xs font-medium text-slate-600">議題（任意）</label>
+              <input
+                maxLength={500}
+                value={logForm.agenda}
+                onChange={logField('agenda')}
+                placeholder="議題を入力"
+                className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-indigo-400 focus:outline-none"
+              />
+            </div>
+            <div>
+              <label className="mb-1 block text-xs font-medium text-slate-600">
+                議事内容 <span className="text-rose-500">*</span>
+              </label>
+              <textarea
+                required
+                rows={4}
+                maxLength={5000}
+                value={logForm.content}
+                onChange={logField('content')}
+                placeholder="1on1 の内容を記録"
+                className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-indigo-400 focus:outline-none"
+              />
+            </div>
+            <div>
+              <label className="mb-1 block text-xs font-medium text-slate-600">
+                ネクストアクション（任意）
+              </label>
+              <textarea
+                rows={2}
+                maxLength={2000}
+                value={logForm.nextActions}
+                onChange={logField('nextActions')}
+                placeholder="次回までのアクション"
+                className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-indigo-400 focus:outline-none"
+              />
+            </div>
+            <div>
+              <label className="mb-1 block text-xs font-medium text-slate-600">公開範囲</label>
+              <select
+                value={logForm.visibility}
+                onChange={logField('visibility')}
+                className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-indigo-400 focus:outline-none"
+              >
+                <option value="MANAGER_ONLY">マネージャーのみ</option>
+                <option value="BOTH">本人にも公開</option>
+              </select>
+            </div>
+            {logError && <p className="text-xs text-rose-600">{logError}</p>}
+            <div className="flex justify-end">
+              <button
+                type="submit"
+                disabled={submitting}
+                className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
+              >
+                {submitting ? '保存中…' : '保存する'}
+              </button>
+            </div>
+          </form>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// LogContent
+// ─────────────────────────────────────────────────────────────────────────────
+
+function LogContent({ log }: { readonly log: OneOnOneLogRecord }): ReactElement {
+  return (
+    <div className="space-y-2">
+      {log.agenda && (
+        <div>
+          <p className="text-xs font-medium text-slate-500">議題</p>
+          <p className="text-sm text-slate-700">{log.agenda}</p>
+        </div>
+      )}
+      <div>
+        <p className="text-xs font-medium text-slate-500">議事内容</p>
+        <p className="text-sm whitespace-pre-wrap text-slate-700">{log.content}</p>
+      </div>
+      {log.nextActions && (
+        <div>
+          <p className="text-xs font-medium text-slate-500">ネクストアクション</p>
+          <p className="text-sm whitespace-pre-wrap text-slate-700">{log.nextActions}</p>
+        </div>
+      )}
+      <div className="flex flex-wrap items-center gap-3 pt-1">
+        <span
+          className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${
+            log.visibility === 'BOTH'
+              ? 'bg-emerald-100 text-emerald-700'
+              : 'bg-slate-100 text-slate-600'
+          }`}
+        >
+          {log.visibility === 'BOTH' ? '本人にも公開' : 'マネージャーのみ'}
+        </span>
+        <span className="text-xs text-slate-400">記録日: {formatDate(log.recordedAt)}</span>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- **Task 14.1 (Req 7.1, 7.2)** `src/app/one-on-one/schedule/page.tsx` — 1on1 予定登録画面
  - `GET /api/one-on-one/sessions` で自分のセッション一覧を取得・新着順表示
  - `POST /api/one-on-one/sessions` でセッション作成（対象社員ID / 日時 / 所要時間 / アジェンダ）
  - 実施済み/予定バッジ、タイムラインページへの直リンク

- **Task 14.2 (Req 7.3, 7.4, 7.5)** `src/app/one-on-one/timeline/page.tsx` — タイムライン画面
  - `employeeId` + `managerId` クエリパラメータ対応（schedule から直リンク可能）
  - `GET /api/one-on-one/timeline` で取得した時系列エントリを垂直ライン UI で表示
  - ログあり=indigo ドット / 未入力=グレードット
  - MANAGER: `POST /api/one-on-one/sessions/[id]/log` でログ追記フォーム（議題 / 議事内容 / ネクストアクション / 公開範囲）

- **Task 14.3 (Req 7.6, 7.7, 7.8)** `src/app/one-on-one/reminder/page.tsx` — リマインダー/評価連携画面
  - `POST /api/one-on-one/reminder/scan` でリマインダースキャン実行（ADMIN 専用、403 はエラーメッセージ表示）
  - `GET /api/one-on-one/evaluation-links` で期間指定の評価フォーム用ログ参照（記録あり/未記録バッジ）
  - `GET /api/one-on-one/admin/logs` でページング付き全ログ一覧（HR_MANAGER+、403 は非表示）

## Test plan

- [ ] `/one-on-one/schedule` にアクセスしセッション一覧が表示されること
- [ ] MANAGER ロールで「＋ 予定を追加」フォームから予定を登録できること
- [ ] EMPLOYEE ロールで登録しようとすると権限エラーメッセージが表示されること
- [ ] セッションカードの「ログを見る」リンクでタイムラインへ遷移できること
- [ ] `/one-on-one/timeline` で社員ID/マネージャーIDを入力してタイムラインが表示されること
- [ ] ログ未入力セッションに「＋ ログを記録」ボタンが表示されること
- [ ] MANAGER でログフォームを送信するとエントリが更新されること
- [ ] `/one-on-one/reminder` でスキャン実行ボタンが表示されること
- [ ] 評価フォーム参照で社員IDを入力し期間を絞り込めること
- [ ] HR_MANAGER ロールで全ログ一覧が表示されること
- [ ] EMPLOYEE ロールで全ログ一覧セクションが非表示になること