### PR TITLE
fix: app-session.ts の getDevelopmentSession 重複定義を削除 (Issue #193)

### DIFF
--- a/src/lib/auth/app-session.ts
+++ b/src/lib/auth/app-session.ts
@@ -22,18 +22,6 @@ function isDevelopmentAuthBypassEnabled(): boolean {
   )
 }
 
-function getDevelopmentSession(): AppSession {
-  return {
-    user: {
-      email: process.env.DEV_AUTH_EMAIL ?? 'dev-admin@example.com',
-      name: process.env.DEV_AUTH_NAME ?? 'Development User',
-    },
-    userId: process.env.DEV_AUTH_USER_ID ?? 'dev-user-1',
-    sessionId: process.env.DEV_AUTH_SESSION_ID ?? 'dev-session-1',
-    role: process.env.DEV_AUTH_ROLE ?? 'ADMIN',
-  }
-}
-
 function getLegacySessionGetter(): LegacySessionGetter | undefined {
   return undefined
 }


### PR DESCRIPTION
## Summary

- `src/lib/auth/app-session.ts` 内で `getDevelopmentSession` 関数が2箇所に定義されていた
- env変数ベースの旧定義（旧25〜35行）を削除し、`DEV_SESSION` 定数を使う新定義のみ残す

## Root Cause

旧定義と新定義の両方がマージされた状態でコミットされており、Turbopack のビルド時に致命的エラーとなっていた。

## Changes

`src/lib/auth/app-session.ts` の12行削除のみ（パブリック API `getAppSession` の動作変化なし）

## Test plan

- [ ] `pnpm tsc --noEmit` で TS2393 エラーが消えていること
- [ ] `pnpm build` または `pnpm dev` でビルドエラーが解消されること
- [ ] `/api/dashboard/kpi` など既存の API ルートが正常に動作すること

Closes #193