### PR TITLE
feat: 総合評価UI（プレビュー/ウェイト上書き/確定・修正）を実装 (Issue #181)

### DIFF
--- a/src/app/evaluation/total/finalize/page.tsx
+++ b/src/app/evaluation/total/finalize/page.tsx
@@ -1,0 +1,527 @@
+/**
+ * Issue #181 / Task 19.3 / Req 12.5, 12.6: 総合評価 確定・クローズ / ADMIN修正画面
+ *
+ * - POST /api/total-evaluation/finalize    — サイクル確定（HR_MANAGER/ADMIN）
+ * - PUT  /api/total-evaluation/correction  — 確定後スコア修正（ADMIN）
+ */
+'use client'
+
+import { useState, type ReactElement, type FormEvent } from 'react'
+import { useSearchParams } from 'next/navigation'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface ApiEnvelope<T> {
+  readonly success?: boolean
+  readonly data?: T
+  readonly error?: string
+}
+
+interface TotalEvaluationResult {
+  readonly subjectId: string
+  readonly finalScore: number
+  readonly status: string
+}
+
+type FinalizeState =
+  | { readonly kind: 'idle' }
+  | { readonly kind: 'confirming' }
+  | { readonly kind: 'finalizing' }
+  | { readonly kind: 'done'; readonly results: readonly TotalEvaluationResult[] }
+  | { readonly kind: 'error'; readonly message: string }
+
+interface CorrectionForm {
+  subjectId: string
+  performanceScore: string
+  goalScore: string
+  feedbackScore: string
+  incentiveAdjustment: string
+  performanceWeight: string
+  goalWeight: string
+  feedbackWeight: string
+  reason: string
+}
+
+type CorrectionState =
+  | { readonly kind: 'idle' }
+  | { readonly kind: 'saving' }
+  | { readonly kind: 'done'; readonly subjectId: string }
+  | { readonly kind: 'error'; readonly message: string }
+
+const EMPTY_CORRECTION: CorrectionForm = {
+  subjectId: '',
+  performanceScore: '',
+  goalScore: '',
+  feedbackScore: '',
+  incentiveAdjustment: '0',
+  performanceWeight: '',
+  goalWeight: '',
+  feedbackWeight: '',
+  reason: '',
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function fetchJson<T>(url: string, options?: RequestInit): Promise<T> {
+  const res = await fetch(url, { cache: 'no-store', ...options })
+  const envelope = (await res.json().catch(() => ({}))) as ApiEnvelope<T>
+  if (!res.ok) throw new Error(envelope.error ?? `HTTP ${res.status}`)
+  return (envelope.data ?? null) as T
+}
+
+function readError(err: unknown): string {
+  if (err instanceof Error) return err.message
+  return '予期せぬエラーが発生しました'
+}
+
+function parseNum(s: string): number | null {
+  const n = parseFloat(s)
+  return isNaN(n) ? null : n
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Sub-components
+// ─────────────────────────────────────────────────────────────────────────────
+
+function NumberInput({
+  id,
+  label,
+  value,
+  onChange,
+  disabled,
+  step = '1',
+  min,
+  max,
+}: {
+  readonly id: string
+  readonly label: string
+  readonly value: string
+  readonly onChange: (v: string) => void
+  readonly disabled: boolean
+  readonly step?: string
+  readonly min?: string
+  readonly max?: string
+}): ReactElement {
+  return (
+    <div>
+      <label htmlFor={id} className="mb-1 block text-xs font-medium text-slate-600">
+        {label}
+      </label>
+      <input
+        id={id}
+        type="number"
+        step={step}
+        min={min}
+        max={max}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        disabled={disabled}
+        className="w-full rounded-lg border border-slate-300 px-3 py-2 font-mono text-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none disabled:bg-slate-50 disabled:text-slate-400"
+      />
+    </div>
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Page
+// ─────────────────────────────────────────────────────────────────────────────
+
+export default function TotalEvaluationFinalizePage(): ReactElement {
+  const searchParams = useSearchParams()
+  const cycleId = searchParams.get('cycleId') ?? ''
+
+  const [finalizeState, setFinalizeState] = useState<FinalizeState>({ kind: 'idle' })
+  const [correction, setCorrection] = useState<CorrectionForm>(EMPTY_CORRECTION)
+  const [correctionState, setCorrectionState] = useState<CorrectionState>({ kind: 'idle' })
+
+  // ── Finalize ──────────────────────────────────────────────────────────────
+
+  async function handleFinalize(): Promise<void> {
+    if (!cycleId) return
+    setFinalizeState({ kind: 'finalizing' })
+    try {
+      const results = await fetchJson<TotalEvaluationResult[]>('/api/total-evaluation/finalize', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ cycleId }),
+      })
+      setFinalizeState({ kind: 'done', results: results ?? [] })
+    } catch (err) {
+      setFinalizeState({ kind: 'error', message: readError(err) })
+    }
+  }
+
+  // ── Correction ────────────────────────────────────────────────────────────
+
+  const cPerf = parseNum(correction.performanceScore)
+  const cGoal = parseNum(correction.goalScore)
+  const cFeed = parseNum(correction.feedbackScore)
+  const cIncent = parseNum(correction.incentiveAdjustment)
+  const cPW = parseNum(correction.performanceWeight)
+  const cGW = parseNum(correction.goalWeight)
+  const cFW = parseNum(correction.feedbackWeight)
+
+  const weightSum = cPW !== null && cGW !== null && cFW !== null ? cPW + cGW + cFW : null
+  const weightValid = weightSum !== null && Math.abs(weightSum - 1) <= 1e-4
+
+  const canCorrect =
+    correction.subjectId.trim().length > 0 &&
+    cPerf !== null &&
+    cGoal !== null &&
+    cFeed !== null &&
+    cIncent !== null &&
+    weightValid &&
+    correction.reason.trim().length > 0 &&
+    correctionState.kind !== 'saving'
+
+  async function handleCorrection(e: FormEvent): Promise<void> {
+    e.preventDefault()
+    if (!canCorrect || !cycleId) return
+    setCorrectionState({ kind: 'saving' })
+    try {
+      await fetchJson<null>('/api/total-evaluation/correction', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          cycleId,
+          subjectId: correction.subjectId.trim(),
+          performanceScore: cPerf,
+          goalScore: cGoal,
+          feedbackScore: cFeed,
+          incentiveAdjustment: cIncent,
+          performanceWeight: cPW,
+          goalWeight: cGW,
+          feedbackWeight: cFW,
+          reason: correction.reason.trim(),
+        }),
+      })
+      setCorrectionState({ kind: 'done', subjectId: correction.subjectId.trim() })
+      setCorrection(EMPTY_CORRECTION)
+    } catch (err) {
+      setCorrectionState({ kind: 'error', message: readError(err) })
+    }
+  }
+
+  return (
+    <main className="mx-auto max-w-3xl px-6 py-10">
+      <header className="mb-8 flex items-start justify-between gap-4">
+        <div>
+          <p className="text-xs font-semibold tracking-widest text-indigo-600 uppercase">
+            総合評価
+          </p>
+          <h1 className="mt-1 text-3xl font-bold text-slate-900">確定・クローズ</h1>
+          <p className="mt-2 text-sm text-slate-600">
+            全社員の総合評価を確定し、評価サイクルをクローズします。
+          </p>
+          {cycleId && (
+            <p className="mt-1 text-xs text-slate-500">
+              サイクル ID: <span className="font-mono">{cycleId}</span>
+            </p>
+          )}
+        </div>
+        <div className="flex shrink-0 flex-wrap gap-2">
+          {cycleId && (
+            <a
+              href={`/evaluation/total/preview?cycleId=${encodeURIComponent(cycleId)}`}
+              className="rounded-lg border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50"
+            >
+              ← プレビューへ戻る
+            </a>
+          )}
+          <a
+            href="/evaluation/cycles"
+            className="rounded-lg border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50"
+          >
+            ← サイクル一覧
+          </a>
+        </div>
+      </header>
+
+      {!cycleId ? (
+        <div className="rounded-xl border border-slate-200 bg-white py-16 text-center text-sm text-slate-400">
+          URL に <span className="font-mono">?cycleId=...</span> を付けてアクセスしてください
+        </div>
+      ) : (
+        <div className="space-y-8">
+          {/* ── 確定セクション ── */}
+          <section className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+            <h2 className="mb-2 font-semibold text-slate-800">評価を確定する</h2>
+            <p className="mb-4 text-sm text-slate-600">
+              確定すると全社員のスコアが FINALIZED 状態に移行します。この操作は取り消せません。
+            </p>
+
+            {finalizeState.kind === 'idle' && (
+              <button
+                type="button"
+                onClick={() => setFinalizeState({ kind: 'confirming' })}
+                className="rounded-lg bg-rose-600 px-5 py-2 text-sm font-medium text-white hover:bg-rose-700"
+              >
+                確定・クローズ
+              </button>
+            )}
+
+            {finalizeState.kind === 'confirming' && (
+              <div className="rounded-lg border border-rose-200 bg-rose-50 p-4">
+                <p className="mb-3 text-sm font-semibold text-rose-800">
+                  本当に確定しますか？この操作は元に戻せません。
+                </p>
+                <div className="flex gap-3">
+                  <button
+                    type="button"
+                    onClick={() => void handleFinalize()}
+                    className="rounded-lg bg-rose-600 px-5 py-2 text-sm font-medium text-white hover:bg-rose-700"
+                  >
+                    確定する
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setFinalizeState({ kind: 'idle' })}
+                    className="rounded-lg border border-slate-300 px-5 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50"
+                  >
+                    キャンセル
+                  </button>
+                </div>
+              </div>
+            )}
+
+            {finalizeState.kind === 'finalizing' && (
+              <div className="py-4 text-center text-sm text-slate-400">
+                <span className="animate-pulse">確定処理中…</span>
+              </div>
+            )}
+
+            {finalizeState.kind === 'error' && (
+              <div className="rounded-lg border border-rose-300 bg-rose-50 p-4 text-sm text-rose-800">
+                <p className="font-semibold">確定に失敗しました</p>
+                <p className="mt-1 text-xs">{finalizeState.message}</p>
+                <button
+                  type="button"
+                  onClick={() => setFinalizeState({ kind: 'idle' })}
+                  className="mt-2 text-xs font-medium text-rose-700 underline hover:text-rose-900"
+                >
+                  再試行
+                </button>
+              </div>
+            )}
+
+            {finalizeState.kind === 'done' && (
+              <div className="space-y-3">
+                <div className="rounded-lg border border-emerald-200 bg-emerald-50 px-4 py-3">
+                  <p className="text-sm font-semibold text-emerald-800">
+                    ✓ 確定が完了しました（{finalizeState.results.length} 件）
+                  </p>
+                  <p className="mt-0.5 text-xs text-emerald-700">
+                    全社員の評価が FINALIZED になりました。
+                  </p>
+                </div>
+                {finalizeState.results.length > 0 && (
+                  <div className="overflow-hidden rounded-lg border border-slate-200">
+                    <table className="w-full text-xs">
+                      <thead className="bg-slate-50">
+                        <tr>
+                          <th className="px-4 py-2 text-left font-medium text-slate-500">
+                            社員 ID
+                          </th>
+                          <th className="px-4 py-2 text-right font-medium text-slate-500">
+                            最終スコア
+                          </th>
+                          <th className="px-4 py-2 text-center font-medium text-slate-500">
+                            ステータス
+                          </th>
+                        </tr>
+                      </thead>
+                      <tbody className="divide-y divide-slate-100">
+                        {finalizeState.results.map((r) => (
+                          <tr key={r.subjectId} className="hover:bg-slate-50">
+                            <td className="px-4 py-2 font-mono text-slate-700">{r.subjectId}</td>
+                            <td className="px-4 py-2 text-right text-slate-700 tabular-nums">
+                              {r.finalScore.toFixed(1)}
+                            </td>
+                            <td className="px-4 py-2 text-center">
+                              <span className="rounded bg-emerald-100 px-1.5 py-0.5 text-xs font-semibold text-emerald-700">
+                                {r.status}
+                              </span>
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                )}
+              </div>
+            )}
+          </section>
+
+          {/* ── ADMIN 修正セクション ── */}
+          <section className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+            <h2 className="mb-1 font-semibold text-slate-800">確定後スコア修正（ADMIN）</h2>
+            <p className="mb-4 text-sm text-slate-600">
+              確定後に個別社員のスコアを修正します。ADMIN 権限が必要です。
+            </p>
+
+            {correctionState.kind === 'done' && (
+              <div className="mb-4 rounded-lg border border-emerald-200 bg-emerald-50 px-4 py-3">
+                <p className="text-sm font-semibold text-emerald-800">
+                  ✓ {correctionState.subjectId} のスコアを修正しました
+                </p>
+              </div>
+            )}
+
+            <form onSubmit={(e) => void handleCorrection(e)} className="space-y-4">
+              {/* 社員ID */}
+              <div>
+                <label
+                  htmlFor="corrSubjectId"
+                  className="mb-1 block text-xs font-medium text-slate-600"
+                >
+                  社員 ID <span className="text-rose-500">*</span>
+                </label>
+                <input
+                  id="corrSubjectId"
+                  type="text"
+                  value={correction.subjectId}
+                  onChange={(e) => setCorrection((f) => ({ ...f, subjectId: e.target.value }))}
+                  disabled={correctionState.kind === 'saving'}
+                  placeholder="user-xxxx"
+                  className="w-full rounded-lg border border-slate-300 px-3 py-2 font-mono text-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none disabled:bg-slate-50"
+                />
+              </div>
+
+              {/* スコア */}
+              <div>
+                <p className="mb-2 text-xs font-semibold tracking-wide text-slate-500 uppercase">
+                  スコア（0〜100）
+                </p>
+                <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+                  <NumberInput
+                    id="corrPerf"
+                    label="業績スコア"
+                    value={correction.performanceScore}
+                    onChange={(v) => setCorrection((f) => ({ ...f, performanceScore: v }))}
+                    disabled={correctionState.kind === 'saving'}
+                    step="0.1"
+                    min="0"
+                    max="100"
+                  />
+                  <NumberInput
+                    id="corrGoal"
+                    label="目標スコア"
+                    value={correction.goalScore}
+                    onChange={(v) => setCorrection((f) => ({ ...f, goalScore: v }))}
+                    disabled={correctionState.kind === 'saving'}
+                    step="0.1"
+                    min="0"
+                    max="100"
+                  />
+                  <NumberInput
+                    id="corrFeed"
+                    label="360度スコア"
+                    value={correction.feedbackScore}
+                    onChange={(v) => setCorrection((f) => ({ ...f, feedbackScore: v }))}
+                    disabled={correctionState.kind === 'saving'}
+                    step="0.1"
+                    min="0"
+                    max="100"
+                  />
+                  <NumberInput
+                    id="corrIncent"
+                    label="インセンティブ加算"
+                    value={correction.incentiveAdjustment}
+                    onChange={(v) => setCorrection((f) => ({ ...f, incentiveAdjustment: v }))}
+                    disabled={correctionState.kind === 'saving'}
+                    step="0.1"
+                    min="-100"
+                    max="100"
+                  />
+                </div>
+              </div>
+
+              {/* ウェイト */}
+              <div>
+                <p className="mb-2 text-xs font-semibold tracking-wide text-slate-500 uppercase">
+                  ウェイト（合計 = 1.0）
+                </p>
+                <div className="grid grid-cols-3 gap-4">
+                  <NumberInput
+                    id="corrPW"
+                    label="業績ウェイト"
+                    value={correction.performanceWeight}
+                    onChange={(v) => setCorrection((f) => ({ ...f, performanceWeight: v }))}
+                    disabled={correctionState.kind === 'saving'}
+                    step="0.01"
+                    min="0"
+                    max="1"
+                  />
+                  <NumberInput
+                    id="corrGW"
+                    label="目標ウェイト"
+                    value={correction.goalWeight}
+                    onChange={(v) => setCorrection((f) => ({ ...f, goalWeight: v }))}
+                    disabled={correctionState.kind === 'saving'}
+                    step="0.01"
+                    min="0"
+                    max="1"
+                  />
+                  <NumberInput
+                    id="corrFW"
+                    label="360度ウェイト"
+                    value={correction.feedbackWeight}
+                    onChange={(v) => setCorrection((f) => ({ ...f, feedbackWeight: v }))}
+                    disabled={correctionState.kind === 'saving'}
+                    step="0.01"
+                    min="0"
+                    max="1"
+                  />
+                </div>
+                {weightSum !== null && (
+                  <p
+                    className={`mt-1 text-xs font-medium ${weightValid ? 'text-emerald-600' : 'text-rose-600'}`}
+                  >
+                    合計: {weightSum.toFixed(4)}{' '}
+                    {weightValid ? '✓' : '✗ 合計が 1.0 になるように設定してください'}
+                  </p>
+                )}
+              </div>
+
+              {/* 理由 */}
+              <div>
+                <label
+                  htmlFor="corrReason"
+                  className="mb-1 block text-xs font-medium text-slate-600"
+                >
+                  修正理由 <span className="text-rose-500">*</span>
+                </label>
+                <textarea
+                  id="corrReason"
+                  rows={3}
+                  value={correction.reason}
+                  onChange={(e) => setCorrection((f) => ({ ...f, reason: e.target.value }))}
+                  disabled={correctionState.kind === 'saving'}
+                  placeholder="修正する理由を入力してください"
+                  className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none disabled:bg-slate-50"
+                />
+              </div>
+
+              <div className="flex items-center gap-4">
+                <button
+                  type="submit"
+                  disabled={!canCorrect}
+                  className="rounded-lg bg-amber-600 px-5 py-2 text-sm font-medium text-white hover:bg-amber-700 disabled:opacity-50"
+                >
+                  {correctionState.kind === 'saving' ? '保存中…' : 'スコアを修正'}
+                </button>
+                {correctionState.kind === 'error' && (
+                  <p className="text-sm text-rose-600">{correctionState.message}</p>
+                )}
+              </div>
+            </form>
+          </section>
+        </div>
+      )}
+    </main>
+  )
+}

--- a/src/app/evaluation/total/override/page.tsx
+++ b/src/app/evaluation/total/override/page.tsx
@@ -1,0 +1,385 @@
+/**
+ * Issue #181 / Task 19.2 / Req 12.3: 総合評価 個別ウェイト上書き画面
+ *
+ * - GET /api/total-evaluation/override?cycleId=X&subjectId=Y — 現在のウェイト上書き取得
+ * - PUT /api/total-evaluation/override                        — ウェイト上書き保存
+ */
+'use client'
+
+import { useEffect, useState, type ReactElement, type FormEvent } from 'react'
+import { useSearchParams } from 'next/navigation'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface WeightOverride {
+  readonly cycleId: string
+  readonly subjectId: string
+  readonly performanceWeight: number
+  readonly goalWeight: number
+  readonly feedbackWeight: number
+  readonly reason: string
+  readonly adjustedBy: string
+  readonly adjustedAt: string
+}
+
+interface ApiEnvelope<T> {
+  readonly success?: boolean
+  readonly data?: T
+  readonly error?: string
+}
+
+interface WeightForm {
+  performanceWeight: string
+  goalWeight: string
+  feedbackWeight: string
+  reason: string
+}
+
+type OverrideState =
+  | { readonly kind: 'idle' }
+  | { readonly kind: 'loading' }
+  | { readonly kind: 'error'; readonly message: string }
+  | { readonly kind: 'ready'; readonly existing: WeightOverride | null }
+
+type SaveState =
+  | { readonly kind: 'idle' }
+  | { readonly kind: 'saving' }
+  | { readonly kind: 'done' }
+  | { readonly kind: 'error'; readonly message: string }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function fetchJson<T>(url: string, options?: RequestInit): Promise<T> {
+  const res = await fetch(url, { cache: 'no-store', ...options })
+  const envelope = (await res.json().catch(() => ({}))) as ApiEnvelope<T>
+  if (!res.ok) throw new Error(envelope.error ?? `HTTP ${res.status}`)
+  return (envelope.data ?? null) as T
+}
+
+function readError(err: unknown): string {
+  if (err instanceof Error) return err.message
+  return '予期せぬエラーが発生しました'
+}
+
+function pct(w: number): string {
+  return `${Math.round(w * 100)}%`
+}
+
+function formatDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleString('ja-JP', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    })
+  } catch {
+    return iso
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Sub-components
+// ─────────────────────────────────────────────────────────────────────────────
+
+function WeightField({
+  id,
+  label,
+  value,
+  onChange,
+  disabled,
+}: {
+  readonly id: string
+  readonly label: string
+  readonly value: string
+  readonly onChange: (v: string) => void
+  readonly disabled: boolean
+}): ReactElement {
+  const num = parseFloat(value)
+  const displayPct = isNaN(num) ? '—' : pct(num)
+
+  return (
+    <div>
+      <label htmlFor={id} className="mb-1 block text-xs font-medium text-slate-600">
+        {label}
+      </label>
+      <div className="flex items-center gap-2">
+        <input
+          id={id}
+          type="number"
+          step="0.01"
+          min="0"
+          max="1"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          disabled={disabled}
+          className="w-28 rounded-lg border border-slate-300 px-3 py-2 font-mono text-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none disabled:bg-slate-50 disabled:text-slate-400"
+        />
+        <span className="text-sm text-slate-500">{displayPct}</span>
+      </div>
+    </div>
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Page
+// ─────────────────────────────────────────────────────────────────────────────
+
+export default function TotalEvaluationOverridePage(): ReactElement {
+  const searchParams = useSearchParams()
+  const cycleId = searchParams.get('cycleId') ?? ''
+  const subjectId = searchParams.get('subjectId') ?? ''
+
+  const [overrideState, setOverrideState] = useState<OverrideState>(
+    cycleId && subjectId ? { kind: 'loading' } : { kind: 'idle' },
+  )
+  const [saveState, setSaveState] = useState<SaveState>({ kind: 'idle' })
+  const [form, setForm] = useState<WeightForm>({
+    performanceWeight: '0.4',
+    goalWeight: '0.4',
+    feedbackWeight: '0.2',
+    reason: '',
+  })
+
+  useEffect(() => {
+    if (!cycleId || !subjectId) return
+    setOverrideState({ kind: 'loading' })
+    void (async () => {
+      try {
+        const existing = await fetchJson<WeightOverride | null>(
+          `/api/total-evaluation/override?cycleId=${encodeURIComponent(cycleId)}&subjectId=${encodeURIComponent(subjectId)}`,
+        )
+        setOverrideState({ kind: 'ready', existing })
+        if (existing) {
+          setForm({
+            performanceWeight: existing.performanceWeight.toString(),
+            goalWeight: existing.goalWeight.toString(),
+            feedbackWeight: existing.feedbackWeight.toString(),
+            reason: '',
+          })
+        }
+      } catch (err) {
+        setOverrideState({ kind: 'error', message: readError(err) })
+      }
+    })()
+  }, [cycleId, subjectId])
+
+  const perf = parseFloat(form.performanceWeight)
+  const goal = parseFloat(form.goalWeight)
+  const feed = parseFloat(form.feedbackWeight)
+  const weightSum = isNaN(perf) || isNaN(goal) || isNaN(feed) ? null : perf + goal + feed
+  const sumValid = weightSum !== null && Math.abs(weightSum - 1) <= 1e-4
+
+  const canSave =
+    sumValid &&
+    form.reason.trim().length > 0 &&
+    saveState.kind !== 'saving' &&
+    saveState.kind !== 'done'
+
+  async function handleSave(e: FormEvent): Promise<void> {
+    e.preventDefault()
+    if (!canSave) return
+    setSaveState({ kind: 'saving' })
+    try {
+      await fetchJson<null>('/api/total-evaluation/override', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          cycleId,
+          subjectId,
+          performanceWeight: perf,
+          goalWeight: goal,
+          feedbackWeight: feed,
+          reason: form.reason.trim(),
+        }),
+      })
+      setSaveState({ kind: 'done' })
+    } catch (err) {
+      setSaveState({ kind: 'error', message: readError(err) })
+    }
+  }
+
+  const isBusy = saveState.kind === 'saving'
+
+  return (
+    <main className="mx-auto max-w-2xl px-6 py-10">
+      <header className="mb-8 flex items-start justify-between gap-4">
+        <div>
+          <p className="text-xs font-semibold tracking-widest text-indigo-600 uppercase">
+            総合評価
+          </p>
+          <h1 className="mt-1 text-3xl font-bold text-slate-900">ウェイト上書き</h1>
+          <p className="mt-2 text-sm text-slate-600">
+            個別社員のスコア計算ウェイトを変更します（HR_MANAGER 専用）。
+          </p>
+          {cycleId && subjectId && (
+            <p className="mt-1 text-xs text-slate-500">
+              サイクル ID: <span className="font-mono">{cycleId}</span>
+              <span className="mx-2">·</span>
+              社員 ID: <span className="font-mono">{subjectId}</span>
+            </p>
+          )}
+        </div>
+        <div className="flex shrink-0 flex-wrap gap-2">
+          {cycleId && (
+            <a
+              href={`/evaluation/total/preview?cycleId=${encodeURIComponent(cycleId)}`}
+              className="rounded-lg border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50"
+            >
+              ← プレビューへ戻る
+            </a>
+          )}
+          <a
+            href="/evaluation/cycles"
+            className="rounded-lg border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50"
+          >
+            ← サイクル一覧
+          </a>
+        </div>
+      </header>
+
+      {!cycleId || !subjectId ? (
+        <div className="rounded-xl border border-slate-200 bg-white py-16 text-center text-sm text-slate-400">
+          URL に <span className="font-mono">?cycleId=...&amp;subjectId=...</span>{' '}
+          を付けてアクセスしてください
+        </div>
+      ) : (
+        <div className="space-y-6">
+          {/* 読み込み中 */}
+          {overrideState.kind === 'loading' && (
+            <div className="py-16 text-center text-sm text-slate-400">
+              <span className="animate-pulse">読み込み中…</span>
+            </div>
+          )}
+
+          {/* 取得エラー */}
+          {overrideState.kind === 'error' && (
+            <div className="rounded-xl border border-rose-300 bg-rose-50 p-6 text-sm text-rose-800">
+              <p className="font-semibold">データの取得に失敗しました</p>
+              <p className="mt-1 text-xs">{overrideState.message}</p>
+            </div>
+          )}
+
+          {/* 既存上書き情報 */}
+          {overrideState.kind === 'ready' && overrideState.existing && (
+            <div className="rounded-xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-800">
+              <p className="font-semibold">既存のウェイト上書きがあります</p>
+              <p className="mt-1 text-xs">
+                調整者:{' '}
+                <span className="font-mono font-medium">{overrideState.existing.adjustedBy}</span>
+                <span className="mx-2">·</span>
+                調整日時: {formatDate(overrideState.existing.adjustedAt)}
+              </p>
+              <p className="mt-1 text-xs">
+                現在のウェイト: 業績{' '}
+                <span className="font-medium">{pct(overrideState.existing.performanceWeight)}</span>
+                {' / '}目標{' '}
+                <span className="font-medium">{pct(overrideState.existing.goalWeight)}</span>
+                {' / '}360度{' '}
+                <span className="font-medium">{pct(overrideState.existing.feedbackWeight)}</span>
+              </p>
+            </div>
+          )}
+
+          {/* フォーム */}
+          {(overrideState.kind === 'ready' || overrideState.kind === 'idle') && (
+            <section className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+              <h2 className="mb-4 font-semibold text-slate-800">ウェイトを設定</h2>
+              <form onSubmit={(e) => void handleSave(e)} className="space-y-5">
+                <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+                  <WeightField
+                    id="performanceWeight"
+                    label="業績ウェイト"
+                    value={form.performanceWeight}
+                    onChange={(v) => setForm((f) => ({ ...f, performanceWeight: v }))}
+                    disabled={isBusy}
+                  />
+                  <WeightField
+                    id="goalWeight"
+                    label="目標ウェイト"
+                    value={form.goalWeight}
+                    onChange={(v) => setForm((f) => ({ ...f, goalWeight: v }))}
+                    disabled={isBusy}
+                  />
+                  <WeightField
+                    id="feedbackWeight"
+                    label="360度ウェイト"
+                    value={form.feedbackWeight}
+                    onChange={(v) => setForm((f) => ({ ...f, feedbackWeight: v }))}
+                    disabled={isBusy}
+                  />
+                </div>
+
+                {/* 合計バリデーション */}
+                <div
+                  className={`rounded-lg px-3 py-2 text-xs font-medium ${
+                    weightSum === null
+                      ? 'bg-slate-50 text-slate-400'
+                      : sumValid
+                        ? 'bg-emerald-50 text-emerald-700'
+                        : 'bg-rose-50 text-rose-700'
+                  }`}
+                >
+                  合計:{' '}
+                  {weightSum === null
+                    ? '—'
+                    : `${weightSum.toFixed(4)} ${sumValid ? '✓ 合計 = 1.0' : '✗ 合計が 1.0 になるように設定してください'}`}
+                </div>
+
+                {/* 理由 */}
+                <div>
+                  <label htmlFor="reason" className="mb-1 block text-xs font-medium text-slate-600">
+                    上書き理由 <span className="text-rose-500">*</span>
+                  </label>
+                  <textarea
+                    id="reason"
+                    rows={3}
+                    value={form.reason}
+                    onChange={(e) => setForm((f) => ({ ...f, reason: e.target.value }))}
+                    disabled={isBusy}
+                    placeholder="上書きする理由を入力してください"
+                    className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none disabled:bg-slate-50 disabled:text-slate-400"
+                  />
+                </div>
+
+                {/* 保存ボタン */}
+                {saveState.kind === 'done' ? (
+                  <div className="rounded-lg border border-emerald-200 bg-emerald-50 px-4 py-3">
+                    <p className="text-sm font-semibold text-emerald-800">
+                      ✓ ウェイトを保存しました
+                    </p>
+                    <p className="mt-0.5 text-xs text-emerald-700">
+                      次回の総合評価計算に反映されます。
+                    </p>
+                  </div>
+                ) : (
+                  <div className="flex items-center gap-4">
+                    <button
+                      type="submit"
+                      disabled={!canSave}
+                      className="rounded-lg bg-indigo-600 px-5 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
+                    >
+                      {isBusy ? '保存中…' : 'ウェイトを保存'}
+                    </button>
+                    {!sumValid && weightSum !== null && (
+                      <p className="text-xs text-rose-600">ウェイトの合計を 1.0 にしてください</p>
+                    )}
+                  </div>
+                )}
+
+                {saveState.kind === 'error' && (
+                  <p className="text-sm text-rose-600">{saveState.message}</p>
+                )}
+              </form>
+            </section>
+          )}
+        </div>
+      )}
+    </main>
+  )
+}

