### PR TITLE
[UI] ISSUE #180 — フィードバック承認/閲覧・インセンティブ画面の実装

### DIFF
--- a/src/app/evaluation/feedback/approval/page.tsx
+++ b/src/app/evaluation/feedback/approval/page.tsx
@@ -1,0 +1,291 @@
+/**
+ * Issue #180 / Task 17.3 / Req 10.4, 10.6: HR_MANAGER フィードバック承認・公開画面
+ *
+ * - GET  /api/feedback/preview?cycleId=X&subjectId=Y — 変換後プレビュー取得（HR_MANAGER/ADMIN）
+ * - POST /api/feedback/approve                       — 承認・公開（HR_MANAGER/ADMIN）
+ */
+'use client'
+
+import { useState, type ReactElement, type FormEvent } from 'react'
+import { useSearchParams } from 'next/navigation'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface FeedbackPreview {
+  readonly cycleId: string
+  readonly subjectId: string
+  readonly transformedBatch: readonly string[]
+  readonly summary: string
+  readonly status: string
+}
+
+interface ApiEnvelope<T> {
+  readonly success?: boolean
+  readonly data?: T
+  readonly error?: string
+}
+
+type PreviewState =
+  | { readonly kind: 'idle' }
+  | { readonly kind: 'loading' }
+  | { readonly kind: 'error'; readonly message: string }
+  | { readonly kind: 'ready'; readonly preview: FeedbackPreview }
+
+type ApproveState =
+  | { readonly kind: 'idle' }
+  | { readonly kind: 'approving' }
+  | { readonly kind: 'done' }
+  | { readonly kind: 'error'; readonly message: string }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function fetchJson<T>(url: string, options?: RequestInit): Promise<T> {
+  const res = await fetch(url, { cache: 'no-store', ...options })
+  const envelope = (await res.json().catch(() => ({}))) as ApiEnvelope<T>
+  if (!res.ok) throw new Error(envelope.error ?? `HTTP ${res.status}`)
+  return (envelope.data ?? null) as T
+}
+
+function readError(err: unknown): string {
+  if (err instanceof Error) return err.message
+  return '予期せぬエラーが発生しました'
+}
+
+const STATUS_LABELS: Record<string, string> = {
+  TRANSFORMING: '変換中',
+  PENDING_HR_APPROVAL: 'HR承認待ち',
+  APPROVED: '承認済み',
+  PUBLISHED: '公開済み',
+  ARCHIVED: 'アーカイブ済み',
+}
+
+const STATUS_COLORS: Record<string, string> = {
+  TRANSFORMING: 'bg-amber-50 text-amber-700 border-amber-200',
+  PENDING_HR_APPROVAL: 'bg-blue-50 text-blue-700 border-blue-200',
+  APPROVED: 'bg-emerald-50 text-emerald-700 border-emerald-200',
+  PUBLISHED: 'bg-indigo-50 text-indigo-700 border-indigo-200',
+  ARCHIVED: 'bg-slate-50 text-slate-600 border-slate-200',
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Page
+// ─────────────────────────────────────────────────────────────────────────────
+
+export default function FeedbackApprovalPage(): ReactElement {
+  const searchParams = useSearchParams()
+  const defaultCycleId = searchParams.get('cycleId') ?? ''
+  const defaultSubjectId = searchParams.get('subjectId') ?? ''
+
+  const [cycleId, setCycleId] = useState(defaultCycleId)
+  const [subjectId, setSubjectId] = useState(defaultSubjectId)
+  const [previewState, setPreviewState] = useState<PreviewState>({ kind: 'idle' })
+  const [approveState, setApproveState] = useState<ApproveState>({ kind: 'idle' })
+
+  async function handlePreview(e: FormEvent): Promise<void> {
+    e.preventDefault()
+    if (!cycleId.trim() || !subjectId.trim()) return
+
+    setPreviewState({ kind: 'loading' })
+    setApproveState({ kind: 'idle' })
+    try {
+      const preview = await fetchJson<FeedbackPreview>(
+        `/api/feedback/preview?cycleId=${encodeURIComponent(cycleId.trim())}&subjectId=${encodeURIComponent(subjectId.trim())}`,
+      )
+      setPreviewState({ kind: 'ready', preview })
+    } catch (err) {
+      setPreviewState({ kind: 'error', message: readError(err) })
+    }
+  }
+
+  async function handleApprove(): Promise<void> {
+    if (previewState.kind !== 'ready') return
+    setApproveState({ kind: 'approving' })
+    try {
+      await fetchJson<null>('/api/feedback/approve', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          cycleId: previewState.preview.cycleId,
+          subjectId: previewState.preview.subjectId,
+        }),
+      })
+      setApproveState({ kind: 'done' })
+      setPreviewState({
+        kind: 'ready',
+        preview: { ...previewState.preview, status: 'PUBLISHED' },
+      })
+    } catch (err) {
+      setApproveState({ kind: 'error', message: readError(err) })
+    }
+  }
+
+  const canApprove =
+    previewState.kind === 'ready' &&
+    (previewState.preview.status === 'PENDING_HR_APPROVAL' ||
+      previewState.preview.status === 'APPROVED') &&
+    approveState.kind !== 'approving' &&
+    approveState.kind !== 'done'
+
+  return (
+    <main className="mx-auto max-w-3xl px-6 py-10">
+      <header className="mb-8 flex items-start justify-between gap-4">
+        <div>
+          <p className="text-xs font-semibold tracking-widest text-indigo-600 uppercase">
+            360度評価
+          </p>
+          <h1 className="mt-1 text-3xl font-bold text-slate-900">フィードバック承認・公開</h1>
+          <p className="mt-2 text-sm text-slate-600">
+            変換後のフィードバックを確認し、被評価者へ公開します（HR_MANAGER 専用）。
+          </p>
+        </div>
+        <a
+          href="/evaluation/cycles"
+          className="shrink-0 rounded-lg border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50"
+        >
+          ← サイクル一覧
+        </a>
+      </header>
+
+      {/* 検索フォーム */}
+      <section className="mb-6 rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+        <h2 className="mb-4 font-semibold text-slate-800">対象を指定</h2>
+        <form onSubmit={(e) => void handlePreview(e)} className="space-y-4">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <div>
+              <label htmlFor="cycleId" className="mb-1 block text-xs font-medium text-slate-600">
+                サイクル ID
+              </label>
+              <input
+                id="cycleId"
+                type="text"
+                value={cycleId}
+                onChange={(e) => setCycleId(e.target.value)}
+                placeholder="cycle-xxxx"
+                className="w-full rounded-lg border border-slate-300 px-3 py-2 font-mono text-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+              />
+            </div>
+            <div>
+              <label htmlFor="subjectId" className="mb-1 block text-xs font-medium text-slate-600">
+                被評価者 ID
+              </label>
+              <input
+                id="subjectId"
+                type="text"
+                value={subjectId}
+                onChange={(e) => setSubjectId(e.target.value)}
+                placeholder="user-xxxx"
+                className="w-full rounded-lg border border-slate-300 px-3 py-2 font-mono text-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+              />
+            </div>
+          </div>
+          <button
+            type="submit"
+            disabled={!cycleId.trim() || !subjectId.trim() || previewState.kind === 'loading'}
+            className="rounded-lg bg-indigo-600 px-5 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
+          >
+            {previewState.kind === 'loading' ? '読み込み中…' : 'プレビューを取得'}
+          </button>
+        </form>
+      </section>
+
+      {/* エラー */}
+      {previewState.kind === 'error' && (
+        <div className="mb-6 rounded-xl border border-rose-300 bg-rose-50 p-4 text-sm text-rose-800">
+          <p className="font-semibold">プレビューの取得に失敗しました</p>
+          <p className="mt-1 text-xs">{previewState.message}</p>
+        </div>
+      )}
+
+      {/* プレビュー */}
+      {previewState.kind === 'ready' && (
+        <section className="space-y-5 rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+          <div className="flex items-center justify-between">
+            <h2 className="font-semibold text-slate-800">変換後フィードバック</h2>
+            <span
+              className={`rounded-full border px-2.5 py-0.5 text-xs font-medium ${STATUS_COLORS[previewState.preview.status] ?? 'border-slate-200 bg-slate-50 text-slate-600'}`}
+            >
+              {STATUS_LABELS[previewState.preview.status] ?? previewState.preview.status}
+            </span>
+          </div>
+
+          <div className="rounded-lg bg-slate-50 p-3 text-xs text-slate-500">
+            <span>サイクル ID: </span>
+            <span className="font-mono font-medium text-slate-700">
+              {previewState.preview.cycleId}
+            </span>
+            <span className="mx-2">·</span>
+            <span>被評価者 ID: </span>
+            <span className="font-mono font-medium text-slate-700">
+              {previewState.preview.subjectId}
+            </span>
+          </div>
+
+          {/* 要約 */}
+          <div>
+            <h3 className="mb-2 text-xs font-semibold tracking-wide text-slate-500 uppercase">
+              AI 生成サマリー
+            </h3>
+            <p className="rounded-lg border border-indigo-100 bg-indigo-50 px-4 py-3 text-sm leading-relaxed text-slate-800">
+              {previewState.preview.summary}
+            </p>
+          </div>
+
+          {/* 変換後コメント一覧 */}
+          {previewState.preview.transformedBatch.length > 0 && (
+            <div>
+              <h3 className="mb-2 text-xs font-semibold tracking-wide text-slate-500 uppercase">
+                変換後コメント（{previewState.preview.transformedBatch.length} 件）
+              </h3>
+              <ul className="space-y-2">
+                {previewState.preview.transformedBatch.map((comment, i) => (
+                  <li
+                    key={i}
+                    className="rounded-lg border border-slate-100 bg-white px-4 py-3 text-sm leading-relaxed text-slate-700 shadow-sm"
+                  >
+                    {comment}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {/* 承認ボタン */}
+          <div className="border-t border-slate-100 pt-4">
+            {approveState.kind === 'done' ? (
+              <div className="rounded-lg border border-emerald-200 bg-emerald-50 px-4 py-3">
+                <p className="text-sm font-semibold text-emerald-800">✓ 承認・公開が完了しました</p>
+                <p className="mt-0.5 text-xs text-emerald-700">
+                  被評価者のマイページで閲覧可能になりました。
+                </p>
+              </div>
+            ) : (
+              <div className="flex items-center gap-4">
+                <button
+                  type="button"
+                  onClick={() => void handleApprove()}
+                  disabled={!canApprove}
+                  className="rounded-lg bg-emerald-600 px-5 py-2 text-sm font-medium text-white hover:bg-emerald-700 disabled:opacity-50"
+                >
+                  {approveState.kind === 'approving' ? '処理中…' : '承認して公開'}
+                </button>
+                {previewState.preview.status === 'PUBLISHED' && (
+                  <p className="text-sm text-slate-500">このフィードバックはすでに公開済みです</p>
+                )}
+                {previewState.preview.status === 'ARCHIVED' && (
+                  <p className="text-sm text-slate-500">このフィードバックはアーカイブ済みです</p>
+                )}
+              </div>
+            )}
+            {approveState.kind === 'error' && (
+              <p className="mt-2 text-sm text-rose-600">{approveState.message}</p>
+            )}
+          </div>
+        </section>
+      )}
+    </main>
+  )
+}

--- a/src/app/evaluation/feedback/page.tsx
+++ b/src/app/evaluation/feedback/page.tsx
@@ -1,0 +1,246 @@
+/**
+ * Issue #180 / Task 17.4 / Req 10.6, 10.7, 10.8: 被評価者向けフィードバック閲覧画面
+ *
+ * - GET  /api/feedback/published — 自分への公開済みフィードバック一覧（evaluatorId 除外）
+ * - POST /api/feedback/view      — 閲覧確認日時を記録（{ cycleId, subjectId }）
+ */
+'use client'
+
+import { useEffect, useState, type ReactElement } from 'react'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface PublishedFeedback {
+  readonly id: string
+  readonly cycleId: string
+  readonly subjectId: string
+  readonly transformedBatch: readonly string[]
+  readonly summary: string
+  readonly publishedAt: string
+}
+
+interface ApiEnvelope<T> {
+  readonly success?: boolean
+  readonly data?: T
+  readonly error?: string
+}
+
+type ListState =
+  | { readonly kind: 'loading' }
+  | { readonly kind: 'error'; readonly message: string }
+  | { readonly kind: 'ready'; readonly items: readonly PublishedFeedback[] }
+
+// viewedAt は API から返されないため、画面セッション内で管理
+type ViewedSet = ReadonlySet<string> // feedback.id
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function fetchJson<T>(url: string, options?: RequestInit): Promise<T> {
+  const res = await fetch(url, { cache: 'no-store', ...options })
+  const envelope = (await res.json().catch(() => ({}))) as ApiEnvelope<T>
+  if (!res.ok) throw new Error(envelope.error ?? `HTTP ${res.status}`)
+  return (envelope.data ?? null) as T
+}
+
+function readError(err: unknown): string {
+  if (err instanceof Error) return err.message
+  return '予期せぬエラーが発生しました'
+}
+
+function formatDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleDateString('ja-JP', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    })
+  } catch {
+    return iso
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Page
+// ─────────────────────────────────────────────────────────────────────────────
+
+export default function FeedbackViewPage(): ReactElement {
+  const [listState, setListState] = useState<ListState>({ kind: 'loading' })
+  const [viewed, setViewed] = useState<ViewedSet>(new Set())
+  const [expanded, setExpanded] = useState<ReadonlySet<string>>(new Set())
+
+  useEffect(() => {
+    void (async () => {
+      try {
+        const items = await fetchJson<PublishedFeedback[]>('/api/feedback/published')
+        setListState({ kind: 'ready', items: items ?? [] })
+      } catch (err) {
+        setListState({ kind: 'error', message: readError(err) })
+      }
+    })()
+  }, [])
+
+  function toggleExpand(id: string): void {
+    setExpanded((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) {
+        next.delete(id)
+      } else {
+        next.add(id)
+      }
+      return next
+    })
+  }
+
+  async function markViewed(fb: PublishedFeedback): Promise<void> {
+    if (viewed.has(fb.id)) return
+    try {
+      await fetchJson<null>('/api/feedback/view', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ cycleId: fb.cycleId, subjectId: fb.subjectId }),
+      })
+      setViewed((prev) => new Set([...prev, fb.id]))
+    } catch {
+      // 閲覧記録の失敗はサイレントに処理（UX を妨げない）
+    }
+  }
+
+  function handleExpand(fb: PublishedFeedback): void {
+    toggleExpand(fb.id)
+    if (!viewed.has(fb.id) && !expanded.has(fb.id)) {
+      void markViewed(fb)
+    }
+  }
+
+  return (
+    <main className="mx-auto max-w-3xl px-6 py-10">
+      <header className="mb-8 flex items-start justify-between gap-4">
+        <div>
+          <p className="text-xs font-semibold tracking-widest text-indigo-600 uppercase">
+            360度評価
+          </p>
+          <h1 className="mt-1 text-3xl font-bold text-slate-900">フィードバック閲覧</h1>
+          <p className="mt-2 text-sm text-slate-600">
+            あなたへの公開済みフィードバックを確認できます（評価者名は非表示）。
+          </p>
+        </div>
+        <a
+          href="/evaluation/cycles"
+          className="shrink-0 rounded-lg border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50"
+        >
+          ← サイクル一覧
+        </a>
+      </header>
+
+      {listState.kind === 'loading' && (
+        <div className="py-16 text-center text-sm text-slate-400">
+          <span className="animate-pulse">読み込み中…</span>
+        </div>
+      )}
+
+      {listState.kind === 'error' && (
+        <div className="rounded-xl border border-rose-300 bg-rose-50 p-6 text-sm text-rose-800">
+          <p className="font-semibold">フィードバックの取得に失敗しました</p>
+          <p className="mt-1 text-xs">{listState.message}</p>
+        </div>
+      )}
+
+      {listState.kind === 'ready' && listState.items.length === 0 && (
+        <div className="rounded-xl border border-slate-200 bg-white py-16 text-center text-sm text-slate-400">
+          公開済みのフィードバックはまだありません
+        </div>
+      )}
+
+      {listState.kind === 'ready' && listState.items.length > 0 && (
+        <div className="space-y-4">
+          {listState.items.map((fb) => {
+            const isExpanded = expanded.has(fb.id)
+            const isViewed = viewed.has(fb.id)
+
+            return (
+              <article
+                key={fb.id}
+                className="rounded-xl border border-slate-200 bg-white shadow-sm"
+              >
+                {/* ヘッダー */}
+                <button
+                  type="button"
+                  onClick={() => handleExpand(fb)}
+                  className="flex w-full items-center justify-between px-6 py-4 text-left"
+                >
+                  <div className="flex items-center gap-3">
+                    <div>
+                      <div className="flex items-center gap-2">
+                        <p className="text-sm font-semibold text-slate-800">
+                          サイクル:{' '}
+                          <span className="font-mono text-xs text-slate-600">{fb.cycleId}</span>
+                        </p>
+                        {isViewed ? (
+                          <span className="rounded-full bg-emerald-50 px-2 py-0.5 text-xs font-medium text-emerald-700">
+                            閲覧済み
+                          </span>
+                        ) : (
+                          <span className="rounded-full bg-blue-50 px-2 py-0.5 text-xs font-medium text-blue-700">
+                            未読
+                          </span>
+                        )}
+                      </div>
+                      <p className="mt-0.5 text-xs text-slate-500">
+                        公開日: {formatDate(fb.publishedAt)}
+                      </p>
+                    </div>
+                  </div>
+                  <span className="text-slate-400" aria-hidden>
+                    {isExpanded ? '▲' : '▼'}
+                  </span>
+                </button>
+
+                {/* コンテンツ */}
+                {isExpanded && (
+                  <div className="space-y-4 border-t border-slate-100 px-6 pt-4 pb-6">
+                    {/* サマリー */}
+                    <div>
+                      <h3 className="mb-2 text-xs font-semibold tracking-wide text-slate-500 uppercase">
+                        サマリー
+                      </h3>
+                      <p className="rounded-lg border border-indigo-100 bg-indigo-50 px-4 py-3 text-sm leading-relaxed text-slate-800">
+                        {fb.summary}
+                      </p>
+                    </div>
+
+                    {/* 個別コメント */}
+                    {fb.transformedBatch.length > 0 && (
+                      <div>
+                        <h3 className="mb-2 text-xs font-semibold tracking-wide text-slate-500 uppercase">
+                          コメント（{fb.transformedBatch.length} 件）
+                        </h3>
+                        <ul className="space-y-2">
+                          {fb.transformedBatch.map((comment, i) => (
+                            <li
+                              key={i}
+                              className="rounded-lg border border-slate-100 bg-slate-50 px-4 py-3 text-sm leading-relaxed text-slate-700"
+                            >
+                              {comment}
+                            </li>
+                          ))}
+                        </ul>
+                      </div>
+                    )}
+
+                    <p className="text-xs text-slate-400">
+                      ※ 評価者の氏名は匿名性保護のため表示されません
+                    </p>
+                  </div>
+                )}
+              </article>
+            )
+          })}
+        </div>
+      )}
+    </main>
+  )
+}

