### PR TITLE
[UI] ISSUE #179 — 360度評価運用画面の実装

### DIFF
--- a/src/app/evaluation/assignments/page.tsx
+++ b/src/app/evaluation/assignments/page.tsx
@@ -1,0 +1,455 @@
+/**
+ * Issue #179 / Task 15.3 / Req 8.3, 8.4, 8.10, 8.11, 8.12: 評価割り当て管理画面
+ *
+ * - cycleId をクエリパラメータで受け取る
+ * - GET  /api/evaluation/assignments?cycleId=...   — 全割り当て（HR_MANAGER/ADMIN）
+ * - POST /api/evaluation/assignments               — 割り当て追加（HR_MANAGER/ADMIN）
+ * - POST /api/evaluation/assignments/[id]/decline  — 辞退（本人）
+ */
+'use client'
+
+import { useEffect, useState, type ReactElement, type FormEvent, type ChangeEvent } from 'react'
+import { useSearchParams } from 'next/navigation'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+type AssignmentStatus = 'ACTIVE' | 'DECLINED' | 'REPLACED'
+
+interface ReviewDeclineRecord {
+  readonly id: string
+  readonly assignmentId: string
+  readonly reason: string
+  readonly replacementEvaluatorId: string | null
+  readonly declinedAt: string
+}
+
+interface ReviewAssignmentRecord {
+  readonly id: string
+  readonly cycleId: string
+  readonly evaluatorId: string
+  readonly targetUserId: string
+  readonly status: AssignmentStatus
+  readonly createdAt: string
+  readonly decline?: ReviewDeclineRecord
+}
+
+interface ApiEnvelope<T> {
+  readonly success?: boolean
+  readonly data?: T
+  readonly error?: string
+}
+
+type AssignmentState =
+  | { readonly kind: 'idle' }
+  | { readonly kind: 'loading' }
+  | { readonly kind: 'error'; readonly message: string }
+  | { readonly kind: 'ready'; readonly assignments: readonly ReviewAssignmentRecord[] }
+
+interface AddFormValues {
+  evaluatorId: string
+  targetUserId: string
+}
+
+interface DeclineFormValues {
+  reason: string
+  replacementEvaluatorId: string
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Constants
+// ─────────────────────────────────────────────────────────────────────────────
+
+const ASSIGNMENTS_URL = '/api/evaluation/assignments'
+
+const EMPTY_ADD_FORM: AddFormValues = { evaluatorId: '', targetUserId: '' }
+
+const STATUS_LABELS: Record<AssignmentStatus, string> = {
+  ACTIVE: '有効',
+  DECLINED: '辞退',
+  REPLACED: '代替済み',
+}
+
+const STATUS_COLORS: Record<AssignmentStatus, string> = {
+  ACTIVE: 'bg-indigo-100 text-indigo-700',
+  DECLINED: 'bg-rose-100 text-rose-700',
+  REPLACED: 'bg-slate-100 text-slate-500',
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function fetchJson<T>(url: string, options?: RequestInit): Promise<T> {
+  const res = await fetch(url, { cache: 'no-store', ...options })
+  const envelope = (await res.json().catch(() => ({}))) as ApiEnvelope<T>
+  if (!res.ok) throw new Error(envelope.error ?? `HTTP ${res.status}`)
+  return (envelope.data ?? null) as T
+}
+
+function readError(err: unknown): string {
+  if (err instanceof Error) return err.message
+  return '予期せぬエラーが発生しました'
+}
+
+function formatDate(iso: string): string {
+  return iso.slice(0, 10)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Page
+// ─────────────────────────────────────────────────────────────────────────────
+
+export default function AssignmentsPage(): ReactElement {
+  const searchParams = useSearchParams()
+  const cycleId = searchParams.get('cycleId') ?? ''
+
+  const [state, setState] = useState<AssignmentState>(
+    cycleId ? { kind: 'loading' } : { kind: 'idle' },
+  )
+  const [showAddForm, setShowAddForm] = useState(false)
+  const [addForm, setAddForm] = useState<AddFormValues>(EMPTY_ADD_FORM)
+  const [submitting, setSubmitting] = useState(false)
+  const [actionError, setActionError] = useState<string | null>(null)
+
+  // Decline modal state
+  const [declineTargetId, setDeclineTargetId] = useState<string | null>(null)
+  const [declineForm, setDeclineForm] = useState<DeclineFormValues>({
+    reason: '',
+    replacementEvaluatorId: '',
+  })
+  const [declining, setDeclining] = useState(false)
+
+  async function loadAssignments(): Promise<void> {
+    if (!cycleId) return
+    setState({ kind: 'loading' })
+    try {
+      const assignments = await fetchJson<ReviewAssignmentRecord[]>(
+        `${ASSIGNMENTS_URL}?cycleId=${encodeURIComponent(cycleId)}`,
+      )
+      setState({ kind: 'ready', assignments: Array.isArray(assignments) ? assignments : [] })
+    } catch (err) {
+      setState({ kind: 'error', message: readError(err) })
+    }
+  }
+
+  useEffect(() => {
+    if (cycleId) void loadAssignments()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [cycleId])
+
+  async function handleAdd(e: FormEvent): Promise<void> {
+    e.preventDefault()
+    setSubmitting(true)
+    setActionError(null)
+    try {
+      await fetchJson(ASSIGNMENTS_URL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          cycleId,
+          evaluatorId: addForm.evaluatorId,
+          targetUserId: addForm.targetUserId,
+        }),
+      })
+      setAddForm(EMPTY_ADD_FORM)
+      setShowAddForm(false)
+      await loadAssignments()
+    } catch (err) {
+      const msg = readError(err)
+      setActionError(
+        msg.toLowerCase().includes('403') || msg.toLowerCase().includes('forbidden')
+          ? '割り当て追加には HR_MANAGER/ADMIN 権限が必要です'
+          : msg,
+      )
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  async function handleDecline(assignmentId: string): Promise<void> {
+    setDeclining(true)
+    setActionError(null)
+    try {
+      await fetchJson(`${ASSIGNMENTS_URL}/${assignmentId}/decline`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          reason: declineForm.reason,
+          replacementEvaluatorId: declineForm.replacementEvaluatorId || undefined,
+        }),
+      })
+      setDeclineTargetId(null)
+      setDeclineForm({ reason: '', replacementEvaluatorId: '' })
+      await loadAssignments()
+    } catch (err) {
+      setActionError(readError(err))
+    } finally {
+      setDeclining(false)
+    }
+  }
+
+  function addField(key: keyof AddFormValues) {
+    return (e: ChangeEvent<HTMLInputElement>) =>
+      setAddForm((v) => ({ ...v, [key]: e.target.value }))
+  }
+
+  function declineField(key: keyof DeclineFormValues) {
+    return (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) =>
+      setDeclineForm((v) => ({ ...v, [key]: e.target.value }))
+  }
+
+  return (
+    <main className="mx-auto max-w-4xl px-6 py-10">
+      <header className="mb-8 flex items-start justify-between gap-4">
+        <div>
+          <p className="text-xs font-semibold tracking-widest text-indigo-600 uppercase">
+            360度評価
+          </p>
+          <h1 className="mt-1 text-3xl font-bold text-slate-900">評価割り当て管理</h1>
+          <p className="mt-2 text-sm text-slate-600">
+            評価者・対象者の割り当て追加と辞退処理を行います。
+          </p>
+          {cycleId && (
+            <p className="mt-1 text-xs text-slate-500">
+              サイクル ID: <span className="font-mono">{cycleId}</span>
+            </p>
+          )}
+        </div>
+        <div className="flex shrink-0 gap-2">
+          <a
+            href="/evaluation/cycles"
+            className="rounded-lg border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50"
+          >
+            ← サイクル一覧
+          </a>
+          {cycleId && (
+            <button
+              type="button"
+              onClick={() => setShowAddForm((v) => !v)}
+              className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700"
+            >
+              {showAddForm ? 'キャンセル' : '＋ 割り当て追加'}
+            </button>
+          )}
+        </div>
+      </header>
+
+      {!cycleId && (
+        <div className="rounded-xl border border-slate-200 bg-white py-16 text-center text-sm text-slate-400">
+          URL に <span className="font-mono">?cycleId=...</span> を付けてアクセスしてください
+        </div>
+      )}
+
+      {cycleId && actionError && (
+        <div className="mb-4 rounded-lg border border-rose-300 bg-rose-50 p-3 text-sm text-rose-800">
+          {actionError}
+        </div>
+      )}
+
+      {cycleId && showAddForm && (
+        <form
+          onSubmit={handleAdd}
+          className="mb-8 rounded-xl border border-indigo-200 bg-indigo-50 p-6"
+        >
+          <h2 className="mb-4 font-semibold text-slate-800">割り当てを追加</h2>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div>
+              <label className="mb-1 block text-xs font-medium text-slate-600">
+                評価者 ID <span className="text-rose-500">*</span>
+              </label>
+              <input
+                required
+                value={addForm.evaluatorId}
+                onChange={addField('evaluatorId')}
+                placeholder="評価者の社員 ID"
+                className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-indigo-400 focus:outline-none"
+              />
+            </div>
+            <div>
+              <label className="mb-1 block text-xs font-medium text-slate-600">
+                対象者 ID <span className="text-rose-500">*</span>
+              </label>
+              <input
+                required
+                value={addForm.targetUserId}
+                onChange={addField('targetUserId')}
+                placeholder="被評価者の社員 ID"
+                className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-indigo-400 focus:outline-none"
+              />
+            </div>
+          </div>
+          <div className="mt-4 flex justify-end">
+            <button
+              type="submit"
+              disabled={submitting}
+              className="rounded-lg bg-indigo-600 px-5 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
+            >
+              {submitting ? '追加中…' : '追加する'}
+            </button>
+          </div>
+        </form>
+      )}
+
+      {cycleId && <AssignmentList state={state} onDecline={setDeclineTargetId} />}
+
+      {/* Decline Modal */}
+      {declineTargetId !== null && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+          <div className="w-full max-w-md rounded-xl border border-slate-200 bg-white p-6 shadow-xl">
+            <h3 className="mb-4 font-semibold text-slate-900">評価を辞退する</h3>
+            <div className="space-y-3">
+              <div>
+                <label className="mb-1 block text-xs font-medium text-slate-600">
+                  辞退理由 <span className="text-rose-500">*</span>
+                </label>
+                <textarea
+                  rows={3}
+                  maxLength={1000}
+                  value={declineForm.reason}
+                  onChange={declineField('reason')}
+                  placeholder="辞退理由を入力してください"
+                  className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-indigo-400 focus:outline-none"
+                />
+              </div>
+              <div>
+                <label className="mb-1 block text-xs font-medium text-slate-600">
+                  代替評価者 ID（任意）
+                </label>
+                <input
+                  value={declineForm.replacementEvaluatorId}
+                  onChange={declineField('replacementEvaluatorId')}
+                  placeholder="代替の評価者 ID（任意）"
+                  className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-indigo-400 focus:outline-none"
+                />
+              </div>
+            </div>
+            {actionError && <p className="mt-2 text-xs text-rose-600">{actionError}</p>}
+            <div className="mt-4 flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => {
+                  setDeclineTargetId(null)
+                  setDeclineForm({ reason: '', replacementEvaluatorId: '' })
+                  setActionError(null)
+                }}
+                className="rounded-lg border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50"
+              >
+                キャンセル
+              </button>
+              <button
+                type="button"
+                disabled={declining || !declineForm.reason}
+                onClick={() => void handleDecline(declineTargetId)}
+                className="rounded-lg bg-rose-600 px-4 py-2 text-sm font-medium text-white hover:bg-rose-700 disabled:opacity-50"
+              >
+                {declining ? '処理中…' : '辞退する'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </main>
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// AssignmentList
+// ─────────────────────────────────────────────────────────────────────────────
+
+function AssignmentList({
+  state,
+  onDecline,
+}: {
+  readonly state: AssignmentState
+  readonly onDecline: (id: string) => void
+}): ReactElement {
+  if (state.kind === 'idle') {
+    return (
+      <div className="rounded-xl border border-slate-200 bg-white py-16 text-center text-sm text-slate-400">
+        サイクル ID を指定してください
+      </div>
+    )
+  }
+  if (state.kind === 'loading') {
+    return (
+      <div className="flex items-center justify-center rounded-xl border border-slate-200 bg-white py-16 text-sm text-slate-500">
+        <span className="animate-pulse">読み込み中…</span>
+      </div>
+    )
+  }
+  if (state.kind === 'error') {
+    return (
+      <div className="rounded-xl border border-rose-300 bg-rose-50 p-6 text-sm text-rose-800">
+        <p className="font-semibold">データの取得に失敗しました</p>
+        <p className="mt-1 text-xs">{state.message}</p>
+      </div>
+    )
+  }
+  if (state.assignments.length === 0) {
+    return (
+      <div className="rounded-xl border border-slate-200 bg-white py-16 text-center text-sm text-slate-400">
+        割り当てがありません
+      </div>
+    )
+  }
+
+  const sorted = [...state.assignments].sort(
+    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+  )
+
+  return (
+    <div className="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-slate-100 bg-slate-50">
+            <th className="px-4 py-3 text-left text-xs font-medium text-slate-500">評価者 ID</th>
+            <th className="px-4 py-3 text-left text-xs font-medium text-slate-500">対象者 ID</th>
+            <th className="px-4 py-3 text-left text-xs font-medium text-slate-500">ステータス</th>
+            <th className="px-4 py-3 text-left text-xs font-medium text-slate-500">作成日</th>
+            <th className="px-4 py-3 text-left text-xs font-medium text-slate-500">操作</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-slate-100">
+          {sorted.map((a) => (
+            <tr key={a.id} className="hover:bg-slate-50">
+              <td className="px-4 py-3 font-mono text-xs text-slate-700">{a.evaluatorId}</td>
+              <td className="px-4 py-3 font-mono text-xs text-slate-700">{a.targetUserId}</td>
+              <td className="px-4 py-3">
+                <span
+                  className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${STATUS_COLORS[a.status]}`}
+                >
+                  {STATUS_LABELS[a.status]}
+                </span>
+                {a.decline && (
+                  <p className="mt-0.5 text-xs text-slate-400">理由: {a.decline.reason}</p>
+                )}
+              </td>
+              <td className="px-4 py-3 text-xs text-slate-500">{formatDate(a.createdAt)}</td>
+              <td className="px-4 py-3">
+                {a.status === 'ACTIVE' && (
+                  <div className="flex flex-wrap gap-2">
+                    <a
+                      href={`/evaluation/form?cycleId=${a.cycleId}&targetUserId=${a.targetUserId}`}
+                      className="rounded-md border border-indigo-200 px-2 py-1 text-xs font-medium text-indigo-600 hover:bg-indigo-50"
+                    >
+                      評価する →
+                    </a>
+                    <button
+                      type="button"
+                      onClick={() => onDecline(a.id)}
+                      className="rounded-md border border-rose-200 px-2 py-1 text-xs font-medium text-rose-600 hover:bg-rose-50"
+                    >
+                      辞退
+                    </button>
+                  </div>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/src/app/evaluation/cycles/page.tsx
+++ b/src/app/evaluation/cycles/page.tsx
@@ -1,0 +1,489 @@
+/**
+ * Issue #179 / Task 15.2 / Req 8.1, 8.2: 360度評価サイクル管理画面
+ *
+ * - GET  /api/evaluation/cycles — サイクル一覧
+ * - POST /api/evaluation/cycles — サイクル作成（HR_MANAGER/ADMIN）
+ * - POST /api/evaluation/cycles/[id]/activate — DRAFT → ACTIVE
+ * - POST /api/evaluation/cycles/[id]/close    — FINALIZED → CLOSED
+ */
+'use client'
+
+import { useEffect, useState, type ReactElement, type FormEvent, type ChangeEvent } from 'react'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+type ReviewCycleStatus =
+  | 'DRAFT'
+  | 'ACTIVE'
+  | 'AGGREGATING'
+  | 'PENDING_FEEDBACK_APPROVAL'
+  | 'FINALIZED'
+  | 'CLOSED'
+
+interface ReviewCycleRecord {
+  readonly id: string
+  readonly name: string
+  readonly status: ReviewCycleStatus
+  readonly startDate: string
+  readonly endDate: string
+  readonly items: readonly string[]
+  readonly incentiveK: number
+  readonly minReviewers: number
+  readonly maxTargets: number
+  readonly createdBy: string
+  readonly createdAt: string
+}
+
+interface ApiEnvelope<T> {
+  readonly success?: boolean
+  readonly data?: T
+  readonly error?: string
+}
+
+type PageState =
+  | { readonly kind: 'loading' }
+  | { readonly kind: 'error'; readonly message: string }
+  | { readonly kind: 'ready'; readonly cycles: readonly ReviewCycleRecord[] }
+
+interface FormValues {
+  name: string
+  startDate: string
+  endDate: string
+  items: string
+  incentiveK: string
+  minReviewers: string
+  maxTargets: string
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Constants
+// ─────────────────────────────────────────────────────────────────────────────
+
+const CYCLES_URL = '/api/evaluation/cycles'
+
+const EMPTY_FORM: FormValues = {
+  name: '',
+  startDate: '',
+  endDate: '',
+  items: '',
+  incentiveK: '1',
+  minReviewers: '3',
+  maxTargets: '10',
+}
+
+const STATUS_LABELS: Record<ReviewCycleStatus, string> = {
+  DRAFT: '下書き',
+  ACTIVE: '実施中',
+  AGGREGATING: '集計中',
+  PENDING_FEEDBACK_APPROVAL: 'FB承認待ち',
+  FINALIZED: '完了',
+  CLOSED: 'クローズ',
+}
+
+const STATUS_COLORS: Record<ReviewCycleStatus, string> = {
+  DRAFT: 'bg-slate-100 text-slate-600',
+  ACTIVE: 'bg-indigo-100 text-indigo-700',
+  AGGREGATING: 'bg-amber-100 text-amber-700',
+  PENDING_FEEDBACK_APPROVAL: 'bg-purple-100 text-purple-700',
+  FINALIZED: 'bg-emerald-100 text-emerald-700',
+  CLOSED: 'bg-slate-100 text-slate-500',
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function fetchJson<T>(url: string, options?: RequestInit): Promise<T> {
+  const res = await fetch(url, { cache: 'no-store', ...options })
+  const envelope = (await res.json().catch(() => ({}))) as ApiEnvelope<T>
+  if (!res.ok) throw new Error(envelope.error ?? `HTTP ${res.status}`)
+  return (envelope.data ?? null) as T
+}
+
+function readError(err: unknown): string {
+  if (err instanceof Error) return err.message
+  return '予期せぬエラーが発生しました'
+}
+
+function formatDate(iso: string): string {
+  return iso.slice(0, 10)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Page
+// ─────────────────────────────────────────────────────────────────────────────
+
+export default function EvaluationCyclesPage(): ReactElement {
+  const [state, setState] = useState<PageState>({ kind: 'loading' })
+  const [showForm, setShowForm] = useState(false)
+  const [form, setForm] = useState<FormValues>(EMPTY_FORM)
+  const [submitting, setSubmitting] = useState(false)
+  const [actionError, setActionError] = useState<string | null>(null)
+  const [transitionId, setTransitionId] = useState<string | null>(null)
+
+  async function loadCycles(): Promise<void> {
+    setState({ kind: 'loading' })
+    try {
+      const cycles = await fetchJson<ReviewCycleRecord[]>(CYCLES_URL)
+      setState({ kind: 'ready', cycles: Array.isArray(cycles) ? cycles : [] })
+    } catch (err) {
+      setState({ kind: 'error', message: readError(err) })
+    }
+  }
+
+  useEffect(() => {
+    void loadCycles()
+  }, [])
+
+  async function handleCreate(e: FormEvent): Promise<void> {
+    e.preventDefault()
+    setSubmitting(true)
+    setActionError(null)
+    try {
+      const itemsArray = form.items
+        .split('\n')
+        .map((s) => s.trim())
+        .filter(Boolean)
+      await fetchJson(CYCLES_URL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: form.name,
+          startDate: form.startDate,
+          endDate: form.endDate,
+          items: itemsArray,
+          incentiveK: Number(form.incentiveK),
+          minReviewers: Number(form.minReviewers),
+          maxTargets: Number(form.maxTargets),
+        }),
+      })
+      setForm(EMPTY_FORM)
+      setShowForm(false)
+      await loadCycles()
+    } catch (err) {
+      const msg = readError(err)
+      setActionError(
+        msg.toLowerCase().includes('403') || msg.toLowerCase().includes('forbidden')
+          ? 'サイクル作成には HR_MANAGER/ADMIN 権限が必要です'
+          : msg,
+      )
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  async function handleTransition(cycleId: string, action: 'activate' | 'close'): Promise<void> {
+    setTransitionId(cycleId)
+    setActionError(null)
+    try {
+      await fetchJson(`${CYCLES_URL}/${cycleId}/${action}`, { method: 'POST' })
+      await loadCycles()
+    } catch (err) {
+      setActionError(readError(err))
+    } finally {
+      setTransitionId(null)
+    }
+  }
+
+  function field(key: keyof FormValues) {
+    return (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) =>
+      setForm((v) => ({ ...v, [key]: e.target.value }))
+  }
+
+  return (
+    <main className="mx-auto max-w-4xl px-6 py-10">
+      <header className="mb-8 flex items-start justify-between gap-4">
+        <div>
+          <p className="text-xs font-semibold tracking-widest text-indigo-600 uppercase">
+            360度評価
+          </p>
+          <h1 className="mt-1 text-3xl font-bold text-slate-900">評価サイクル管理</h1>
+          <p className="mt-2 text-sm text-slate-600">
+            評価サイクルの作成・状態管理を行います。HR_MANAGER/ADMIN のみ作成・状態変更可能です。
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => setShowForm((v) => !v)}
+          className="shrink-0 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700"
+        >
+          {showForm ? 'キャンセル' : '＋ サイクルを作成'}
+        </button>
+      </header>
+
+      {actionError && (
+        <div className="mb-4 rounded-lg border border-rose-300 bg-rose-50 p-3 text-sm text-rose-800">
+          {actionError}
+        </div>
+      )}
+
+      {showForm && (
+        <form
+          onSubmit={handleCreate}
+          className="mb-8 rounded-xl border border-indigo-200 bg-indigo-50 p-6"
+        >
+          <h2 className="mb-4 font-semibold text-slate-800">評価サイクルを登録</h2>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="sm:col-span-2">
+              <label className="mb-1 block text-xs font-medium text-slate-600">
+                サイクル名 <span className="text-rose-500">*</span>
+              </label>
+              <input
+                required
+                value={form.name}
+                onChange={field('name')}
+                placeholder="例: 2024年度上期 360度評価"
+                className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-indigo-400 focus:outline-none"
+              />
+            </div>
+            <div>
+              <label className="mb-1 block text-xs font-medium text-slate-600">
+                開始日 <span className="text-rose-500">*</span>
+              </label>
+              <input
+                required
+                type="date"
+                value={form.startDate}
+                onChange={field('startDate')}
+                className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-indigo-400 focus:outline-none"
+              />
+            </div>
+            <div>
+              <label className="mb-1 block text-xs font-medium text-slate-600">
+                終了日 <span className="text-rose-500">*</span>
+              </label>
+              <input
+                required
+                type="date"
+                value={form.endDate}
+                onChange={field('endDate')}
+                className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-indigo-400 focus:outline-none"
+              />
+            </div>
+            <div className="sm:col-span-2">
+              <label className="mb-1 block text-xs font-medium text-slate-600">
+                評価項目（1行1項目）<span className="text-rose-500">*</span>
+              </label>
+              <textarea
+                required
+                rows={4}
+                value={form.items}
+                onChange={field('items')}
+                placeholder={'価値観体現\n経営貢献\nチームワーク'}
+                className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-indigo-400 focus:outline-none"
+              />
+            </div>
+            <div>
+              <label className="mb-1 block text-xs font-medium text-slate-600">
+                インセンティブ係数 k <span className="text-rose-500">*</span>
+              </label>
+              <input
+                required
+                type="number"
+                step="0.1"
+                min="0.1"
+                max="10"
+                value={form.incentiveK}
+                onChange={field('incentiveK')}
+                className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-indigo-400 focus:outline-none"
+              />
+            </div>
+            <div>
+              <label className="mb-1 block text-xs font-medium text-slate-600">
+                最低評価者数 <span className="text-rose-500">*</span>
+              </label>
+              <input
+                required
+                type="number"
+                min="1"
+                max="50"
+                value={form.minReviewers}
+                onChange={field('minReviewers')}
+                className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-indigo-400 focus:outline-none"
+              />
+            </div>
+            <div>
+              <label className="mb-1 block text-xs font-medium text-slate-600">
+                最大対象者数 <span className="text-rose-500">*</span>
+              </label>
+              <input
+                required
+                type="number"
+                min="1"
+                max="1000"
+                value={form.maxTargets}
+                onChange={field('maxTargets')}
+                className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-indigo-400 focus:outline-none"
+              />
+            </div>
+          </div>
+          <div className="mt-4 flex justify-end">
+            <button
+              type="submit"
+              disabled={submitting}
+              className="rounded-lg bg-indigo-600 px-5 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
+            >
+              {submitting ? '作成中…' : '作成する'}
+            </button>
+          </div>
+        </form>
+      )}
+
+      <CycleList
+        state={state}
+        transitionId={transitionId}
+        onActivate={(id) => void handleTransition(id, 'activate')}
+        onClose={(id) => void handleTransition(id, 'close')}
+      />
+    </main>
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CycleList
+// ─────────────────────────────────────────────────────────────────────────────
+
+function CycleList({
+  state,
+  transitionId,
+  onActivate,
+  onClose,
+}: {
+  readonly state: PageState
+  readonly transitionId: string | null
+  readonly onActivate: (id: string) => void
+  readonly onClose: (id: string) => void
+}): ReactElement {
+  if (state.kind === 'loading') {
+    return (
+      <div className="flex items-center justify-center rounded-xl border border-slate-200 bg-white py-16 text-sm text-slate-500">
+        <span className="animate-pulse">読み込み中…</span>
+      </div>
+    )
+  }
+  if (state.kind === 'error') {
+    return (
+      <div className="rounded-xl border border-rose-300 bg-rose-50 p-6 text-sm text-rose-800">
+        <p className="font-semibold">データの取得に失敗しました</p>
+        <p className="mt-1 text-xs">{state.message}</p>
+      </div>
+    )
+  }
+  if (state.cycles.length === 0) {
+    return (
+      <div className="rounded-xl border border-slate-200 bg-white py-16 text-center text-sm text-slate-400">
+        評価サイクルがありません
+      </div>
+    )
+  }
+
+  const sorted = [...state.cycles].sort(
+    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+  )
+
+  return (
+    <div className="space-y-4">
+      {sorted.map((cycle) => (
+        <CycleCard
+          key={cycle.id}
+          cycle={cycle}
+          isTransitioning={transitionId === cycle.id}
+          onActivate={onActivate}
+          onClose={onClose}
+        />
+      ))}
+    </div>
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CycleCard
+// ─────────────────────────────────────────────────────────────────────────────
+
+function CycleCard({
+  cycle,
+  isTransitioning,
+  onActivate,
+  onClose,
+}: {
+  readonly cycle: ReviewCycleRecord
+  readonly isTransitioning: boolean
+  readonly onActivate: (id: string) => void
+  readonly onClose: (id: string) => void
+}): ReactElement {
+  return (
+    <div className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <span
+              className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${STATUS_COLORS[cycle.status]}`}
+            >
+              {STATUS_LABELS[cycle.status]}
+            </span>
+          </div>
+          <p className="mt-1 font-semibold text-slate-900">{cycle.name}</p>
+          <p className="mt-0.5 text-xs text-slate-500">
+            {formatDate(cycle.startDate)} 〜 {formatDate(cycle.endDate)}
+          </p>
+          <div className="mt-2 flex flex-wrap gap-3 text-xs text-slate-500">
+            <span>最低評価者: {cycle.minReviewers}名</span>
+            <span>最大対象者: {cycle.maxTargets}名</span>
+            <span>係数 k: {cycle.incentiveK}</span>
+          </div>
+          <div className="mt-2 flex flex-wrap gap-1">
+            {cycle.items.map((item) => (
+              <span
+                key={item}
+                className="rounded-full bg-slate-100 px-2 py-0.5 text-xs text-slate-600"
+              >
+                {item}
+              </span>
+            ))}
+          </div>
+        </div>
+
+        <div className="flex shrink-0 flex-col gap-2">
+          {cycle.status === 'DRAFT' && (
+            <button
+              type="button"
+              disabled={isTransitioning}
+              onClick={() => onActivate(cycle.id)}
+              className="rounded-md bg-indigo-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
+            >
+              {isTransitioning ? '処理中…' : '開始する'}
+            </button>
+          )}
+          {cycle.status === 'FINALIZED' && (
+            <button
+              type="button"
+              disabled={isTransitioning}
+              onClick={() => onClose(cycle.id)}
+              className="rounded-md border border-slate-300 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 hover:bg-slate-50 disabled:opacity-50"
+            >
+              {isTransitioning ? '処理中…' : 'クローズ'}
+            </button>
+          )}
+          <a
+            href={`/evaluation/assignments?cycleId=${cycle.id}`}
+            className="rounded-md border border-indigo-200 px-3 py-1.5 text-center text-xs font-medium text-indigo-600 hover:bg-indigo-50"
+          >
+            割り当て管理 →
+          </a>
+          {(cycle.status === 'ACTIVE' ||
+            cycle.status === 'AGGREGATING' ||
+            cycle.status === 'FINALIZED') && (
+            <a
+              href={`/evaluation/progress?cycleId=${cycle.id}`}
+              className="rounded-md border border-emerald-200 px-3 py-1.5 text-center text-xs font-medium text-emerald-600 hover:bg-emerald-50"
+            >
+              進捗確認 →
+            </a>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/evaluation/form/page.tsx
+++ b/src/app/evaluation/form/page.tsx
@@ -1,0 +1,569 @@
+/**
+ * Issue #179 / Task 15.4 + 16.2 / Req 8.5, 8.6, 8.7, 9.1–9.6:
+ * 自己評価・ピア評価フォーム（AI コーチ統合）
+ *
+ * - cycleId + targetUserId をクエリパラメータで受け取る
+ * - POST /api/evaluation/responses/draft  — 下書き保存
+ * - POST /api/evaluation/responses/submit — 評価送信
+ * - POST /api/evaluation/ai-coach/validate — AI 品質ゲート
+ */
+'use client'
+
+import {
+  useState,
+  useRef,
+  useEffect,
+  type ReactElement,
+  type FormEvent,
+  type ChangeEvent,
+  type KeyboardEvent,
+} from 'react'
+import { useSearchParams } from 'next/navigation'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+type EvaluationResponseType = 'SELF' | 'TOP_DOWN' | 'PEER'
+
+interface ChatTurn {
+  readonly role: 'user' | 'assistant'
+  readonly content: string
+}
+
+interface ValidateResult {
+  readonly qualityOk: boolean
+  readonly missingAspects: readonly string[]
+  readonly suggestions: string
+  readonly turnNumber: number
+}
+
+interface ApiEnvelope<T> {
+  readonly success?: boolean
+  readonly data?: T
+  readonly error?: string
+  readonly timeout?: {
+    readonly timeout: true
+    readonly elapsedMs: number
+    readonly fallbackToManual: true
+  }
+}
+
+type SubmitState = 'idle' | 'saving' | 'submitting' | 'done'
+
+type AiState =
+  | { readonly kind: 'idle' }
+  | { readonly kind: 'checking' }
+  | { readonly kind: 'ok'; readonly result: ValidateResult }
+  | { readonly kind: 'ng'; readonly result: ValidateResult }
+  | { readonly kind: 'timeout' }
+  | { readonly kind: 'manual' }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Constants
+// ─────────────────────────────────────────────────────────────────────────────
+
+const RESPONSE_TYPE_LABELS: Record<EvaluationResponseType, string> = {
+  SELF: '自己評価',
+  TOP_DOWN: '上司評価',
+  PEER: 'ピア評価',
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function postJson<T>(url: string, body: unknown): Promise<ApiEnvelope<T>> {
+  const res = await fetch(url, {
+    method: 'POST',
+    cache: 'no-store',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+  return (await res.json().catch(() => ({}))) as ApiEnvelope<T>
+}
+
+function readError(err: unknown): string {
+  if (err instanceof Error) return err.message
+  return '予期せぬエラーが発生しました'
+}
+
+function buildAiMessage(result: ValidateResult): string {
+  if (result.qualityOk) {
+    return `✅ 品質チェック通過！\n\n${result.suggestions}`
+  }
+  const aspects = result.missingAspects.map((a) => `• ${a}`).join('\n')
+  return `❌ 改善が必要です\n\n不足している観点:\n${aspects}\n\n提案:\n${result.suggestions}`
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Page
+// ─────────────────────────────────────────────────────────────────────────────
+
+export default function EvaluationFormPage(): ReactElement {
+  const searchParams = useSearchParams()
+  const cycleId = searchParams.get('cycleId') ?? ''
+  const targetUserId = searchParams.get('targetUserId') ?? ''
+
+  // Form fields
+  const [responseType, setResponseType] = useState<EvaluationResponseType>('PEER')
+  const [score, setScore] = useState('80')
+  const [comment, setComment] = useState('')
+  const [subjectRoleContext, setSubjectRoleContext] = useState('')
+
+  // AI coach
+  const [chatHistory, setChatHistory] = useState<readonly ChatTurn[]>([])
+  const [chatInput, setChatInput] = useState('')
+  const [aiState, setAiState] = useState<AiState>({ kind: 'idle' })
+  const chatBottomRef = useRef<HTMLDivElement>(null)
+
+  // Submit
+  const [submitState, setSubmitState] = useState<SubmitState>('idle')
+  const [actionError, setActionError] = useState<string | null>(null)
+  const [draftMsg, setDraftMsg] = useState<string | null>(null)
+
+  useEffect(() => {
+    chatBottomRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [chatHistory])
+
+  const aiQualityPassed = aiState.kind === 'ok' || aiState.kind === 'manual'
+  const canSubmit =
+    submitState === 'idle' &&
+    cycleId !== '' &&
+    targetUserId !== '' &&
+    comment.trim() !== '' &&
+    aiQualityPassed
+
+  // ── AI helpers ──────────────────────────────────────────────────────────────
+
+  async function runAiValidate(history: readonly ChatTurn[]): Promise<void> {
+    setAiState({ kind: 'checking' })
+    try {
+      const envelope = await postJson<ValidateResult>('/api/evaluation/ai-coach/validate', {
+        cycleId,
+        subjectRoleContext: subjectRoleContext || '役割情報なし',
+        draftComment: comment,
+        conversationHistory: history,
+      })
+
+      if (envelope.timeout) {
+        setAiState({ kind: 'timeout' })
+        setChatHistory((h) => [
+          ...h,
+          {
+            role: 'assistant',
+            content: 'AI の応答がタイムアウトしました。手動モードに切り替えられます。',
+          },
+        ])
+        return
+      }
+
+      const result = envelope.data
+      if (!result) {
+        setAiState({
+          kind: 'ng',
+          result: {
+            qualityOk: false,
+            missingAspects: [],
+            suggestions: envelope.error ?? 'エラーが発生しました',
+            turnNumber: 0,
+          },
+        })
+        return
+      }
+
+      setChatHistory((h) => [...h, { role: 'assistant', content: buildAiMessage(result) }])
+      setAiState(result.qualityOk ? { kind: 'ok', result } : { kind: 'ng', result })
+    } catch (err) {
+      setAiState({
+        kind: 'ng',
+        result: {
+          qualityOk: false,
+          missingAspects: [],
+          suggestions: readError(err),
+          turnNumber: 0,
+        },
+      })
+    }
+  }
+
+  async function handleAiCheck(): Promise<void> {
+    if (!comment.trim()) return
+    const nextHistory: readonly ChatTurn[] = [
+      ...chatHistory,
+      { role: 'user', content: `評価コメント:\n${comment}` },
+    ]
+    setChatHistory(nextHistory)
+    await runAiValidate(nextHistory)
+  }
+
+  async function handleChatSend(): Promise<void> {
+    if (!chatInput.trim() || aiState.kind === 'checking') return
+    const userMsg = chatInput.trim()
+    setChatInput('')
+    const nextHistory: readonly ChatTurn[] = [...chatHistory, { role: 'user', content: userMsg }]
+    setChatHistory(nextHistory)
+    await runAiValidate(nextHistory)
+  }
+
+  function handleChatKeyDown(e: KeyboardEvent<HTMLTextAreaElement>): void {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      void handleChatSend()
+    }
+  }
+
+  // ── Form actions ─────────────────────────────────────────────────────────────
+
+  async function handleSaveDraft(e: FormEvent): Promise<void> {
+    e.preventDefault()
+    setSubmitState('saving')
+    setActionError(null)
+    setDraftMsg(null)
+    try {
+      const envelope = await postJson('/api/evaluation/responses/draft', {
+        cycleId,
+        targetUserId,
+        responseType,
+        score: Number(score),
+        comment: comment || undefined,
+      })
+      if (envelope.error) throw new Error(envelope.error)
+      setDraftMsg('下書きを保存しました')
+    } catch (err) {
+      setActionError(readError(err))
+    } finally {
+      setSubmitState('idle')
+    }
+  }
+
+  async function handleSubmit(): Promise<void> {
+    if (!canSubmit) return
+    setSubmitState('submitting')
+    setActionError(null)
+    setDraftMsg(null)
+    try {
+      const envelope = await postJson('/api/evaluation/responses/submit', {
+        cycleId,
+        targetUserId,
+        responseType,
+        score: Number(score),
+        comment: comment || undefined,
+      })
+      if (envelope.error) throw new Error(envelope.error)
+      setSubmitState('done')
+    } catch (err) {
+      setActionError(readError(err))
+      setSubmitState('idle')
+    }
+  }
+
+  // ── Guard: missing query params ───────────────────────────────────────────
+
+  if (!cycleId || !targetUserId) {
+    return (
+      <main className="mx-auto max-w-2xl px-6 py-10">
+        <div className="rounded-xl border border-amber-300 bg-amber-50 p-6 text-sm text-amber-800">
+          <p className="font-semibold">パラメータが不足しています</p>
+          <p className="mt-1 text-xs">
+            URL に <span className="font-mono">?cycleId=...&targetUserId=...</span> が必要です。
+          </p>
+          <a
+            href="/evaluation/assignments"
+            className="mt-3 inline-block text-xs font-medium text-amber-700 underline"
+          >
+            割り当て一覧から開く
+          </a>
+        </div>
+      </main>
+    )
+  }
+
+  // ── Complete screen ───────────────────────────────────────────────────────
+
+  if (submitState === 'done') {
+    return (
+      <main className="mx-auto max-w-2xl px-6 py-10">
+        <div className="rounded-xl border border-emerald-300 bg-emerald-50 p-10 text-center">
+          <p className="text-2xl font-bold text-emerald-800">評価を送信しました ✓</p>
+          <p className="mt-2 text-sm text-emerald-700">ご協力ありがとうございました。</p>
+          <a
+            href="/evaluation/assignments"
+            className="mt-5 inline-block rounded-lg border border-emerald-400 px-5 py-2 text-sm font-medium text-emerald-700 hover:bg-emerald-100"
+          >
+            割り当て一覧に戻る
+          </a>
+        </div>
+      </main>
+    )
+  }
+
+  // ── Main form ─────────────────────────────────────────────────────────────
+
+  return (
+    <main className="mx-auto max-w-3xl px-6 py-10">
+      <header className="mb-8">
+        <p className="text-xs font-semibold tracking-widest text-indigo-600 uppercase">360度評価</p>
+        <h1 className="mt-1 text-3xl font-bold text-slate-900">評価フォーム</h1>
+        <p className="mt-2 text-sm text-slate-600">
+          評価を入力し、AI コーチの品質チェックを通過してから送信してください。
+        </p>
+        <div className="mt-2 flex flex-wrap gap-3 text-xs text-slate-500">
+          <span>
+            サイクル: <span className="font-mono">{cycleId}</span>
+          </span>
+          <span>
+            対象者: <span className="font-mono">{targetUserId}</span>
+          </span>
+        </div>
+      </header>
+
+      <div className="space-y-6">
+        {/* ── Evaluation form ── */}
+        <form
+          onSubmit={handleSaveDraft}
+          className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm"
+        >
+          <h2 className="mb-4 font-semibold text-slate-800">評価内容</h2>
+          <div className="space-y-4">
+            {/* Response type */}
+            <div>
+              <label className="mb-1 block text-xs font-medium text-slate-600">評価種別</label>
+              <div className="flex flex-wrap gap-2">
+                {(['SELF', 'TOP_DOWN', 'PEER'] as const).map((t) => (
+                  <button
+                    key={t}
+                    type="button"
+                    onClick={() => setResponseType(t)}
+                    className={`rounded-lg border px-3 py-1.5 text-xs font-medium transition-colors ${
+                      responseType === t
+                        ? 'border-indigo-400 bg-indigo-50 text-indigo-700'
+                        : 'border-slate-200 bg-white text-slate-600 hover:border-indigo-200'
+                    }`}
+                  >
+                    {RESPONSE_TYPE_LABELS[t]}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* Score slider */}
+            <div>
+              <label className="mb-1 block text-xs font-medium text-slate-600">
+                スコア（0〜100）<span className="text-rose-500">*</span>
+              </label>
+              <div className="flex items-center gap-3">
+                <input
+                  type="range"
+                  min="0"
+                  max="100"
+                  value={score}
+                  onChange={(e: ChangeEvent<HTMLInputElement>) => setScore(e.target.value)}
+                  className="flex-1"
+                />
+                <span className="w-10 text-right text-lg font-bold text-indigo-600">{score}</span>
+              </div>
+              <div className="mt-0.5 flex justify-between text-xs text-slate-400">
+                <span>0</span>
+                <span>基準: 80点</span>
+                <span>100</span>
+              </div>
+            </div>
+
+            {/* Subject role context */}
+            <div>
+              <label className="mb-1 block text-xs font-medium text-slate-600">
+                対象者の役職・等級コンテキスト（AI コーチ用）
+              </label>
+              <input
+                value={subjectRoleContext}
+                onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                  setSubjectRoleContext(e.target.value)
+                }
+                placeholder="例: シニアエンジニア / グレード3"
+                className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-indigo-400 focus:outline-none"
+              />
+            </div>
+
+            {/* Comment */}
+            <div>
+              <label className="mb-1 block text-xs font-medium text-slate-600">
+                評価コメント <span className="text-rose-500">*</span>
+              </label>
+              <textarea
+                rows={5}
+                maxLength={2000}
+                value={comment}
+                onChange={(e: ChangeEvent<HTMLTextAreaElement>) => {
+                  setComment(e.target.value)
+                  if (aiState.kind === 'ok' || aiState.kind === 'ng') {
+                    setAiState({ kind: 'idle' })
+                  }
+                }}
+                placeholder="具体的なエピソードを含め、価値観体現・経営貢献の観点から評価してください"
+                className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-indigo-400 focus:outline-none"
+              />
+              <p className="mt-0.5 text-right text-xs text-slate-400">{comment.length} / 2000</p>
+            </div>
+          </div>
+
+          {actionError && <p className="mt-2 text-xs text-rose-600">{actionError}</p>}
+          {draftMsg && <p className="mt-2 text-xs text-emerald-600">{draftMsg}</p>}
+
+          <div className="mt-4 flex justify-end">
+            <button
+              type="submit"
+              disabled={submitState === 'saving'}
+              className="rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50 disabled:opacity-50"
+            >
+              {submitState === 'saving' ? '保存中…' : '下書き保存'}
+            </button>
+          </div>
+        </form>
+
+        {/* ── AI Coach Chat ── */}
+        <div className="rounded-xl border border-slate-200 bg-white shadow-sm">
+          <div className="flex items-center justify-between border-b border-slate-100 px-5 py-3">
+            <div>
+              <p className="font-semibold text-slate-800">AI コーチ</p>
+              <p className="text-xs text-slate-500">
+                コメントの具体性・価値観関連性を判定します（品質ゲート）
+              </p>
+            </div>
+            <AiBadge state={aiState} />
+          </div>
+
+          {/* Messages */}
+          <div className="max-h-72 space-y-3 overflow-y-auto p-4">
+            {chatHistory.length === 0 && (
+              <p className="py-4 text-center text-xs text-slate-400">
+                「AI チェック開始」を押すと品質チェックが始まります
+              </p>
+            )}
+            {chatHistory.map((turn, i) => (
+              <div
+                key={i}
+                className={`flex ${turn.role === 'user' ? 'justify-end' : 'justify-start'}`}
+              >
+                <div
+                  className={`max-w-[80%] rounded-xl px-3 py-2 text-xs whitespace-pre-wrap ${
+                    turn.role === 'user'
+                      ? 'bg-indigo-600 text-white'
+                      : 'bg-slate-100 text-slate-700'
+                  }`}
+                >
+                  {turn.content}
+                </div>
+              </div>
+            ))}
+            {aiState.kind === 'checking' && (
+              <div className="flex justify-start">
+                <div className="rounded-xl bg-slate-100 px-3 py-2 text-xs text-slate-500">
+                  <span className="animate-pulse">AI が判定中…</span>
+                </div>
+              </div>
+            )}
+            <div ref={chatBottomRef} />
+          </div>
+
+          {/* Input area */}
+          <div className="border-t border-slate-100 p-4">
+            {aiState.kind === 'idle' && (
+              <button
+                type="button"
+                disabled={!comment.trim()}
+                onClick={() => void handleAiCheck()}
+                className="w-full rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
+              >
+                AI チェック開始
+              </button>
+            )}
+
+            {aiState.kind === 'ng' && (
+              <div className="flex gap-2">
+                <textarea
+                  rows={2}
+                  value={chatInput}
+                  onChange={(e) => setChatInput(e.target.value)}
+                  onKeyDown={handleChatKeyDown}
+                  placeholder="AI に質問・追記内容を入力（Enter で送信）"
+                  className="flex-1 rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-indigo-400 focus:outline-none"
+                />
+                <button
+                  type="button"
+                  disabled={!chatInput.trim()}
+                  onClick={() => void handleChatSend()}
+                  className="shrink-0 self-end rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
+                >
+                  送信
+                </button>
+              </div>
+            )}
+
+            {aiState.kind === 'timeout' && (
+              <div className="flex items-center justify-between rounded-lg bg-amber-50 px-4 py-2">
+                <p className="text-xs text-amber-700">AI タイムアウト — 手動モードで送信できます</p>
+                <button
+                  type="button"
+                  onClick={() => setAiState({ kind: 'manual' })}
+                  className="text-xs font-medium text-amber-700 underline"
+                >
+                  手動モードで続行
+                </button>
+              </div>
+            )}
+
+            {(aiState.kind === 'ok' || aiState.kind === 'manual') && (
+              <p className="text-center text-xs text-emerald-600">
+                ✅{' '}
+                {aiState.kind === 'ok'
+                  ? '品質チェック通過 — 送信ボタンが有効になりました'
+                  : '手動モード — 送信ボタンが有効になりました'}
+              </p>
+            )}
+          </div>
+        </div>
+
+        {/* ── Submit ── */}
+        <div className="flex flex-col items-end gap-1">
+          <button
+            type="button"
+            disabled={
+              submitState !== 'idle' ||
+              !aiQualityPassed ||
+              !comment.trim() ||
+              !cycleId ||
+              !targetUserId
+            }
+            onClick={() => void handleSubmit()}
+            className="rounded-lg bg-emerald-600 px-6 py-2.5 text-sm font-medium text-white hover:bg-emerald-700 disabled:opacity-40"
+          >
+            {submitState === 'submitting' ? '送信中…' : '評価を送信する'}
+          </button>
+          {!aiQualityPassed && comment.trim() && (
+            <p className="text-xs text-slate-400">
+              ※ AI 品質チェックを通過すると送信ボタンが有効になります
+            </p>
+          )}
+        </div>
+      </div>
+    </main>
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// AiBadge
+// ─────────────────────────────────────────────────────────────────────────────
+
+function AiBadge({ state }: { readonly state: AiState }): ReactElement {
+  const badges: Record<AiState['kind'], { label: string; cls: string }> = {
+    idle: { label: '未チェック', cls: 'bg-slate-100 text-slate-500' },
+    checking: { label: '判定中…', cls: 'bg-amber-100 text-amber-700 animate-pulse' },
+    ok: { label: '✓ 通過', cls: 'bg-emerald-100 text-emerald-700 font-medium' },
+    ng: { label: '要改善', cls: 'bg-rose-100 text-rose-700 font-medium' },
+    timeout: { label: 'タイムアウト', cls: 'bg-amber-100 text-amber-700 font-medium' },
+    manual: { label: '✓ 手動', cls: 'bg-emerald-100 text-emerald-700 font-medium' },
+  }
+  const { label, cls } = badges[state.kind]
+  return <span className={`rounded-full px-2 py-0.5 text-xs ${cls}`}>{label}</span>
+}

--- a/src/app/evaluation/progress/page.tsx
+++ b/src/app/evaluation/progress/page.tsx
@@ -1,0 +1,446 @@
+/**
+ * Issue #179 / Task 15.6 / Req 8.8, 8.9: 評価進捗表示・リマインダー画面
+ *
+ * - cycleId をクエリパラメータで受け取る
+ * - GET  /api/evaluation/cycles/[id]/progress     — HR向け全体進捗（HR_MANAGER/ADMIN）
+ * - GET  /api/evaluation/cycles/[id]/progress/me  — 個人進捗（全員）
+ * - POST /api/evaluation/reminder/scan            — リマインダースキャン（ADMIN）
+ */
+'use client'
+
+import { useEffect, useState, type ReactElement } from 'react'
+import { useSearchParams } from 'next/navigation'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface EvaluatorProgressRecord {
+  readonly evaluatorId: string
+  readonly totalAssignments: number
+  readonly submittedCount: number
+  readonly pendingCount: number
+}
+
+interface CycleProgressRecord {
+  readonly cycleId: string
+  readonly totalEvaluators: number
+  readonly fullySubmittedCount: number
+  readonly evaluators: readonly EvaluatorProgressRecord[]
+}
+
+interface ReminderScanResult {
+  readonly notified: number
+  readonly skipped: number
+}
+
+interface ApiEnvelope<T> {
+  readonly success?: boolean
+  readonly data?: T
+  readonly error?: string
+}
+
+type ProgressState =
+  | { readonly kind: 'idle' }
+  | { readonly kind: 'loading' }
+  | { readonly kind: 'error'; readonly message: string }
+  | { readonly kind: 'hidden' }
+  | { readonly kind: 'ready'; readonly progress: CycleProgressRecord }
+
+type MyProgressState =
+  | { readonly kind: 'loading' }
+  | { readonly kind: 'error'; readonly message: string }
+  | { readonly kind: 'ready'; readonly progress: EvaluatorProgressRecord }
+
+type ScanState =
+  | { readonly kind: 'idle' }
+  | { readonly kind: 'scanning' }
+  | { readonly kind: 'done'; readonly result: ReminderScanResult }
+  | { readonly kind: 'error'; readonly message: string }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function fetchJson<T>(url: string, options?: RequestInit): Promise<T> {
+  const res = await fetch(url, { cache: 'no-store', ...options })
+  const envelope = (await res.json().catch(() => ({}))) as ApiEnvelope<T>
+  if (!res.ok) throw new Error(envelope.error ?? `HTTP ${res.status}`)
+  return (envelope.data ?? null) as T
+}
+
+function readError(err: unknown): string {
+  if (err instanceof Error) return err.message
+  return '予期せぬエラーが発生しました'
+}
+
+function isForbidden(err: unknown): boolean {
+  if (!(err instanceof Error)) return false
+  const msg = err.message.toLowerCase()
+  return msg.includes('403') || msg.includes('forbidden')
+}
+
+function pct(submitted: number, total: number): number {
+  if (total === 0) return 0
+  return Math.round((submitted / total) * 100)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Page
+// ─────────────────────────────────────────────────────────────────────────────
+
+export default function EvaluationProgressPage(): ReactElement {
+  const searchParams = useSearchParams()
+  const cycleId = searchParams.get('cycleId') ?? ''
+
+  const [progressState, setProgressState] = useState<ProgressState>(
+    cycleId ? { kind: 'loading' } : { kind: 'idle' },
+  )
+  const [myState, setMyState] = useState<MyProgressState>({ kind: 'loading' })
+  const [scanState, setScanState] = useState<ScanState>({ kind: 'idle' })
+
+  async function loadAll(): Promise<void> {
+    if (!cycleId) return
+
+    // Load personal progress (all roles)
+    try {
+      const my = await fetchJson<EvaluatorProgressRecord>(
+        `/api/evaluation/cycles/${encodeURIComponent(cycleId)}/progress/me`,
+      )
+      setMyState({ kind: 'ready', progress: my })
+    } catch (err) {
+      setMyState({ kind: 'error', message: readError(err) })
+    }
+
+    // Load HR progress (HR_MANAGER/ADMIN only — 403 → hidden)
+    try {
+      const all = await fetchJson<CycleProgressRecord>(
+        `/api/evaluation/cycles/${encodeURIComponent(cycleId)}/progress`,
+      )
+      setProgressState({ kind: 'ready', progress: all })
+    } catch (err) {
+      if (isForbidden(err)) {
+        setProgressState({ kind: 'hidden' })
+      } else {
+        setProgressState({ kind: 'error', message: readError(err) })
+      }
+    }
+  }
+
+  useEffect(() => {
+    void loadAll()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [cycleId])
+
+  async function handleScan(): Promise<void> {
+    setScanState({ kind: 'scanning' })
+    try {
+      const result = await fetchJson<ReminderScanResult>('/api/evaluation/reminder/scan', {
+        method: 'POST',
+      })
+      setScanState({ kind: 'done', result })
+    } catch (err) {
+      setScanState({ kind: 'error', message: readError(err) })
+    }
+  }
+
+  return (
+    <main className="mx-auto max-w-4xl px-6 py-10">
+      <header className="mb-8 flex items-start justify-between gap-4">
+        <div>
+          <p className="text-xs font-semibold tracking-widest text-indigo-600 uppercase">
+            360度評価
+          </p>
+          <h1 className="mt-1 text-3xl font-bold text-slate-900">進捗確認</h1>
+          <p className="mt-2 text-sm text-slate-600">
+            評価の提出状況を確認します。リマインダー通知は ADMIN のみ実行できます。
+          </p>
+          {cycleId && (
+            <p className="mt-1 text-xs text-slate-500">
+              サイクル ID: <span className="font-mono">{cycleId}</span>
+            </p>
+          )}
+        </div>
+        <a
+          href="/evaluation/cycles"
+          className="shrink-0 rounded-lg border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50"
+        >
+          ← サイクル一覧
+        </a>
+      </header>
+
+      {!cycleId ? (
+        <div className="rounded-xl border border-slate-200 bg-white py-16 text-center text-sm text-slate-400">
+          URL に <span className="font-mono">?cycleId=...</span> を付けてアクセスしてください
+        </div>
+      ) : (
+        <div className="space-y-6">
+          {/* My progress */}
+          <MyProgressSection state={myState} />
+
+          {/* HR full progress */}
+          {progressState.kind !== 'hidden' && <HrProgressSection state={progressState} />}
+
+          {/* Reminder scan (ADMIN) */}
+          <ReminderSection scanState={scanState} onScan={() => void handleScan()} />
+        </div>
+      )}
+    </main>
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// MyProgressSection
+// ─────────────────────────────────────────────────────────────────────────────
+
+function MyProgressSection({ state }: { readonly state: MyProgressState }): ReactElement {
+  return (
+    <section className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+      <h2 className="mb-4 font-semibold text-slate-800">自分の進捗</h2>
+      {state.kind === 'loading' && (
+        <div className="text-center text-sm text-slate-400">
+          <span className="animate-pulse">読み込み中…</span>
+        </div>
+      )}
+      {state.kind === 'error' && <p className="text-sm text-rose-600">{state.message}</p>}
+      {state.kind === 'ready' && (
+        <div className="space-y-4">
+          <div className="grid grid-cols-3 gap-4 text-center">
+            <Stat label="割り当て総数" value={state.progress.totalAssignments} />
+            <Stat label="提出済み" value={state.progress.submittedCount} color="text-emerald-600" />
+            <Stat label="未提出" value={state.progress.pendingCount} color="text-rose-600" />
+          </div>
+          <ProgressBar
+            submitted={state.progress.submittedCount}
+            total={state.progress.totalAssignments}
+          />
+        </div>
+      )}
+    </section>
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// HrProgressSection
+// ─────────────────────────────────────────────────────────────────────────────
+
+function HrProgressSection({ state }: { readonly state: ProgressState }): ReactElement {
+  if (state.kind === 'idle') return <></>
+
+  return (
+    <section className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+      <h2 className="mb-4 font-semibold text-slate-800">全体進捗（HR 向け）</h2>
+
+      {state.kind === 'loading' && (
+        <div className="text-center text-sm text-slate-400">
+          <span className="animate-pulse">読み込み中…</span>
+        </div>
+      )}
+      {state.kind === 'error' && (
+        <div className="rounded-lg border border-rose-300 bg-rose-50 p-4 text-sm text-rose-800">
+          <p className="font-semibold">データの取得に失敗しました</p>
+          <p className="mt-1 text-xs">{state.message}</p>
+        </div>
+      )}
+      {state.kind === 'ready' && (
+        <div className="space-y-5">
+          <div className="grid grid-cols-2 gap-4 text-center sm:grid-cols-3">
+            <Stat label="評価者総数" value={state.progress.totalEvaluators} />
+            <Stat
+              label="全提出完了"
+              value={state.progress.fullySubmittedCount}
+              color="text-emerald-600"
+            />
+            <Stat
+              label="完了率"
+              value={`${pct(state.progress.fullySubmittedCount, state.progress.totalEvaluators)}%`}
+              color="text-indigo-600"
+            />
+          </div>
+          <ProgressBar
+            submitted={state.progress.fullySubmittedCount}
+            total={state.progress.totalEvaluators}
+          />
+
+          {state.progress.evaluators.length > 0 && (
+            <div className="mt-4">
+              <h3 className="mb-2 text-xs font-medium text-slate-500">評価者別進捗</h3>
+              <div className="overflow-hidden rounded-lg border border-slate-100">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="bg-slate-50">
+                      <th className="px-3 py-2 text-left text-xs font-medium text-slate-500">
+                        評価者 ID
+                      </th>
+                      <th className="px-3 py-2 text-right text-xs font-medium text-slate-500">
+                        割り当て
+                      </th>
+                      <th className="px-3 py-2 text-right text-xs font-medium text-slate-500">
+                        提出済み
+                      </th>
+                      <th className="px-3 py-2 text-right text-xs font-medium text-slate-500">
+                        未提出
+                      </th>
+                      <th className="px-3 py-2 text-left text-xs font-medium text-slate-500">
+                        進捗
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-slate-100">
+                    {state.progress.evaluators.map((ev) => (
+                      <tr key={ev.evaluatorId} className="hover:bg-slate-50">
+                        <td className="px-3 py-2 font-mono text-xs text-slate-700">
+                          {ev.evaluatorId}
+                        </td>
+                        <td className="px-3 py-2 text-right text-xs text-slate-600">
+                          {ev.totalAssignments}
+                        </td>
+                        <td className="px-3 py-2 text-right text-xs font-medium text-emerald-600">
+                          {ev.submittedCount}
+                        </td>
+                        <td className="px-3 py-2 text-right text-xs text-rose-600">
+                          {ev.pendingCount}
+                        </td>
+                        <td className="px-3 py-2">
+                          <MiniProgressBar
+                            submitted={ev.submittedCount}
+                            total={ev.totalAssignments}
+                          />
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </section>
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ReminderSection
+// ─────────────────────────────────────────────────────────────────────────────
+
+function ReminderSection({
+  scanState,
+  onScan,
+}: {
+  readonly scanState: ScanState
+  readonly onScan: () => void
+}): ReactElement {
+  return (
+    <section className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+      <h2 className="mb-1 font-semibold text-slate-800">リマインダー通知（ADMIN 専用）</h2>
+      <p className="mb-4 text-xs text-slate-500">
+        締切 3 日前のアクティブなサイクルの未提出者に通知を送ります。
+      </p>
+
+      {scanState.kind === 'idle' && (
+        <button
+          type="button"
+          onClick={onScan}
+          className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700"
+        >
+          リマインダーを送信
+        </button>
+      )}
+      {scanState.kind === 'scanning' && (
+        <p className="text-sm text-slate-500">
+          <span className="animate-pulse">スキャン中…</span>
+        </p>
+      )}
+      {scanState.kind === 'done' && (
+        <div className="rounded-lg border border-emerald-200 bg-emerald-50 p-4">
+          <p className="text-sm font-semibold text-emerald-800">スキャン完了</p>
+          <div className="mt-2 flex gap-6 text-sm text-emerald-700">
+            <span>
+              通知送信: <strong>{scanState.result.notified}</strong> 件
+            </span>
+            <span>
+              スキップ: <strong>{scanState.result.skipped}</strong> 件
+            </span>
+          </div>
+        </div>
+      )}
+      {scanState.kind === 'error' && (
+        <div className="rounded-lg border border-rose-300 bg-rose-50 p-4">
+          <p className="text-sm font-semibold text-rose-800">エラーが発生しました</p>
+          <p className="mt-1 text-xs text-rose-700">{scanState.message}</p>
+          {(scanState.message.toLowerCase().includes('403') ||
+            scanState.message.toLowerCase().includes('forbidden')) && (
+            <p className="mt-1 text-xs text-rose-600">リマインダー送信には ADMIN 権限が必要です</p>
+          )}
+        </div>
+      )}
+    </section>
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Sub-components
+// ─────────────────────────────────────────────────────────────────────────────
+
+function Stat({
+  label,
+  value,
+  color = 'text-slate-900',
+}: {
+  readonly label: string
+  readonly value: number | string
+  readonly color?: string
+}): ReactElement {
+  return (
+    <div>
+      <p className={`text-2xl font-bold ${color}`}>{value}</p>
+      <p className="text-xs text-slate-500">{label}</p>
+    </div>
+  )
+}
+
+function ProgressBar({
+  submitted,
+  total,
+}: {
+  readonly submitted: number
+  readonly total: number
+}): ReactElement {
+  const p = pct(submitted, total)
+  return (
+    <div>
+      <div className="mb-1 flex justify-between text-xs text-slate-500">
+        <span>完了率</span>
+        <span>{p}%</span>
+      </div>
+      <div className="h-2.5 w-full overflow-hidden rounded-full bg-slate-100">
+        <div
+          className="h-full rounded-full bg-indigo-500 transition-all"
+          style={{ width: `${p}%` }}
+        />
+      </div>
+    </div>
+  )
+}
+
+function MiniProgressBar({
+  submitted,
+  total,
+}: {
+  readonly submitted: number
+  readonly total: number
+}): ReactElement {
+  const p = pct(submitted, total)
+  return (
+    <div className="flex items-center gap-1.5">
+      <div className="h-1.5 w-20 overflow-hidden rounded-full bg-slate-200">
+        <div
+          className={`h-full rounded-full ${p === 100 ? 'bg-emerald-500' : 'bg-indigo-400'}`}
+          style={{ width: `${p}%` }}
+        />
+      </div>
+      <span className="text-xs text-slate-500">{p}%</span>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- **Task 15.2** `/evaluation/cycles` — 評価サイクル作成・状態管理（DRAFT→ACTIVE→CLOSED）
- **Task 15.3** `/evaluation/assignments` — 割り当て追加（HR_MANAGER/ADMIN）・辞退モーダル（本人）
- **Task 15.4 + 16.2** `/evaluation/form` — 自己/ピア/上司評価フォーム + AI コーチチャット品質ゲート統合
- **Task 15.6** `/evaluation/progress` — 進捗表示（個人 & HR全体）・リマインダースキャン（ADMIN）

## Changes

| Page | Route | Key API |
|------|-------|---------|
| サイクル管理 | `/evaluation/cycles` | `GET/POST /api/evaluation/cycles`, `POST .../activate`, `.../close` |
| 割り当て管理 | `/evaluation/assignments?cycleId=` | `GET/POST /api/evaluation/assignments`, `POST .../decline` |
| 評価フォーム | `/evaluation/form?cycleId=&targetUserId=` | `POST .../responses/draft`, `.../submit`, `.../ai-coach/validate` |
| 進捗確認 | `/evaluation/progress?cycleId=` | `GET .../cycles/[id]/progress`, `.../progress/me`, `POST .../reminder/scan` |

## Design notes

- AI コーチ: チャット形式。`qualityOk=false` のとき送信ボタン無効化。タイムアウト時は手動モード切替
- 403 → `hidden` 状態で該当セクションを非表示（progress の HR セクション）
- 全ページ discriminated union state + `fetchJson<T>` ヘルパーで統一

## Test plan

- [ ] `/evaluation/cycles` でサイクル作成 → 一覧表示
- [ ] 「開始する」ボタンで DRAFT→ACTIVE 遷移
- [ ] `/evaluation/assignments?cycleId=xxx` で割り当て追加・辞退モーダル動作
- [ ] `/evaluation/form?cycleId=xxx&targetUserId=yyy` で AI チェック → 送信
- [ ] AI タイムアウト時に手動モード切替で送信可能
- [ ] `/evaluation/progress?cycleId=xxx` で個人進捗・HR全体進捗・リマインダースキャン
- [ ] 一般ユーザーで HR 全体進捗が hidden になる（403）
- [ ] `pnpm tsc --noEmit` エラーなし（pre-existing globals.css エラーを除く）

Closes #179