### PR TITLE
feat: 異議申立て送信・審査画面を実装 (Issue #182)

### DIFF
--- a/src/app/evaluation/appeals/page.tsx
+++ b/src/app/evaluation/appeals/page.tsx
@@ -1,0 +1,496 @@
+/**
+ * Issue #182 / Task 20.2 / Req 18.4, 18.5: HR_MANAGER 異議申立て審査一覧・詳細画面
+ *
+ * - GET  /api/appeals               — 未対応申立て一覧（HR_MANAGER/ADMIN）
+ * - PATCH /api/appeals/{appealId}   — 審査結果を記録
+ *   body: { status, reviewComment }
+ */
+'use client'
+
+import { useEffect, useState, type ReactElement, type FormEvent } from 'react'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+type AppealTargetType = 'FEEDBACK' | 'TOTAL_EVALUATION'
+
+type AppealStatus = 'SUBMITTED' | 'UNDER_REVIEW' | 'ACCEPTED' | 'REJECTED' | 'WITHDRAWN'
+
+type ReviewDecision = Extract<AppealStatus, 'UNDER_REVIEW' | 'ACCEPTED' | 'REJECTED' | 'WITHDRAWN'>
+
+interface Appeal {
+  readonly id: string
+  readonly appellantId: string
+  readonly cycleId: string
+  readonly subjectId: string
+  readonly targetType: AppealTargetType
+  readonly targetId: string
+  readonly reason: string
+  readonly desiredOutcome: string | null
+  readonly status: AppealStatus
+  readonly reviewerId: string | null
+  readonly reviewComment: string | null
+  readonly reviewedAt: string | null
+  readonly submittedAt: string
+}
+
+interface ApiEnvelope<T> {
+  readonly success?: boolean
+  readonly data?: T
+  readonly error?: string
+}
+
+type ListState =
+  | { readonly kind: 'loading' }
+  | { readonly kind: 'error'; readonly message: string }
+  | { readonly kind: 'ready'; readonly appeals: readonly Appeal[] }
+
+interface ReviewForm {
+  status: ReviewDecision
+  reviewComment: string
+}
+
+type ReviewState =
+  | { readonly kind: 'idle' }
+  | { readonly kind: 'reviewing'; readonly appealId: string }
+  | { readonly kind: 'saving' }
+  | { readonly kind: 'done'; readonly appealId: string }
+  | { readonly kind: 'error'; readonly message: string }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function fetchJson<T>(url: string, options?: RequestInit): Promise<T> {
+  const res = await fetch(url, { cache: 'no-store', ...options })
+  const envelope = (await res.json().catch(() => ({}))) as ApiEnvelope<T>
+  if (!res.ok) throw new Error(envelope.error ?? `HTTP ${res.status}`)
+  return (envelope.data ?? null) as T
+}
+
+function readError(err: unknown): string {
+  if (err instanceof Error) return err.message
+  return '予期せぬエラーが発生しました'
+}
+
+function formatDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleDateString('ja-JP', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    })
+  } catch {
+    return iso
+  }
+}
+
+const STATUS_LABELS: Record<AppealStatus, string> = {
+  SUBMITTED: '提出済み',
+  UNDER_REVIEW: '審査中',
+  ACCEPTED: '認容',
+  REJECTED: '棄却',
+  WITHDRAWN: '取り下げ',
+}
+
+const STATUS_COLORS: Record<AppealStatus, string> = {
+  SUBMITTED: 'bg-blue-50 text-blue-700 border-blue-200',
+  UNDER_REVIEW: 'bg-amber-50 text-amber-700 border-amber-200',
+  ACCEPTED: 'bg-emerald-50 text-emerald-700 border-emerald-200',
+  REJECTED: 'bg-rose-50 text-rose-700 border-rose-200',
+  WITHDRAWN: 'bg-slate-50 text-slate-600 border-slate-200',
+}
+
+const TARGET_TYPE_LABELS: Record<AppealTargetType, string> = {
+  FEEDBACK: '360度フィードバック',
+  TOTAL_EVALUATION: '総合評価',
+}
+
+const DECISION_OPTIONS: { value: ReviewDecision; label: string }[] = [
+  { value: 'UNDER_REVIEW', label: '審査中に変更' },
+  { value: 'ACCEPTED', label: '認容（再計算トリガー）' },
+  { value: 'REJECTED', label: '棄却' },
+  { value: 'WITHDRAWN', label: '取り下げ' },
+]
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Sub-components
+// ─────────────────────────────────────────────────────────────────────────────
+
+function StatusBadge({ status }: { readonly status: AppealStatus }): ReactElement {
+  return (
+    <span
+      className={`rounded-full border px-2.5 py-0.5 text-xs font-medium ${STATUS_COLORS[status]}`}
+    >
+      {STATUS_LABELS[status]}
+    </span>
+  )
+}
+
+function AppealCard({
+  appeal,
+  isSelected,
+  onSelect,
+}: {
+  readonly appeal: Appeal
+  readonly isSelected: boolean
+  readonly onSelect: () => void
+}): ReactElement {
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      className={`w-full rounded-xl border bg-white p-4 text-left shadow-sm transition-colors hover:border-indigo-300 ${
+        isSelected ? 'border-indigo-400 ring-1 ring-indigo-300' : 'border-slate-200'
+      }`}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <span className="text-xs font-semibold text-slate-500">
+              {TARGET_TYPE_LABELS[appeal.targetType]}
+            </span>
+            <StatusBadge status={appeal.status} />
+          </div>
+          <p className="mt-1 truncate font-mono text-xs text-slate-500">{appeal.appellantId}</p>
+          <p className="mt-1 line-clamp-2 text-sm text-slate-700">{appeal.reason}</p>
+        </div>
+      </div>
+      <p className="mt-2 text-xs text-slate-400">提出日: {formatDate(appeal.submittedAt)}</p>
+    </button>
+  )
+}
+
+function AppealDetail({
+  appeal,
+  reviewForm,
+  setReviewForm,
+  reviewState,
+  onReview,
+  onClose,
+}: {
+  readonly appeal: Appeal
+  readonly reviewForm: ReviewForm
+  readonly setReviewForm: (fn: (f: ReviewForm) => ReviewForm) => void
+  readonly reviewState: ReviewState
+  readonly onReview: (e: FormEvent) => void
+  readonly onClose: () => void
+}): ReactElement {
+  const isPending = appeal.status === 'SUBMITTED' || appeal.status === 'UNDER_REVIEW'
+  const isSaving = reviewState.kind === 'saving'
+
+  return (
+    <div className="rounded-xl border border-slate-200 bg-white shadow-sm">
+      <div className="flex items-center justify-between border-b border-slate-100 px-5 py-4">
+        <h2 className="font-semibold text-slate-800">申立て詳細</h2>
+        <button
+          type="button"
+          onClick={onClose}
+          className="text-xs text-slate-400 hover:text-slate-600"
+          aria-label="閉じる"
+        >
+          ✕
+        </button>
+      </div>
+
+      <div className="space-y-4 px-5 py-4">
+        <dl className="space-y-2 text-sm">
+          <div>
+            <dt className="text-xs font-medium text-slate-500">申立て ID</dt>
+            <dd className="mt-0.5 font-mono text-xs text-slate-700">{appeal.id}</dd>
+          </div>
+          <div>
+            <dt className="text-xs font-medium text-slate-500">申立者 ID</dt>
+            <dd className="mt-0.5 font-mono text-xs text-slate-700">{appeal.appellantId}</dd>
+          </div>
+          <div>
+            <dt className="text-xs font-medium text-slate-500">対象</dt>
+            <dd className="mt-0.5 text-slate-700">
+              {TARGET_TYPE_LABELS[appeal.targetType]}
+              <span className="ml-1 font-mono text-xs text-slate-400">({appeal.targetId})</span>
+            </dd>
+          </div>
+          <div>
+            <dt className="text-xs font-medium text-slate-500">ステータス</dt>
+            <dd className="mt-0.5">
+              <StatusBadge status={appeal.status} />
+            </dd>
+          </div>
+          <div>
+            <dt className="text-xs font-medium text-slate-500">提出日</dt>
+            <dd className="mt-0.5 text-slate-700">{formatDate(appeal.submittedAt)}</dd>
+          </div>
+        </dl>
+
+        <div>
+          <p className="mb-1 text-xs font-medium text-slate-500">申立て理由</p>
+          <p className="rounded-lg border border-slate-100 bg-slate-50 px-3 py-2 text-sm leading-relaxed text-slate-800">
+            {appeal.reason}
+          </p>
+        </div>
+
+        {appeal.desiredOutcome && (
+          <div>
+            <p className="mb-1 text-xs font-medium text-slate-500">希望する対応</p>
+            <p className="rounded-lg border border-indigo-100 bg-indigo-50 px-3 py-2 text-sm leading-relaxed text-slate-800">
+              {appeal.desiredOutcome}
+            </p>
+          </div>
+        )}
+
+        {!isPending && appeal.reviewComment && (
+          <div>
+            <p className="mb-1 text-xs font-medium text-slate-500">審査コメント</p>
+            <p className="rounded-lg border border-slate-100 bg-slate-50 px-3 py-2 text-sm leading-relaxed text-slate-700">
+              {appeal.reviewComment}
+            </p>
+            {appeal.reviewedAt && (
+              <p className="mt-1 text-xs text-slate-400">審査日: {formatDate(appeal.reviewedAt)}</p>
+            )}
+          </div>
+        )}
+
+        {isPending && (
+          <form onSubmit={onReview} className="space-y-3 border-t border-slate-100 pt-4">
+            <p className="text-xs font-semibold text-slate-700">審査を記録する</p>
+
+            <div>
+              <label htmlFor="decision" className="mb-1 block text-xs font-medium text-slate-600">
+                判定
+              </label>
+              <select
+                id="decision"
+                value={reviewForm.status}
+                onChange={(e) =>
+                  setReviewForm((f) => ({ ...f, status: e.target.value as ReviewDecision }))
+                }
+                disabled={isSaving}
+                className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none disabled:bg-slate-50"
+              >
+                {DECISION_OPTIONS.map((opt) => (
+                  <option key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div>
+              <label
+                htmlFor="reviewComment"
+                className="mb-1 block text-xs font-medium text-slate-600"
+              >
+                審査コメント <span className="text-rose-500">*</span>
+              </label>
+              <textarea
+                id="reviewComment"
+                rows={4}
+                value={reviewForm.reviewComment}
+                onChange={(e) => setReviewForm((f) => ({ ...f, reviewComment: e.target.value }))}
+                disabled={isSaving}
+                placeholder="審査結果の理由を記入してください（2000文字以内）"
+                maxLength={2000}
+                className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none disabled:bg-slate-50"
+              />
+            </div>
+
+            {reviewState.kind === 'error' && (
+              <p className="text-xs text-rose-600">{reviewState.message}</p>
+            )}
+
+            <button
+              type="submit"
+              disabled={isSaving || reviewForm.reviewComment.trim().length === 0}
+              className="w-full rounded-lg bg-indigo-600 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
+            >
+              {isSaving ? '保存中…' : '審査結果を記録'}
+            </button>
+          </form>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Page
+// ─────────────────────────────────────────────────────────────────────────────
+
+export default function AppealReviewPage(): ReactElement {
+  const [listState, setListState] = useState<ListState>({ kind: 'loading' })
+  const [selectedId, setSelectedId] = useState<string | null>(null)
+  const [reviewState, setReviewState] = useState<ReviewState>({ kind: 'idle' })
+  const [reviewForm, setReviewForm] = useState<ReviewForm>({
+    status: 'UNDER_REVIEW',
+    reviewComment: '',
+  })
+
+  useEffect(() => {
+    void (async () => {
+      try {
+        const appeals = await fetchJson<Appeal[]>('/api/appeals')
+        setListState({ kind: 'ready', appeals: appeals ?? [] })
+      } catch (err) {
+        setListState({ kind: 'error', message: readError(err) })
+      }
+    })()
+  }, [])
+
+  function openReview(appeal: Appeal): void {
+    setSelectedId(appeal.id)
+    setReviewForm({ status: 'UNDER_REVIEW', reviewComment: '' })
+    setReviewState({ kind: 'reviewing', appealId: appeal.id })
+  }
+
+  function closeReview(): void {
+    setSelectedId(null)
+    setReviewState({ kind: 'idle' })
+  }
+
+  async function handleReview(e: FormEvent): Promise<void> {
+    e.preventDefault()
+    if (!selectedId || reviewForm.reviewComment.trim().length === 0) return
+    setReviewState({ kind: 'saving' })
+    try {
+      await fetchJson<Appeal>(`/api/appeals/${encodeURIComponent(selectedId)}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          status: reviewForm.status,
+          reviewComment: reviewForm.reviewComment.trim(),
+        }),
+      })
+      const updated = await fetchJson<Appeal[]>('/api/appeals')
+      setListState({ kind: 'ready', appeals: updated ?? [] })
+      setReviewState({ kind: 'done', appealId: selectedId })
+      setSelectedId(null)
+    } catch (err) {
+      setReviewState({ kind: 'error', message: readError(err) })
+    }
+  }
+
+  const selectedAppeal =
+    listState.kind === 'ready' && selectedId
+      ? (listState.appeals.find((a) => a.id === selectedId) ?? null)
+      : null
+
+  const pendingAppeals =
+    listState.kind === 'ready'
+      ? listState.appeals.filter((a) => a.status === 'SUBMITTED' || a.status === 'UNDER_REVIEW')
+      : []
+
+  const resolvedAppeals =
+    listState.kind === 'ready'
+      ? listState.appeals.filter(
+          (a) => a.status === 'ACCEPTED' || a.status === 'REJECTED' || a.status === 'WITHDRAWN',
+        )
+      : []
+
+  return (
+    <main className="mx-auto max-w-5xl px-6 py-10">
+      <header className="mb-8 flex items-start justify-between gap-4">
+        <div>
+          <p className="text-xs font-semibold tracking-widest text-indigo-600 uppercase">評価</p>
+          <h1 className="mt-1 text-3xl font-bold text-slate-900">異議申立て審査</h1>
+          <p className="mt-2 text-sm text-slate-600">
+            社員からの異議申立てを審査し、認容・棄却を決定します（HR_MANAGER 専用）。
+          </p>
+        </div>
+        <a
+          href="/evaluation/cycles"
+          className="shrink-0 rounded-lg border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50"
+        >
+          ← サイクル一覧
+        </a>
+      </header>
+
+      {reviewState.kind === 'done' && (
+        <div className="mb-6 rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-800">
+          ✓ 審査結果を記録しました
+        </div>
+      )}
+
+      {listState.kind === 'loading' && (
+        <div className="py-16 text-center text-sm text-slate-400">
+          <span className="animate-pulse">読み込み中…</span>
+        </div>
+      )}
+
+      {listState.kind === 'error' && (
+        <div className="rounded-xl border border-rose-300 bg-rose-50 p-6 text-sm text-rose-800">
+          <p className="font-semibold">申立て一覧の取得に失敗しました</p>
+          <p className="mt-1 text-xs">{listState.message}</p>
+        </div>
+      )}
+
+      {listState.kind === 'ready' && (
+        <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
+          {/* ── 一覧パネル ── */}
+          <div className="space-y-6 lg:col-span-2">
+            <section>
+              <h2 className="mb-3 text-sm font-semibold text-slate-700">
+                未対応{' '}
+                <span className="ml-1 rounded-full bg-rose-100 px-2 py-0.5 text-xs font-bold text-rose-700">
+                  {pendingAppeals.length}
+                </span>
+              </h2>
+              {pendingAppeals.length === 0 ? (
+                <div className="rounded-xl border border-slate-200 bg-white py-10 text-center text-sm text-slate-400">
+                  未対応の申立てはありません
+                </div>
+              ) : (
+                <div className="space-y-3">
+                  {pendingAppeals.map((appeal) => (
+                    <AppealCard
+                      key={appeal.id}
+                      appeal={appeal}
+                      isSelected={selectedId === appeal.id}
+                      onSelect={() => openReview(appeal)}
+                    />
+                  ))}
+                </div>
+              )}
+            </section>
+
+            {resolvedAppeals.length > 0 && (
+              <section>
+                <h2 className="mb-3 text-sm font-semibold text-slate-500">
+                  対応済み（{resolvedAppeals.length} 件）
+                </h2>
+                <div className="space-y-3">
+                  {resolvedAppeals.map((appeal) => (
+                    <AppealCard
+                      key={appeal.id}
+                      appeal={appeal}
+                      isSelected={selectedId === appeal.id}
+                      onSelect={() => setSelectedId(appeal.id)}
+                    />
+                  ))}
+                </div>
+              </section>
+            )}
+          </div>
+
+          {/* ── 詳細 / 審査パネル ── */}
+          <div className="lg:col-span-1">
+            {!selectedId ? (
+              <div className="rounded-xl border border-slate-200 bg-slate-50 py-16 text-center text-sm text-slate-400">
+                申立てを選択してください
+              </div>
+            ) : selectedAppeal ? (
+              <AppealDetail
+                appeal={selectedAppeal}
+                reviewForm={reviewForm}
+                setReviewForm={setReviewForm}
+                reviewState={reviewState}
+                onReview={(e) => void handleReview(e)}
+                onClose={closeReview}
+              />
+            ) : null}
+          </div>
+        </div>
+      )}
+    </main>
+  )
+}

--- a/src/app/evaluation/appeals/submit/page.tsx
+++ b/src/app/evaluation/appeals/submit/page.tsx
@@ -1,0 +1,334 @@
+/**
+ * Issue #182 / Task 20.1 / Req 18.1, 18.2, 18.3: 異議申立て送信フォーム
+ *
+ * - POST /api/appeals — 異議申立てを送信（EMPLOYEE）
+ *   body: { targetType, targetId, reason, desiredOutcome? }
+ */
+'use client'
+
+import { useState, type ReactElement, type FormEvent } from 'react'
+import { useSearchParams } from 'next/navigation'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+type AppealTargetType = 'FEEDBACK' | 'TOTAL_EVALUATION'
+
+interface Appeal {
+  readonly id: string
+  readonly appellantId: string
+  readonly cycleId: string
+  readonly subjectId: string
+  readonly targetType: AppealTargetType
+  readonly targetId: string
+  readonly reason: string
+  readonly desiredOutcome: string | null
+  readonly status: string
+  readonly submittedAt: string
+}
+
+interface ApiEnvelope<T> {
+  readonly success?: boolean
+  readonly data?: T
+  readonly error?: string
+  readonly deadline?: string
+}
+
+interface AppealForm {
+  targetType: AppealTargetType
+  targetId: string
+  reason: string
+  desiredOutcome: string
+}
+
+type SubmitState =
+  | { readonly kind: 'idle' }
+  | { readonly kind: 'submitting' }
+  | { readonly kind: 'done'; readonly appeal: Appeal }
+  | { readonly kind: 'deadline'; readonly deadline: string }
+  | { readonly kind: 'error'; readonly message: string }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function postJson<T>(
+  url: string,
+  body: unknown,
+): Promise<{ data: T; envelope: ApiEnvelope<T> }> {
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+    cache: 'no-store',
+  })
+  const envelope = (await res.json().catch(() => ({}))) as ApiEnvelope<T>
+  if (!res.ok) {
+    const err = Object.assign(new Error(envelope.error ?? `HTTP ${res.status}`), { envelope })
+    throw err
+  }
+  return { data: (envelope.data ?? null) as T, envelope }
+}
+
+function readError(err: unknown): string {
+  if (err instanceof Error) return err.message
+  return '予期せぬエラーが発生しました'
+}
+
+function formatDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleDateString('ja-JP', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    })
+  } catch {
+    return iso
+  }
+}
+
+const TARGET_TYPE_LABELS: Record<AppealTargetType, string> = {
+  FEEDBACK: '360度フィードバック',
+  TOTAL_EVALUATION: '総合評価',
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Page
+// ─────────────────────────────────────────────────────────────────────────────
+
+export default function AppealSubmitPage(): ReactElement {
+  const searchParams = useSearchParams()
+  const defaultTargetType = (searchParams.get('targetType') ??
+    'TOTAL_EVALUATION') as AppealTargetType
+  const defaultTargetId = searchParams.get('targetId') ?? ''
+
+  const [form, setForm] = useState<AppealForm>({
+    targetType: defaultTargetType,
+    targetId: defaultTargetId,
+    reason: '',
+    desiredOutcome: '',
+  })
+  const [submitState, setSubmitState] = useState<SubmitState>({ kind: 'idle' })
+
+  const canSubmit =
+    form.targetId.trim().length > 0 &&
+    form.reason.trim().length > 0 &&
+    form.reason.trim().length <= 2000 &&
+    (form.desiredOutcome.trim().length === 0 || form.desiredOutcome.trim().length <= 1000) &&
+    submitState.kind !== 'submitting'
+
+  async function handleSubmit(e: FormEvent): Promise<void> {
+    e.preventDefault()
+    if (!canSubmit) return
+    setSubmitState({ kind: 'submitting' })
+    try {
+      const payload: Record<string, unknown> = {
+        targetType: form.targetType,
+        targetId: form.targetId.trim(),
+        reason: form.reason.trim(),
+      }
+      if (form.desiredOutcome.trim()) {
+        payload.desiredOutcome = form.desiredOutcome.trim()
+      }
+      const { data } = await postJson<Appeal>('/api/appeals', payload)
+      setSubmitState({ kind: 'done', appeal: data })
+    } catch (err) {
+      const envelope = (err as Error & { envelope?: ApiEnvelope<Appeal> }).envelope
+      if (envelope?.deadline) {
+        setSubmitState({ kind: 'deadline', deadline: envelope.deadline })
+        return
+      }
+      setSubmitState({ kind: 'error', message: readError(err) })
+    }
+  }
+
+  return (
+    <main className="mx-auto max-w-2xl px-6 py-10">
+      <header className="mb-8 flex items-start justify-between gap-4">
+        <div>
+          <p className="text-xs font-semibold tracking-widest text-indigo-600 uppercase">評価</p>
+          <h1 className="mt-1 text-3xl font-bold text-slate-900">異議申立て</h1>
+          <p className="mt-2 text-sm text-slate-600">
+            評価結果に異議がある場合は、公開日から 14 日以内に申立てを提出してください。
+          </p>
+        </div>
+        <a
+          href="/evaluation/cycles"
+          className="shrink-0 rounded-lg border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50"
+        >
+          ← サイクル一覧
+        </a>
+      </header>
+
+      {submitState.kind === 'done' ? (
+        /* 送信完了 */
+        <div className="space-y-4">
+          <div className="rounded-xl border border-emerald-200 bg-emerald-50 p-6">
+            <p className="text-lg font-bold text-emerald-800">✓ 異議申立てを受け付けました</p>
+            <p className="mt-1 text-sm text-emerald-700">
+              HR マネージャーが審査を行い、結果をお知らせします。
+            </p>
+          </div>
+          <div className="rounded-xl border border-slate-200 bg-white p-5 text-sm text-slate-700 shadow-sm">
+            <dl className="space-y-2">
+              <div className="flex gap-2">
+                <dt className="shrink-0 font-medium text-slate-500">申立て ID:</dt>
+                <dd className="font-mono text-xs">{submitState.appeal.id}</dd>
+              </div>
+              <div className="flex gap-2">
+                <dt className="shrink-0 font-medium text-slate-500">対象:</dt>
+                <dd>{TARGET_TYPE_LABELS[submitState.appeal.targetType]}</dd>
+              </div>
+              <div className="flex gap-2">
+                <dt className="shrink-0 font-medium text-slate-500">ステータス:</dt>
+                <dd>
+                  <span className="rounded-full bg-blue-50 px-2 py-0.5 text-xs font-medium text-blue-700">
+                    受付済み
+                  </span>
+                </dd>
+              </div>
+              <div className="flex gap-2">
+                <dt className="shrink-0 font-medium text-slate-500">提出日:</dt>
+                <dd>{formatDate(submitState.appeal.submittedAt)}</dd>
+              </div>
+            </dl>
+          </div>
+          <a
+            href="/evaluation/cycles"
+            className="inline-block rounded-lg border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50"
+          >
+            サイクル一覧へ戻る
+          </a>
+        </div>
+      ) : (
+        /* 送信フォーム */
+        <section className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+          {/* 期限切れエラー */}
+          {submitState.kind === 'deadline' && (
+            <div className="mb-5 rounded-lg border border-rose-300 bg-rose-50 p-4 text-sm text-rose-800">
+              <p className="font-semibold">申立て期限が過ぎています</p>
+              <p className="mt-1 text-xs">
+                申立て期限（{formatDate(submitState.deadline)}）を過ぎているため、送信できません。
+              </p>
+            </div>
+          )}
+
+          {/* 汎用エラー */}
+          {submitState.kind === 'error' && (
+            <div className="mb-5 rounded-lg border border-rose-300 bg-rose-50 p-4 text-sm text-rose-800">
+              <p className="font-semibold">送信に失敗しました</p>
+              <p className="mt-1 text-xs">{submitState.message}</p>
+            </div>
+          )}
+
+          <form onSubmit={(e) => void handleSubmit(e)} className="space-y-5">
+            {/* 対象種別 */}
+            <div>
+              <p className="mb-2 text-xs font-medium text-slate-600">
+                対象種別 <span className="text-rose-500">*</span>
+              </p>
+              <div className="flex gap-4">
+                {(['TOTAL_EVALUATION', 'FEEDBACK'] as const).map((type) => (
+                  <label key={type} className="flex items-center gap-2 text-sm text-slate-700">
+                    <input
+                      type="radio"
+                      name="targetType"
+                      value={type}
+                      checked={form.targetType === type}
+                      onChange={() => setForm((f) => ({ ...f, targetType: type }))}
+                      disabled={submitState.kind === 'submitting'}
+                      className="accent-indigo-600"
+                    />
+                    {TARGET_TYPE_LABELS[type]}
+                  </label>
+                ))}
+              </div>
+            </div>
+
+            {/* 対象ID */}
+            <div>
+              <label htmlFor="targetId" className="mb-1 block text-xs font-medium text-slate-600">
+                対象 ID <span className="text-rose-500">*</span>
+              </label>
+              <input
+                id="targetId"
+                type="text"
+                value={form.targetId}
+                onChange={(e) => setForm((f) => ({ ...f, targetId: e.target.value }))}
+                disabled={submitState.kind === 'submitting'}
+                placeholder="評価 ID またはフィードバック ID"
+                className="w-full rounded-lg border border-slate-300 px-3 py-2 font-mono text-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none disabled:bg-slate-50"
+              />
+              <p className="mt-0.5 text-xs text-slate-400">
+                フィードバック閲覧画面または総合評価プレビュー画面の ID をご確認ください
+              </p>
+            </div>
+
+            {/* 理由 */}
+            <div>
+              <label htmlFor="reason" className="mb-1 block text-xs font-medium text-slate-600">
+                申立て理由 <span className="text-rose-500">*</span>
+              </label>
+              <textarea
+                id="reason"
+                rows={5}
+                value={form.reason}
+                onChange={(e) => setForm((f) => ({ ...f, reason: e.target.value }))}
+                disabled={submitState.kind === 'submitting'}
+                placeholder="評価結果に異議がある理由を具体的に記入してください（2000文字以内）"
+                maxLength={2000}
+                className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none disabled:bg-slate-50"
+              />
+              <p className="mt-0.5 text-right text-xs text-slate-400">
+                {form.reason.length} / 2000
+              </p>
+            </div>
+
+            {/* 希望対応（任意） */}
+            <div>
+              <label
+                htmlFor="desiredOutcome"
+                className="mb-1 block text-xs font-medium text-slate-600"
+              >
+                希望する対応{' '}
+                <span className="font-normal text-slate-400">（任意・1000文字以内）</span>
+              </label>
+              <textarea
+                id="desiredOutcome"
+                rows={3}
+                value={form.desiredOutcome}
+                onChange={(e) => setForm((f) => ({ ...f, desiredOutcome: e.target.value }))}
+                disabled={submitState.kind === 'submitting'}
+                placeholder="再評価・説明・修正など、希望する対応があれば記入してください"
+                maxLength={1000}
+                className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none disabled:bg-slate-50"
+              />
+              <p className="mt-0.5 text-right text-xs text-slate-400">
+                {form.desiredOutcome.length} / 1000
+              </p>
+            </div>
+
+            {/* 注意書き */}
+            <div className="rounded-lg border border-amber-100 bg-amber-50 p-3 text-xs text-amber-800">
+              <p className="font-semibold">申立て前にご確認ください</p>
+              <ul className="mt-1 list-inside list-disc space-y-0.5">
+                <li>評価公開日から 14 日以内の申立てのみ受け付けています</li>
+                <li>申立て後は HR マネージャーが審査を行います</li>
+                <li>審査結果は通知でお知らせします</li>
+              </ul>
+            </div>
+
+            <button
+              type="submit"
+              disabled={!canSubmit}
+              className="rounded-lg bg-indigo-600 px-6 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
+            >
+              {submitState.kind === 'submitting' ? '送信中…' : '異議申立てを送信'}
+            </button>
+          </form>
+        </section>
+      )}
+    </main>
+  )
+}


### PR DESCRIPTION
## Summary

- **Task 20.1** `/evaluation/appeals/submit` — 異議申立て送信フォーム（EMPLOYEE）
  - `?targetType=FEEDBACK|TOTAL_EVALUATION&targetId=xxx` でパラメータを初期化
  - POST `/api/appeals` で申立て送信（reason 必須 2000字、desiredOutcome 任意 1000字）
  - 期限切れ（`AppealDeadlineExceededError`）を専用メッセージで表示
  - 文字数カウンター・14日ルール注意書き・送信完了画面（申立て ID 表示）

- **Task 20.2** `/evaluation/appeals` — HR_MANAGER 審査一覧・詳細画面
  - GET `/api/appeals` で全申立てを取得し未対応/対応済みに分類
  - 申立てカードをクリック → 右パネルに詳細（理由・希望対応・審査コメント）を表示
  - PATCH `/api/appeals/{id}` で判定（審査中/認容/棄却/取り下げ）と審査コメントを記録
  - 審査後に一覧を再取得してリアルタイム反映

## Test plan

- [ ] `/evaluation/appeals/submit` にアクセスして送信フォームが表示されること
- [ ] targetType ラジオ・targetId 入力・reason 必須バリデーションが機能すること
- [ ] 期限切れ時に「申立て期限が過ぎています」メッセージが表示されること
- [ ] 送信成功後に完了画面（申立て ID・ステータス）が表示されること
- [ ] `/evaluation/appeals` で未対応申立てが優先表示されること
- [ ] カード選択 → 右パネルに詳細が表示されること
- [ ] 審査コメント未入力時に「審査結果を記録」ボタンが無効になること
- [ ] 認容後に一覧が再取得され対応済みに移動すること