--- a/src/app/evaluation/incentive/page.tsx
+++ b/src/app/evaluation/incentive/page.tsx
@@ -1,0 +1,212 @@
+/**
+ * Issue #180 / Task 18.2 / Req 11.4, 11.5: 評価者インセンティブ マイページ表示
+ *
+ * - GET /api/incentive/score?cycleId=X — 現在のサイクルの評価実施件数と累積スコア
+ * - cycleId はクエリパラメータで受け取る
+ */
+'use client'
+
+import { useEffect, useState, type ReactElement } from 'react'
+import { useSearchParams } from 'next/navigation'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface IncentiveScore {
+  readonly evaluationCount: number
+  readonly cumulativeScore: number
+}
+
+interface ApiEnvelope<T> {
+  readonly success?: boolean
+  readonly data?: T
+  readonly error?: string
+}
+
+type ScoreState =
+  | { readonly kind: 'idle' }
+  | { readonly kind: 'loading' }
+  | { readonly kind: 'error'; readonly message: string }
+  | { readonly kind: 'ready'; readonly score: IncentiveScore }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const res = await fetch(url, { cache: 'no-store' })
+  const envelope = (await res.json().catch(() => ({}))) as ApiEnvelope<T>
+  if (!res.ok) throw new Error(envelope.error ?? `HTTP ${res.status}`)
+  return (envelope.data ?? null) as T
+}
+
+function readError(err: unknown): string {
+  if (err instanceof Error) return err.message
+  return '予期せぬエラーが発生しました'
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Sub-components
+// ─────────────────────────────────────────────────────────────────────────────
+
+function StatCard({
+  label,
+  value,
+  unit,
+  color = 'text-slate-900',
+  description,
+}: {
+  readonly label: string
+  readonly value: number
+  readonly unit?: string
+  readonly color?: string
+  readonly description?: string
+}): ReactElement {
+  return (
+    <div className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+      <p className="text-xs font-semibold tracking-wide text-slate-500 uppercase">{label}</p>
+      <div className="mt-2 flex items-baseline gap-1">
+        <span className={`text-4xl font-bold tabular-nums ${color}`}>{value}</span>
+        {unit && <span className="text-sm text-slate-500">{unit}</span>}
+      </div>
+      {description && <p className="mt-1 text-xs text-slate-400">{description}</p>}
+    </div>
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Page
+// ─────────────────────────────────────────────────────────────────────────────
+
+export default function IncentivePage(): ReactElement {
+  const searchParams = useSearchParams()
+  const cycleId = searchParams.get('cycleId') ?? ''
+
+  const [scoreState, setScoreState] = useState<ScoreState>(
+    cycleId ? { kind: 'loading' } : { kind: 'idle' },
+  )
+
+  useEffect(() => {
+    if (!cycleId) return
+    setScoreState({ kind: 'loading' })
+    void (async () => {
+      try {
+        const score = await fetchJson<IncentiveScore>(
+          `/api/incentive/score?cycleId=${encodeURIComponent(cycleId)}`,
+        )
+        setScoreState({ kind: 'ready', score })
+      } catch (err) {
+        setScoreState({ kind: 'error', message: readError(err) })
+      }
+    })()
+  }, [cycleId])
+
+  return (
+    <main className="mx-auto max-w-3xl px-6 py-10">
+      <header className="mb-8 flex items-start justify-between gap-4">
+        <div>
+          <p className="text-xs font-semibold tracking-widest text-indigo-600 uppercase">
+            360度評価
+          </p>
+          <h1 className="mt-1 text-3xl font-bold text-slate-900">インセンティブスコア</h1>
+          <p className="mt-2 text-sm text-slate-600">
+            評価完了件数に応じたインセンティブスコアを確認できます。
+          </p>
+          {cycleId && (
+            <p className="mt-1 text-xs text-slate-500">
+              サイクル ID: <span className="font-mono">{cycleId}</span>
+            </p>
+          )}
+        </div>
+        <a
+          href="/evaluation/cycles"
+          className="shrink-0 rounded-lg border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50"
+        >
+          ← サイクル一覧
+        </a>
+      </header>
+
+      {!cycleId ? (
+        <div className="rounded-xl border border-slate-200 bg-white py-16 text-center text-sm text-slate-400">
+          URL に <span className="font-mono">?cycleId=...</span> を付けてアクセスしてください
+        </div>
+      ) : (
+        <>
+          {scoreState.kind === 'loading' && (
+            <div className="py-16 text-center text-sm text-slate-400">
+              <span className="animate-pulse">読み込み中…</span>
+            </div>
+          )}
+
+          {scoreState.kind === 'error' && (
+            <div className="rounded-xl border border-rose-300 bg-rose-50 p-6 text-sm text-rose-800">
+              <p className="font-semibold">データの取得に失敗しました</p>
+              <p className="mt-1 text-xs">{scoreState.message}</p>
+            </div>
+          )}
+
+          {scoreState.kind === 'ready' && (
+            <div className="space-y-6">
+              {/* スコアカード */}
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                <StatCard
+                  label="評価実施件数"
+                  value={scoreState.score.evaluationCount}
+                  unit="件"
+                  color="text-indigo-600"
+                  description="品質ゲートを通過した評価のみカウント"
+                />
+                <StatCard
+                  label="累積インセンティブスコア"
+                  value={scoreState.score.cumulativeScore}
+                  unit="pt"
+                  color="text-emerald-600"
+                  description="総合評価への加算に使用されます"
+                />
+              </div>
+
+              {/* 説明 */}
+              <section className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+                <h2 className="mb-3 font-semibold text-slate-800">スコアの計算方法</h2>
+                <dl className="space-y-2 text-sm text-slate-600">
+                  <div className="flex gap-2">
+                    <dt className="shrink-0 font-medium text-slate-700">対象:</dt>
+                    <dd>AI コーチング品質ゲートを通過した評価のみ加算されます</dd>
+                  </div>
+                  <div className="flex gap-2">
+                    <dt className="shrink-0 font-medium text-slate-700">計算式:</dt>
+                    <dd>
+                      累積スコア = 評価件数 × 係数 <span className="font-mono text-xs">k</span>
+                      （サイクル設定に依存）
+                    </dd>
+                  </div>
+                  <div className="flex gap-2">
+                    <dt className="shrink-0 font-medium text-slate-700">反映:</dt>
+                    <dd>サイクル終了後の総合評価（360度評価スコア）に加算されます</dd>
+                  </div>
+                </dl>
+              </section>
+
+              {/* ゼロ件の案内 */}
+              {scoreState.score.evaluationCount === 0 && (
+                <div className="rounded-xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-800">
+                  <p className="font-semibold">まだ評価が記録されていません</p>
+                  <p className="mt-1 text-xs">
+                    評価フォームから評価を提出すると、スコアが加算されます。
+                  </p>
+                  <a
+                    href={`/evaluation/assignments?cycleId=${encodeURIComponent(cycleId)}`}
+                    className="mt-2 inline-block text-xs font-medium text-amber-700 underline hover:text-amber-900"
+                  >
+                    評価アサイン一覧へ →
+                  </a>
+                </div>
+              )}
+            </div>
+          )}
+        </>
+      )}
+    </main>
+  )
+}


### PR DESCRIPTION
## Summary

- **Task 17.3**: `src/app/evaluation/feedback/approval/page.tsx` — HR_MANAGER向けフィードバック承認・公開画面
  - cycleId / subjectId を指定してプレビューを取得（GET `/api/feedback/preview`）
  - 「承認して公開」ボタンで被評価者へ公開（POST `/api/feedback/approve`）
  - ステータスバッジ表示（PENDING_HR_APPROVAL / PUBLISHED / ARCHIVED 等）
- **Task 17.4**: `src/app/evaluation/feedback/page.tsx` — 被評価者向けフィードバック閲覧画面
  - 公開済みフィードバック一覧をアコーディオン表示（GET `/api/feedback/published`）
  - 展開時に自動で閲覧記録（POST `/api/feedback/view`）
  - 未読 / 閲覧済みバッジ表示、匿名性保護の注釈付き
- **Task 18.2**: `src/app/evaluation/incentive/page.tsx` — 評価者インセンティブ マイページ
  - cycleId をクエリパラメータで受け取りスコアを表示（GET `/api/incentive/score`）
  - 評価実施件数・累積スコアのカード表示
  - ゼロ件時の案内（評価アサイン一覧へのリンク付き）

## Test plan

- [ ] `/evaluation/feedback/approval?cycleId=X&subjectId=Y` で HR_MANAGER がプレビューを確認し承認できること
- [ ] 承認後にステータスが PUBLISHED に変わること
- [ ] `/evaluation/feedback` で自分への公開済みフィードバックが表示されること
- [ ] フィードバック展開時に閲覧記録 API が呼ばれること
- [ ] `/evaluation/incentive?cycleId=X` で評価件数・スコアが表示されること
- [ ] cycleId なしアクセス時にガイドメッセージが表示されること
- [ ] TypeScript エラーなし（新規 3 ファイルに関して）

Closes #180