--- a/src/app/evaluation/total/preview/page.tsx
+++ b/src/app/evaluation/total/preview/page.tsx
@@ -1,0 +1,342 @@
+/**
+ * Issue #181 / Task 19.1 / Req 12.1, 12.2, 12.4: 総合評価 確定前プレビュー画面
+ *
+ * - GET /api/total-evaluation/preview?cycleId=X — 全社員の総合評価プレビュー（HR_MANAGER/ADMIN）
+ * - cycleId をクエリパラメータで受け取る
+ */
+'use client'
+
+import { useEffect, useState, type ReactElement } from 'react'
+import { useSearchParams } from 'next/navigation'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface TotalEvaluationPreviewResult {
+  readonly subjectId: string
+  readonly gradeId: string
+  readonly gradeLabel: string
+  readonly performanceScore: number
+  readonly goalScore: number
+  readonly feedbackScore: number
+  readonly incentiveAdjustment: number
+  readonly performanceWeight: number
+  readonly goalWeight: number
+  readonly feedbackWeight: number
+  readonly finalScore: number
+  readonly status: string
+  readonly hasWeightOverride: boolean
+  readonly isNearGradeThreshold: boolean
+  readonly nearestGradeThresholdScore: number | null
+  readonly thresholdDistancePercent: number | null
+}
+
+interface TotalEvaluationPreview {
+  readonly cycleId: string
+  readonly results: readonly TotalEvaluationPreviewResult[]
+}
+
+interface ApiEnvelope<T> {
+  readonly success?: boolean
+  readonly data?: T
+  readonly error?: string
+}
+
+type PreviewState =
+  | { readonly kind: 'idle' }
+  | { readonly kind: 'loading' }
+  | { readonly kind: 'error'; readonly message: string }
+  | { readonly kind: 'ready'; readonly preview: TotalEvaluationPreview }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const res = await fetch(url, { cache: 'no-store' })
+  const envelope = (await res.json().catch(() => ({}))) as ApiEnvelope<T>
+  if (!res.ok) throw new Error(envelope.error ?? `HTTP ${res.status}`)
+  return (envelope.data ?? null) as T
+}
+
+function readError(err: unknown): string {
+  if (err instanceof Error) return err.message
+  return '予期せぬエラーが発生しました'
+}
+
+function pct(w: number): string {
+  return `${Math.round(w * 100)}%`
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Sub-components
+// ─────────────────────────────────────────────────────────────────────────────
+
+function ScoreBar({ score }: { readonly score: number }): ReactElement {
+  const clamped = Math.min(100, Math.max(0, score))
+  const color = clamped >= 80 ? 'bg-emerald-500' : clamped >= 60 ? 'bg-indigo-400' : 'bg-amber-400'
+  return (
+    <div className="flex items-center gap-2">
+      <div className="h-1.5 w-20 overflow-hidden rounded-full bg-slate-100">
+        <div className={`h-full rounded-full ${color}`} style={{ width: `${clamped}%` }} />
+      </div>
+      <span className="text-xs text-slate-600 tabular-nums">{score.toFixed(1)}</span>
+    </div>
+  )
+}
+
+function SummaryCard({
+  label,
+  value,
+  unit,
+  color = 'text-slate-900',
+}: {
+  readonly label: string
+  readonly value: number
+  readonly unit: string
+  readonly color?: string
+}): ReactElement {
+  return (
+    <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+      <p className="text-xs font-medium text-slate-500">{label}</p>
+      <div className="mt-1 flex items-baseline gap-1">
+        <span className={`text-2xl font-bold tabular-nums ${color}`}>{value}</span>
+        <span className="text-xs text-slate-400">{unit}</span>
+      </div>
+    </div>
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Page
+// ─────────────────────────────────────────────────────────────────────────────
+
+export default function TotalEvaluationPreviewPage(): ReactElement {
+  const searchParams = useSearchParams()
+  const cycleId = searchParams.get('cycleId') ?? ''
+
+  const [state, setState] = useState<PreviewState>(cycleId ? { kind: 'loading' } : { kind: 'idle' })
+
+  useEffect(() => {
+    if (!cycleId) return
+    setState({ kind: 'loading' })
+    void (async () => {
+      try {
+        const preview = await fetchJson<TotalEvaluationPreview>(
+          `/api/total-evaluation/preview?cycleId=${encodeURIComponent(cycleId)}`,
+        )
+        setState({ kind: 'ready', preview })
+      } catch (err) {
+        setState({ kind: 'error', message: readError(err) })
+      }
+    })()
+  }, [cycleId])
+
+  return (
+    <main className="mx-auto max-w-6xl px-6 py-10">
+      <header className="mb-8 flex items-start justify-between gap-4">
+        <div>
+          <p className="text-xs font-semibold tracking-widest text-indigo-600 uppercase">
+            総合評価
+          </p>
+          <h1 className="mt-1 text-3xl font-bold text-slate-900">確定前プレビュー</h1>
+          <p className="mt-2 text-sm text-slate-600">
+            全社員の総合評価スコアを確認します。確定は「確定・クローズ」画面で行います。
+          </p>
+          {cycleId && (
+            <p className="mt-1 text-xs text-slate-500">
+              サイクル ID: <span className="font-mono">{cycleId}</span>
+            </p>
+          )}
+        </div>
+        <div className="flex shrink-0 flex-wrap gap-2">
+          {cycleId && (
+            <>
+              <a
+                href={`/evaluation/total/override?cycleId=${encodeURIComponent(cycleId)}`}
+                className="rounded-lg border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50"
+              >
+                ウェイト上書き
+              </a>
+              <a
+                href={`/evaluation/total/finalize?cycleId=${encodeURIComponent(cycleId)}`}
+                className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700"
+              >
+                確定・クローズ →
+              </a>
+            </>
+          )}
+          <a
+            href="/evaluation/cycles"
+            className="rounded-lg border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50"
+          >
+            ← サイクル一覧
+          </a>
+        </div>
+      </header>
+
+      {!cycleId && (
+        <div className="rounded-xl border border-slate-200 bg-white py-16 text-center text-sm text-slate-400">
+          URL に <span className="font-mono">?cycleId=...</span> を付けてアクセスしてください
+        </div>
+      )}
+
+      {state.kind === 'loading' && (
+        <div className="py-16 text-center text-sm text-slate-400">
+          <span className="animate-pulse">読み込み中…</span>
+        </div>
+      )}
+
+      {state.kind === 'error' && (
+        <div className="rounded-xl border border-rose-300 bg-rose-50 p-6 text-sm text-rose-800">
+          <p className="font-semibold">プレビューの取得に失敗しました</p>
+          <p className="mt-1 text-xs">{state.message}</p>
+        </div>
+      )}
+
+      {state.kind === 'ready' && (
+        <div className="space-y-4">
+          {/* 集計サマリー */}
+          <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+            <SummaryCard label="対象者数" value={state.preview.results.length} unit="名" />
+            <SummaryCard
+              label="平均スコア"
+              value={
+                state.preview.results.length > 0
+                  ? parseFloat(
+                      (
+                        state.preview.results.reduce((s, r) => s + r.finalScore, 0) /
+                        state.preview.results.length
+                      ).toFixed(1),
+                    )
+                  : 0
+              }
+              unit="pt"
+              color="text-indigo-600"
+            />
+            <SummaryCard
+              label="ウェイト上書き"
+              value={state.preview.results.filter((r) => r.hasWeightOverride).length}
+              unit="件"
+              color="text-amber-600"
+            />
+            <SummaryCard
+              label="等級境界注意"
+              value={state.preview.results.filter((r) => r.isNearGradeThreshold).length}
+              unit="件"
+              color="text-rose-600"
+            />
+          </div>
+
+          {/* テーブル */}
+          {state.preview.results.length === 0 ? (
+            <div className="rounded-xl border border-slate-200 bg-white py-16 text-center text-sm text-slate-400">
+              プレビューデータがありません
+            </div>
+          ) : (
+            <div className="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b border-slate-100 bg-slate-50">
+                      <th className="px-4 py-3 text-left text-xs font-medium text-slate-500">
+                        社員 ID
+                      </th>
+                      <th className="px-4 py-3 text-center text-xs font-medium text-slate-500">
+                        等級
+                      </th>
+                      <th className="px-4 py-3 text-right text-xs font-medium text-slate-500">
+                        業績
+                      </th>
+                      <th className="px-4 py-3 text-right text-xs font-medium text-slate-500">
+                        目標
+                      </th>
+                      <th className="px-4 py-3 text-right text-xs font-medium text-slate-500">
+                        360度
+                      </th>
+                      <th className="px-4 py-3 text-right text-xs font-medium text-slate-500">
+                        加算
+                      </th>
+                      <th className="px-4 py-3 text-left text-xs font-medium text-slate-500">
+                        最終スコア
+                      </th>
+                      <th className="px-4 py-3 text-center text-xs font-medium text-slate-500">
+                        フラグ
+                      </th>
+                      <th className="px-4 py-3 text-right text-xs font-medium text-slate-500">
+                        操作
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-slate-100">
+                    {state.preview.results.map((r) => (
+                      <tr key={r.subjectId} className="hover:bg-slate-50">
+                        <td className="px-4 py-3 font-mono text-xs text-slate-700">
+                          {r.subjectId}
+                        </td>
+                        <td className="px-4 py-3 text-center">
+                          <span className="rounded bg-indigo-100 px-2 py-0.5 text-xs font-semibold text-indigo-700">
+                            {r.gradeLabel}
+                          </span>
+                        </td>
+                        <td className="px-4 py-3 text-right text-xs text-slate-600">
+                          {r.performanceScore.toFixed(1)}
+                          <span className="ml-1 text-slate-400">({pct(r.performanceWeight)})</span>
+                        </td>
+                        <td className="px-4 py-3 text-right text-xs text-slate-600">
+                          {r.goalScore.toFixed(1)}
+                          <span className="ml-1 text-slate-400">({pct(r.goalWeight)})</span>
+                        </td>
+                        <td className="px-4 py-3 text-right text-xs text-slate-600">
+                          {r.feedbackScore.toFixed(1)}
+                          <span className="ml-1 text-slate-400">({pct(r.feedbackWeight)})</span>
+                        </td>
+                        <td className="px-4 py-3 text-right text-xs text-emerald-600">
+                          {r.incentiveAdjustment > 0
+                            ? `+${r.incentiveAdjustment.toFixed(1)}`
+                            : r.incentiveAdjustment.toFixed(1)}
+                        </td>
+                        <td className="px-4 py-3">
+                          <ScoreBar score={r.finalScore} />
+                        </td>
+                        <td className="px-4 py-3">
+                          <div className="flex justify-center gap-1">
+                            {r.hasWeightOverride && (
+                              <span
+                                title="ウェイト上書きあり"
+                                className="rounded bg-amber-100 px-1.5 py-0.5 text-xs text-amber-700"
+                              >
+                                W
+                              </span>
+                            )}
+                            {r.isNearGradeThreshold && (
+                              <span
+                                title={`等級境界から ${r.thresholdDistancePercent?.toFixed(1)}%`}
+                                className="rounded bg-rose-100 px-1.5 py-0.5 text-xs text-rose-700"
+                              >
+                                ±{r.thresholdDistancePercent?.toFixed(1)}%
+                              </span>
+                            )}
+                          </div>
+                        </td>
+                        <td className="px-4 py-3 text-right">
+                          <a
+                            href={`/evaluation/total/override?cycleId=${encodeURIComponent(cycleId)}&subjectId=${encodeURIComponent(r.subjectId)}`}
+                            className="text-xs font-medium text-indigo-600 hover:text-indigo-800"
+                          >
+                            上書き
+                          </a>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </main>
+  )
+}


### PR DESCRIPTION
## Summary

- **Task 19.1** `/evaluation/total/preview` — 確定前プレビュー画面（HR_MANAGER/ADMIN）
  - GET `/api/total-evaluation/preview?cycleId=X` で全社員スコアを取得
  - 集計サマリーカード4枚（対象者数・平均スコア・ウェイト上書き件数・等級境界注意件数）
  - テーブル: ScoreBar・W/境界フラグバッジ・各社員の上書きリンク
- **Task 19.2** `/evaluation/total/override` — 個別ウェイト上書き画面（HR_MANAGER）
  - GET `/api/total-evaluation/override?cycleId&subjectId` で既存上書きを表示
  - PUT `/api/total-evaluation/override` でウェイト保存
  - 合計バリデーション（1.0 ± 1e-4）、既存上書きをアンバーバナーで表示
- **Task 19.3** `/evaluation/total/finalize` — 確定・クローズ / ADMIN修正画面
  - POST `/api/total-evaluation/finalize` で2ステップ確認後に全件確定
  - PUT `/api/total-evaluation/correction` でADMINによる確定後スコア修正

## Test plan

- [ ] `/evaluation/total/preview?cycleId=X` にアクセスして4枚のサマリーカードとテーブルが表示されること
- [ ] `hasWeightOverride=true` の行に W バッジ、`isNearGradeThreshold=true` の行に境界距離バッジが表示されること
- [ ] `/evaluation/total/override?cycleId=X&subjectId=Y` でウェイト合計が1.0にならない場合は保存ボタンが無効になること
- [ ] 既存上書きがある場合はアンバーバナーに既存値が表示されること
- [ ] `/evaluation/total/finalize?cycleId=X` で「確定・クローズ」→確認ダイアログ→「確定する」の2ステップが機能すること
- [ ] ADMINスコア修正フォームでウェイト合計バリデーションが動作すること
- [ ] cycleId なしでアクセスした場合にプレースホルダー案内が表示されること