### PR TITLE
feat: UIリデザイン — サイドバーレイアウト + 管理画面追加

### DIFF
--- a/src/app/admin/audit-log/page.tsx
+++ b/src/app/admin/audit-log/page.tsx
@@ -1,0 +1,141 @@
+import type { ReactElement } from 'react'
+
+export const metadata = {
+  title: '監査ログ | HR Management',
+}
+
+interface LogColumn {
+  readonly key: string
+  readonly label: string
+}
+
+const COLUMNS: readonly LogColumn[] = [
+  { key: 'timestamp', label: '日時' },
+  { key: 'actor', label: '実行者' },
+  { key: 'action', label: 'アクション' },
+  { key: 'target', label: '対象リソース' },
+  { key: 'ip', label: 'IPアドレス' },
+]
+
+const ACTION_TYPES: readonly string[] = [
+  'すべて',
+  'ログイン',
+  '社員データ編集',
+  'スキル承認',
+  '評価提出',
+  '権限変更',
+]
+
+export default function AuditLogPage(): ReactElement {
+  return (
+    <div className="mx-auto flex max-w-6xl flex-col gap-6 px-8 py-10">
+      <header className="flex flex-col gap-2">
+        <p className="text-xs font-semibold tracking-[0.3em] text-indigo-600 uppercase">
+          Admin / Audit
+        </p>
+        <h1 className="text-3xl font-semibold tracking-tight text-slate-950">監査ログ</h1>
+        <p className="max-w-2xl text-sm leading-6 text-slate-600">
+          システム全体の操作履歴を確認します。社員データの編集、権限変更、評価提出などの重要アクションを追跡できます。
+        </p>
+      </header>
+
+      <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+        <h2 className="text-sm font-semibold text-slate-900">フィルタ</h2>
+        <div className="mt-4 grid gap-4 md:grid-cols-4">
+          <FilterField label="開始日">
+            <input
+              type="date"
+              className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-800 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+              disabled
+            />
+          </FilterField>
+          <FilterField label="終了日">
+            <input
+              type="date"
+              className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-800 focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+              disabled
+            />
+          </FilterField>
+          <FilterField label="アクション種別">
+            <select
+              className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-800"
+              disabled
+            >
+              {ACTION_TYPES.map((action) => (
+                <option key={action}>{action}</option>
+              ))}
+            </select>
+          </FilterField>
+          <FilterField label="実行者">
+            <input
+              type="text"
+              placeholder="社員ID / 氏名"
+              className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-800 placeholder:text-slate-400"
+              disabled
+            />
+          </FilterField>
+        </div>
+        <div className="mt-4 flex justify-end">
+          <button
+            type="button"
+            className="cursor-not-allowed rounded-md bg-slate-200 px-4 py-2 text-sm font-medium text-slate-500"
+            disabled
+          >
+            検索（API 未実装）
+          </button>
+        </div>
+      </section>
+
+      <section className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
+        <header className="flex items-center justify-between border-b border-slate-100 px-6 py-4">
+          <h2 className="text-sm font-semibold text-slate-900">ログ一覧</h2>
+          <span className="rounded-full bg-amber-100 px-3 py-1 text-xs font-semibold text-amber-800">
+            Placeholder
+          </span>
+        </header>
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-slate-200 text-sm">
+            <thead className="bg-slate-50">
+              <tr>
+                {COLUMNS.map((col) => (
+                  <th
+                    key={col.key}
+                    scope="col"
+                    className="px-6 py-3 text-left text-xs font-semibold tracking-wider text-slate-500 uppercase"
+                  >
+                    {col.label}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td
+                  colSpan={COLUMNS.length}
+                  className="px-6 py-16 text-center text-sm text-slate-500"
+                >
+                  監査ログ API は未実装です。実装後にここへログエントリが表示されます。
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+  )
+}
+
+function FilterField({
+  label,
+  children,
+}: {
+  readonly label: string
+  readonly children: ReactElement
+}): ReactElement {
+  return (
+    <label className="flex flex-col gap-1.5">
+      <span className="text-xs font-medium text-slate-600">{label}</span>
+      {children}
+    </label>
+  )
+}

--- a/src/app/admin/masters/page.tsx
+++ b/src/app/admin/masters/page.tsx
@@ -1,0 +1,115 @@
+import type { ReactElement } from 'react'
+
+export const metadata = {
+  title: 'マスタ管理 | HR Management',
+}
+
+interface MasterCard {
+  readonly key: string
+  readonly title: string
+  readonly description: string
+  readonly icon: string
+  readonly accent: string
+}
+
+const MASTER_CARDS: readonly MasterCard[] = [
+  {
+    key: 'skills',
+    title: 'スキルマスタ',
+    description:
+      'スキル項目・カテゴリ・レベル定義を管理します。スキル登録フォームと評価ロジックから参照されます。',
+    icon: '🧠',
+    accent: 'from-indigo-500 to-indigo-700',
+  },
+  {
+    key: 'roles',
+    title: '職種マスタ',
+    description:
+      '職種・ロール・責務定義を管理します。社員配置とキャリアマップ、候補者マッチングで使用されます。',
+    icon: '🧭',
+    accent: 'from-emerald-500 to-emerald-700',
+  },
+  {
+    key: 'grades',
+    title: 'グレードマスタ',
+    description:
+      '等級・職位・評価レベルを管理します。評価制度と給与テーブルに連動する基礎マスタです。',
+    icon: '🏅',
+    accent: 'from-amber-500 to-amber-700',
+  },
+  {
+    key: 'departments',
+    title: '部署マスタ',
+    description: '組織階層と部署属性を管理します。組織図と社員一覧の検索ファセットに使われます。',
+    icon: '🏢',
+    accent: 'from-sky-500 to-sky-700',
+  },
+]
+
+export default function MastersPage(): ReactElement {
+  return (
+    <div className="mx-auto flex max-w-6xl flex-col gap-8 px-8 py-10">
+      <header className="flex flex-col gap-2">
+        <p className="text-xs font-semibold tracking-[0.3em] text-indigo-600 uppercase">
+          Admin / Masters
+        </p>
+        <div className="flex items-end justify-between gap-4">
+          <h1 className="text-3xl font-semibold tracking-tight text-slate-950">マスタ管理</h1>
+          <span className="rounded-full bg-amber-100 px-3 py-1 text-xs font-semibold text-amber-800">
+            Placeholder
+          </span>
+        </div>
+        <p className="max-w-2xl text-sm leading-6 text-slate-600">
+          システム全体で参照される基礎マスタ（スキル・職種・グレード・部署）を管理します。各マスタの編集
+          API は未実装のため、現在は構造のみを表示しています。
+        </p>
+      </header>
+
+      <section className="grid gap-4 md:grid-cols-2">
+        {MASTER_CARDS.map((card) => (
+          <MasterCardView key={card.key} card={card} />
+        ))}
+      </section>
+
+      <section className="rounded-2xl border border-dashed border-slate-300 bg-white/60 p-6 text-sm text-slate-600">
+        <h2 className="text-sm font-semibold text-slate-900">実装予定の操作</h2>
+        <ul className="mt-3 list-disc space-y-1 pl-5">
+          <li>マスタレコードの一覧・検索・フィルタリング</li>
+          <li>新規レコードの作成と編集（論理削除に対応）</li>
+          <li>CSV インポート／エクスポート</li>
+          <li>変更履歴の監査ログ連携</li>
+        </ul>
+      </section>
+    </div>
+  )
+}
+
+function MasterCardView({ card }: { readonly card: MasterCard }): ReactElement {
+  return (
+    <article className="group relative overflow-hidden rounded-2xl border border-slate-200 bg-white p-5 shadow-sm transition-shadow hover:shadow-md">
+      <div
+        className={`pointer-events-none absolute inset-x-0 top-0 h-1 bg-gradient-to-r ${card.accent}`}
+        aria-hidden
+      />
+      <div className="flex items-start gap-4">
+        <span className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-slate-100 text-xl">
+          {card.icon}
+        </span>
+        <div className="flex-1">
+          <h3 className="text-base font-semibold text-slate-900">{card.title}</h3>
+          <p className="mt-1 text-sm leading-6 text-slate-600">{card.description}</p>
+          <div className="mt-4 flex items-center gap-3">
+            <button
+              type="button"
+              className="cursor-not-allowed rounded-md border border-slate-200 bg-slate-50 px-3 py-1.5 text-xs font-medium text-slate-500"
+              disabled
+            >
+              一覧を開く
+            </button>
+            <span className="text-xs text-slate-400">API 未実装</span>
+          </div>
+        </div>
+      </div>
+    </article>
+  )
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,9 +1,18 @@
+/**
+ * Issue #195 / ダッシュボード リデザイン
+ *
+ * - GET /api/dashboard/kpi — ロール別 KPI サマリーを取得
+ * - サイドバーレイアウト適用後の新デザイン
+ */
 'use client'
 
 import Link from 'next/link'
 import { useEffect, useState, type ReactElement } from 'react'
-import { KpiSummaryPanel } from '@/components/dashboard/KpiSummaryPanel'
-import type { DashboardSummary } from '@/lib/dashboard/dashboard-types'
+import type { DashboardSummary, KpiMetric } from '@/lib/dashboard/dashboard-types'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────────────
 
 interface DashboardEnvelope {
   readonly success?: boolean
@@ -17,7 +26,54 @@ type DashboardState =
   | { readonly kind: 'unauthorized'; readonly message: string }
   | { readonly kind: 'error'; readonly message: string }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Constants
+// ─────────────────────────────────────────────────────────────────────────────
+
 const DASHBOARD_URL = '/api/dashboard/kpi'
+
+const QUICK_ACTIONS: readonly {
+  readonly href: string
+  readonly label: string
+  readonly description: string
+  readonly colorClass: string
+}[] = [
+  {
+    href: '/evaluation/cycles',
+    label: '評価サイクル',
+    description: '進行中のサイクルを確認・管理',
+    colorClass: 'border-indigo-200 bg-indigo-50 text-indigo-700 hover:bg-indigo-100',
+  },
+  {
+    href: '/skill-map',
+    label: 'スキルマップ',
+    description: '組織スキル充足率とレーダーチャート',
+    colorClass: 'border-emerald-200 bg-emerald-50 text-emerald-700 hover:bg-emerald-100',
+  },
+  {
+    href: '/goals/personal',
+    label: '個人目標',
+    description: 'OKR / MBO の確認と進捗更新',
+    colorClass: 'border-amber-200 bg-amber-50 text-amber-700 hover:bg-amber-100',
+  },
+  {
+    href: '/one-on-one/schedule',
+    label: '1on1',
+    description: 'スケジュール・ログを確認',
+    colorClass: 'border-sky-200 bg-sky-50 text-sky-700 hover:bg-sky-100',
+  },
+]
+
+const ROLE_LABEL: Record<string, string> = {
+  ADMIN: '管理者',
+  HR_MANAGER: '人事マネージャー',
+  MANAGER: 'マネージャー',
+  EMPLOYEE: '社員',
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Page
+// ─────────────────────────────────────────────────────────────────────────────
 
 export default function DashboardPage(): ReactElement {
   const [state, setState] = useState<DashboardState>({ kind: 'loading' })
@@ -35,9 +91,7 @@ export default function DashboardPage(): ReactElement {
         if (res.status === 401 || res.status === 403) {
           setState({
             kind: 'unauthorized',
-            message:
-              body.error ??
-              'ダッシュボードを表示するにはログイン済みユーザーとしてアクセスしてください。',
+            message: body.error ?? 'ダッシュボードを表示するにはログインが必要です。',
           })
           return
         }
@@ -55,10 +109,7 @@ export default function DashboardPage(): ReactElement {
         if (cancelled) return
         setState({
           kind: 'error',
-          message:
-            error instanceof Error
-              ? error.message
-              : 'ダッシュボードの読み込み中に予期しないエラーが発生しました。',
+          message: error instanceof Error ? error.message : '予期しないエラーが発生しました。',
         })
       }
     })()
@@ -69,113 +120,174 @@ export default function DashboardPage(): ReactElement {
   }, [])
 
   return (
-    <main className="min-h-screen bg-[linear-gradient(180deg,#f8fbff_0%,#ffffff_45%,#f8fafc_100%)]">
-      <div className="mx-auto flex max-w-6xl flex-col gap-8 px-6 py-10">
-        <PageHeader />
-        <QuickLinks />
-        <DashboardBody state={state} />
-      </div>
-    </main>
+    <div className="mx-auto flex max-w-6xl flex-col gap-8 px-8 py-10">
+      <PageHeader state={state} />
+      <MetricsSection state={state} />
+      <QuickActionsSection />
+    </div>
   )
 }
 
-function PageHeader(): ReactElement {
+// ─────────────────────────────────────────────────────────────────────────────
+// Page Header
+// ─────────────────────────────────────────────────────────────────────────────
+
+function PageHeader({ state }: { readonly state: DashboardState }): ReactElement {
+  const roleLabel =
+    state.kind === 'ready' ? (ROLE_LABEL[state.summary.role] ?? state.summary.role) : null
+
   return (
-    <header className="rounded-3xl border border-slate-200 bg-white/90 p-6 shadow-sm backdrop-blur">
-      <p className="text-xs font-semibold tracking-[0.3em] text-sky-700 uppercase">Home</p>
-      <h1 className="mt-2 text-4xl font-semibold tracking-tight text-slate-950">
-        HR Management Dashboard
-      </h1>
-      <p className="mt-3 max-w-3xl text-sm leading-7 text-slate-600">
-        人事業務に必要な主要指標をロールごとに整理して表示します。API 実装済みの KPI
-        サマリーを、この画面からそのまま確認できるようにしました。
-      </p>
+    <header className="flex items-end justify-between gap-4">
+      <div>
+        <p className="text-xs font-semibold tracking-[0.3em] text-indigo-600 uppercase">
+          Dashboard
+        </p>
+        <h1 className="mt-1 text-3xl font-semibold tracking-tight text-slate-950">
+          ダッシュボード
+        </h1>
+        <p className="mt-2 text-sm leading-6 text-slate-600">
+          ロール別の主要指標をひとつの画面で確認できます。
+        </p>
+      </div>
+      {roleLabel && (
+        <span className="shrink-0 rounded-full border border-indigo-200 bg-indigo-50 px-3 py-1 text-xs font-semibold text-indigo-700">
+          {roleLabel}ビュー
+        </span>
+      )}
     </header>
   )
 }
 
-function QuickLinks(): ReactElement {
-  const links = [
-    {
-      href: '/organization',
-      title: '組織管理',
-      description: '組織図の確認と編集フローへ移動',
-    },
-    {
-      href: '/organization/my-team',
-      title: 'マイチーム',
-      description: '直属メンバーの一覧を確認',
-    },
-    {
-      href: '/skill-map',
-      title: 'スキルマップ',
-      description: 'スキル充足率やレーダーチャートを表示',
-    },
-  ] as const
+// ─────────────────────────────────────────────────────────────────────────────
+// Metrics Section
+// ─────────────────────────────────────────────────────────────────────────────
 
-  return (
-    <section className="grid gap-4 md:grid-cols-3">
-      {links.map((link) => (
-        <Link
-          key={link.href}
-          href={link.href}
-          className="group rounded-2xl border border-slate-200 bg-white p-5 shadow-sm transition-colors hover:border-sky-300 hover:bg-sky-50"
-        >
-          <p className="text-lg font-semibold text-slate-900">{link.title}</p>
-          <p className="mt-2 text-sm leading-6 text-slate-600">{link.description}</p>
-          <p className="mt-4 text-xs font-semibold tracking-[0.25em] text-sky-700 uppercase">
-            Open
-          </p>
-        </Link>
-      ))}
-    </section>
-  )
-}
-
-function DashboardBody({ state }: { readonly state: DashboardState }): ReactElement {
+function MetricsSection({ state }: { readonly state: DashboardState }): ReactElement {
   if (state.kind === 'loading') {
     return (
-      <Panel>
-        <p className="animate-pulse text-sm text-slate-500">ダッシュボードを読み込んでいます…</p>
-      </Panel>
+      <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <SkeletonCard key={i} />
+        ))}
+      </div>
     )
   }
 
   if (state.kind === 'unauthorized') {
-    return (
-      <Panel tone="warning">
-        <h2 className="text-lg font-semibold text-amber-950">ログインが必要です</h2>
-        <p className="mt-2 text-sm leading-6 text-amber-900">{state.message}</p>
-      </Panel>
-    )
+    return <AlertBanner tone="warning" title="ログインが必要です" message={state.message} />
   }
 
   if (state.kind === 'error') {
-    return (
-      <Panel tone="error">
-        <h2 className="text-lg font-semibold text-rose-950">ダッシュボードを表示できません</h2>
-        <p className="mt-2 text-sm leading-6 text-rose-900">{state.message}</p>
-      </Panel>
-    )
+    return <AlertBanner tone="error" title="KPI を取得できませんでした" message={state.message} />
   }
 
-  return <KpiSummaryPanel summary={state.summary} />
-}
-
-function Panel(
-  props: Readonly<{
-    children: ReactElement | string | readonly (ReactElement | string)[]
-    tone?: 'neutral' | 'warning' | 'error'
-  }>,
-): ReactElement {
-  const className =
-    props.tone === 'warning'
-      ? 'border-amber-300 bg-amber-50'
-      : props.tone === 'error'
-        ? 'border-rose-300 bg-rose-50'
-        : 'border-slate-200 bg-white'
+  const { summary } = state
 
   return (
-    <section className={`rounded-3xl border p-6 shadow-sm ${className}`}>{props.children}</section>
+    <section className="flex flex-col gap-4">
+      <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        {summary.metrics.map((metric) => (
+          <MetricCard key={metric.key} metric={metric} />
+        ))}
+      </div>
+      {summary.emptyStateMessage && (
+        <div className="rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
+          <p className="font-semibold">データ準備中</p>
+          <p className="mt-0.5">{summary.emptyStateMessage}</p>
+        </div>
+      )}
+    </section>
   )
+}
+
+function MetricCard({ metric }: { readonly metric: KpiMetric }): ReactElement {
+  return (
+    <article className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+      <p className="text-xs font-medium text-slate-500">{metric.label}</p>
+      <p className="mt-2 text-4xl font-semibold tracking-tight text-slate-950">
+        {formatMetricValue(metric)}
+      </p>
+      <p className="mt-1 text-xs font-medium tracking-widest text-slate-400 uppercase">
+        {unitLabel(metric.unit)}
+      </p>
+    </article>
+  )
+}
+
+function SkeletonCard(): ReactElement {
+  return (
+    <div className="animate-pulse rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+      <div className="h-3 w-24 rounded bg-slate-200" />
+      <div className="mt-4 h-9 w-20 rounded bg-slate-200" />
+      <div className="mt-2 h-2 w-12 rounded bg-slate-100" />
+    </div>
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Quick Actions Section
+// ─────────────────────────────────────────────────────────────────────────────
+
+function QuickActionsSection(): ReactElement {
+  return (
+    <section>
+      <h2 className="mb-3 text-sm font-semibold text-slate-700">クイックアクション</h2>
+      <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+        {QUICK_ACTIONS.map((action) => (
+          <Link
+            key={action.href}
+            href={action.href}
+            className={`group rounded-xl border p-4 transition-colors ${action.colorClass}`}
+          >
+            <p className="text-sm font-semibold">{action.label}</p>
+            <p className="mt-1 text-xs leading-5 opacity-80">{action.description}</p>
+            <p className="mt-3 text-xs font-semibold tracking-widest uppercase opacity-60 group-hover:opacity-100">
+              開く →
+            </p>
+          </Link>
+        ))}
+      </div>
+    </section>
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Shared helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+function AlertBanner({
+  tone,
+  title,
+  message,
+}: {
+  readonly tone: 'warning' | 'error'
+  readonly title: string
+  readonly message: string
+}): ReactElement {
+  const styles =
+    tone === 'warning'
+      ? 'border-amber-300 bg-amber-50 text-amber-900'
+      : 'border-rose-300 bg-rose-50 text-rose-900'
+  return (
+    <div className={`rounded-xl border p-5 text-sm ${styles}`}>
+      <p className="font-semibold">{title}</p>
+      <p className="mt-1 leading-6 opacity-80">{message}</p>
+    </div>
+  )
+}
+
+function formatMetricValue(metric: KpiMetric): string {
+  if (metric.unit === 'count') {
+    return new Intl.NumberFormat('ja-JP').format(metric.value)
+  }
+  if (metric.unit === 'percent') {
+    return `${metric.value.toFixed(1)}%`
+  }
+  return metric.value.toFixed(1)
+}
+
+function unitLabel(unit: KpiMetric['unit']): string {
+  if (unit === 'count') return 'Count'
+  if (unit === 'percent') return 'Percent'
+  return 'Score'
 }

--- a/src/app/evaluation/assignments/page.tsx
+++ b/src/app/evaluation/assignments/page.tsx
@@ -201,7 +201,7 @@ export default function AssignmentsPage(): ReactElement {
   }
 
   return (
-    <main className="mx-auto max-w-4xl px-6 py-10">
+    <main className="mx-auto max-w-6xl px-8 py-10">
       <header className="mb-8 flex items-start justify-between gap-4">
         <div>
           <p className="text-xs font-semibold tracking-widest text-indigo-600 uppercase">

--- a/src/app/evaluation/cycles/page.tsx
+++ b/src/app/evaluation/cycles/page.tsx
@@ -193,7 +193,7 @@ export default function EvaluationCyclesPage(): ReactElement {
   }
 
   return (
-    <main className="mx-auto max-w-4xl px-6 py-10">
+    <main className="mx-auto max-w-6xl px-8 py-10">
       <header className="mb-8 flex items-start justify-between gap-4">
         <div>
           <p className="text-xs font-semibold tracking-widest text-indigo-600 uppercase">

--- a/src/app/evaluation/cycles/page.tsx
+++ b/src/app/evaluation/cycles/page.tsx
@@ -192,29 +192,59 @@ export default function EvaluationCyclesPage(): ReactElement {
       setForm((v) => ({ ...v, [key]: e.target.value }))
   }
 
+  const cycles = state.kind === 'ready' ? state.cycles : []
+  const activeCount = cycles.filter((c) => c.status === 'ACTIVE').length
+  const finalizedCount = cycles.filter(
+    (c) => c.status === 'FINALIZED' || c.status === 'CLOSED',
+  ).length
+  const totalCount = cycles.length
+
   return (
     <main className="mx-auto max-w-6xl px-8 py-10">
       <header className="mb-8 flex items-start justify-between gap-4">
         <div>
-          <p className="text-xs font-semibold tracking-widest text-indigo-600 uppercase">
+          <p className="text-xs font-semibold tracking-[0.3em] text-indigo-600 uppercase">
             360度評価
           </p>
-          <h1 className="mt-1 text-3xl font-bold text-slate-900">評価サイクル管理</h1>
-          <p className="mt-2 text-sm text-slate-600">
+          <h1 className="mt-1 text-3xl font-semibold tracking-tight text-slate-950">
+            評価サイクル管理
+          </h1>
+          <p className="mt-2 text-sm leading-6 text-slate-600">
             評価サイクルの作成・状態管理を行います。HR_MANAGER/ADMIN のみ作成・状態変更可能です。
           </p>
         </div>
         <button
           type="button"
           onClick={() => setShowForm((v) => !v)}
-          className="shrink-0 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700"
+          className="shrink-0 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-700"
         >
           {showForm ? 'キャンセル' : '＋ サイクルを作成'}
         </button>
       </header>
 
+      {/* KPI Summary */}
+      <div className="mb-8 grid gap-4 sm:grid-cols-3">
+        <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+          <p className="text-xs font-semibold tracking-wider text-slate-500 uppercase">
+            総サイクル数
+          </p>
+          <p className="mt-2 text-3xl font-bold tabular-nums text-slate-900">{totalCount}</p>
+          <p className="mt-1 text-xs text-slate-500">登録済みサイクル</p>
+        </div>
+        <div className="rounded-2xl border border-indigo-100 bg-indigo-50 p-5 shadow-sm">
+          <p className="text-xs font-semibold tracking-wider text-indigo-500 uppercase">実施中</p>
+          <p className="mt-2 text-3xl font-bold tabular-nums text-indigo-700">{activeCount}</p>
+          <p className="mt-1 text-xs text-indigo-500">現在アクティブなサイクル</p>
+        </div>
+        <div className="rounded-2xl border border-emerald-100 bg-emerald-50 p-5 shadow-sm">
+          <p className="text-xs font-semibold tracking-wider text-emerald-600 uppercase">完了済み</p>
+          <p className="mt-2 text-3xl font-bold tabular-nums text-emerald-700">{finalizedCount}</p>
+          <p className="mt-1 text-xs text-emerald-600">完了・クローズ済みサイクル</p>
+        </div>
+      </div>
+
       {actionError && (
-        <div className="mb-4 rounded-lg border border-rose-300 bg-rose-50 p-3 text-sm text-rose-800">
+        <div className="mb-4 rounded-xl border border-rose-300 bg-rose-50 p-4 text-sm text-rose-800">
           {actionError}
         </div>
       )}

--- a/src/app/evaluation/feedback/page.tsx
+++ b/src/app/evaluation/feedback/page.tsx
@@ -117,7 +117,7 @@ export default function FeedbackViewPage(): ReactElement {
   }
 
   return (
-    <main className="mx-auto max-w-3xl px-6 py-10">
+    <main className="mx-auto max-w-6xl px-8 py-10">
       <header className="mb-8 flex items-start justify-between gap-4">
         <div>
           <p className="text-xs font-semibold tracking-widest text-indigo-600 uppercase">

--- a/src/app/evaluation/progress/page.tsx
+++ b/src/app/evaluation/progress/page.tsx
@@ -145,7 +145,7 @@ export default function EvaluationProgressPage(): ReactElement {
   }
 
   return (
-    <main className="mx-auto max-w-4xl px-6 py-10">
+    <main className="mx-auto max-w-6xl px-8 py-10">
       <header className="mb-8 flex items-start justify-between gap-4">
         <div>
           <p className="text-xs font-semibold tracking-widest text-indigo-600 uppercase">

--- a/src/app/globals.css.d.ts
+++ b/src/app/globals.css.d.ts
@@ -1,0 +1,2 @@
+// Type declaration for globals.css side-effect import (Issue #195)
+export {}

--- a/src/app/goals/personal/page.tsx
+++ b/src/app/goals/personal/page.tsx
@@ -184,7 +184,7 @@ export default function PersonalGoalPage(): ReactElement {
   }
 
   return (
-    <main className="mx-auto max-w-4xl px-6 py-10">
+    <main className="mx-auto max-w-6xl px-8 py-10">
       <header className="mb-8 flex items-start justify-between gap-4">
         <div>
           <p className="text-xs font-semibold tracking-widest text-indigo-600 uppercase">Goals</p>

--- a/src/app/goals/personal/page.tsx
+++ b/src/app/goals/personal/page.tsx
@@ -183,25 +183,53 @@ export default function PersonalGoalPage(): ReactElement {
     }
   }
 
+  const goals = state.kind === 'ready' ? state.goals : []
+  const inProgressCount = goals.filter((g) => g.status === 'IN_PROGRESS').length
+  const pendingCount = goals.filter((g) => g.status === 'PENDING_APPROVAL').length
+  const approvedCount = goals.filter(
+    (g) => g.status === 'APPROVED' || g.status === 'IN_PROGRESS' || g.status === 'COMPLETED',
+  ).length
+
   return (
     <main className="mx-auto max-w-6xl px-8 py-10">
       <header className="mb-8 flex items-start justify-between gap-4">
         <div>
-          <p className="text-xs font-semibold tracking-widest text-indigo-600 uppercase">Goals</p>
-          <h1 className="mt-1 text-3xl font-bold text-slate-900">個人目標</h1>
-          <p className="mt-2 text-sm text-slate-600">目標の登録・申請・承認を行います。</p>
+          <p className="text-xs font-semibold tracking-[0.3em] text-indigo-600 uppercase">Goals</p>
+          <h1 className="mt-1 text-3xl font-semibold tracking-tight text-slate-950">個人目標</h1>
+          <p className="mt-2 text-sm leading-6 text-slate-600">
+            目標の登録・申請・承認を行います。
+          </p>
         </div>
         <button
           type="button"
           onClick={() => setShowForm((v) => !v)}
-          className="shrink-0 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700"
+          className="shrink-0 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-700"
         >
           {showForm ? 'キャンセル' : '＋ 目標を追加'}
         </button>
       </header>
 
+      {/* KPI Summary */}
+      <div className="mb-8 grid gap-4 sm:grid-cols-3">
+        <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+          <p className="text-xs font-semibold tracking-wider text-slate-500 uppercase">目標数</p>
+          <p className="mt-2 text-3xl font-bold tabular-nums text-slate-900">{goals.length}</p>
+          <p className="mt-1 text-xs text-slate-500">登録済みの目標合計</p>
+        </div>
+        <div className="rounded-2xl border border-indigo-100 bg-indigo-50 p-5 shadow-sm">
+          <p className="text-xs font-semibold tracking-wider text-indigo-500 uppercase">進行中</p>
+          <p className="mt-2 text-3xl font-bold tabular-nums text-indigo-700">{inProgressCount}</p>
+          <p className="mt-1 text-xs text-indigo-500">承認済み {approvedCount}件</p>
+        </div>
+        <div className="rounded-2xl border border-amber-100 bg-amber-50 p-5 shadow-sm">
+          <p className="text-xs font-semibold tracking-wider text-amber-600 uppercase">承認待ち</p>
+          <p className="mt-2 text-3xl font-bold tabular-nums text-amber-700">{pendingCount}</p>
+          <p className="mt-1 text-xs text-amber-600">上長承認を待っている目標</p>
+        </div>
+      </div>
+
       {actionError && (
-        <div className="mb-4 rounded-lg border border-rose-300 bg-rose-50 p-3 text-sm text-rose-800">
+        <div className="mb-4 rounded-xl border border-rose-300 bg-rose-50 p-4 text-sm text-rose-800">
           {actionError}
         </div>
       )}

--- a/src/app/goals/progress/page.tsx
+++ b/src/app/goals/progress/page.tsx
@@ -149,7 +149,7 @@ export default function GoalProgressPage(): ReactElement {
   }, [])
 
   return (
-    <main className="mx-auto max-w-4xl px-6 py-10">
+    <main className="mx-auto max-w-6xl px-8 py-10">
       <header className="mb-8">
         <p className="text-xs font-semibold tracking-widest text-indigo-600 uppercase">Goals</p>
         <h1 className="mt-1 text-3xl font-bold text-slate-900">進捗管理</h1>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -16,7 +16,7 @@ export default function RootLayout({
     <html lang="ja">
       <body className="flex h-screen overflow-hidden bg-slate-50 text-slate-900 antialiased">
         <Sidebar />
-        <main className="flex-1 overflow-y-auto">{children}</main>
+        <div className="flex flex-1 flex-col overflow-y-auto">{children}</div>
       </body>
     </html>
   )

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 import './globals.css'
+import { Sidebar } from '@/components/layout/Sidebar'
 
 export const metadata: Metadata = {
   title: 'HR Management System',
@@ -13,7 +14,10 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ja">
-      <body>{children}</body>
+      <body className="flex h-screen overflow-hidden bg-slate-50 text-slate-900 antialiased">
+        <Sidebar />
+        <main className="flex-1 overflow-y-auto">{children}</main>
+      </body>
     </html>
   )
 }

--- a/src/app/one-on-one/reminder/page.tsx
+++ b/src/app/one-on-one/reminder/page.tsx
@@ -166,7 +166,7 @@ export default function ReminderPage(): ReactElement {
   }
 
   return (
-    <main className="mx-auto max-w-4xl px-6 py-10">
+    <main className="mx-auto max-w-6xl px-8 py-10">
       <header className="mb-8">
         <p className="text-xs font-semibold tracking-widest text-indigo-600 uppercase">1on1</p>
         <h1 className="mt-1 text-3xl font-bold text-slate-900">リマインダー / 評価連携</h1>

--- a/src/app/one-on-one/schedule/page.tsx
+++ b/src/app/one-on-one/schedule/page.tsx
@@ -136,7 +136,7 @@ export default function OneOnOneSchedulePage(): ReactElement {
   }
 
   return (
-    <main className="mx-auto max-w-3xl px-6 py-10">
+    <main className="mx-auto max-w-6xl px-8 py-10">
       <header className="mb-8 flex items-start justify-between gap-4">
         <div>
           <p className="text-xs font-semibold tracking-widest text-indigo-600 uppercase">1on1</p>

--- a/src/app/one-on-one/schedule/page.tsx
+++ b/src/app/one-on-one/schedule/page.tsx
@@ -135,25 +135,58 @@ export default function OneOnOneSchedulePage(): ReactElement {
       setForm((v) => ({ ...v, [key]: e.target.value }))
   }
 
+  const sessions = state.kind === 'ready' ? state.sessions : []
+  const now = new Date()
+  const upcomingCount = sessions.filter((s) => new Date(s.scheduledAt) >= now).length
+  const pastCount = sessions.filter((s) => new Date(s.scheduledAt) < now).length
+  const nextSession = sessions
+    .filter((s) => new Date(s.scheduledAt) >= now)
+    .sort((a, b) => new Date(a.scheduledAt).getTime() - new Date(b.scheduledAt).getTime())[0]
+
   return (
     <main className="mx-auto max-w-6xl px-8 py-10">
       <header className="mb-8 flex items-start justify-between gap-4">
         <div>
-          <p className="text-xs font-semibold tracking-widest text-indigo-600 uppercase">1on1</p>
-          <h1 className="mt-1 text-3xl font-bold text-slate-900">1on1 予定</h1>
-          <p className="mt-2 text-sm text-slate-600">1on1 セッションの予定を登録・確認します。</p>
+          <p className="text-xs font-semibold tracking-[0.3em] text-indigo-600 uppercase">1on1</p>
+          <h1 className="mt-1 text-3xl font-semibold tracking-tight text-slate-950">1on1 予定</h1>
+          <p className="mt-2 text-sm leading-6 text-slate-600">
+            1on1 セッションの予定を登録・確認します。
+          </p>
         </div>
         <button
           type="button"
           onClick={() => setShowForm((v) => !v)}
-          className="shrink-0 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700"
+          className="shrink-0 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-700"
         >
           {showForm ? 'キャンセル' : '＋ 予定を追加'}
         </button>
       </header>
 
+      {/* KPI Summary */}
+      <div className="mb-8 grid gap-4 sm:grid-cols-3">
+        <div className="rounded-2xl border border-indigo-100 bg-indigo-50 p-5 shadow-sm">
+          <p className="text-xs font-semibold tracking-wider text-indigo-500 uppercase">予定</p>
+          <p className="mt-2 text-3xl font-bold tabular-nums text-indigo-700">{upcomingCount}</p>
+          <p className="mt-1 text-xs text-indigo-500">今後のセッション件数</p>
+        </div>
+        <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+          <p className="text-xs font-semibold tracking-wider text-slate-500 uppercase">実施済み</p>
+          <p className="mt-2 text-3xl font-bold tabular-nums text-slate-900">{pastCount}</p>
+          <p className="mt-1 text-xs text-slate-500">過去のセッション件数</p>
+        </div>
+        <div className="rounded-2xl border border-emerald-100 bg-emerald-50 p-5 shadow-sm">
+          <p className="text-xs font-semibold tracking-wider text-emerald-600 uppercase">次回予定</p>
+          <p className="mt-2 text-xl font-bold tabular-nums text-emerald-700">
+            {nextSession ? nextSession.scheduledAt.slice(0, 10) : '—'}
+          </p>
+          <p className="mt-1 text-xs text-emerald-600">
+            {nextSession ? `${nextSession.durationMin}分` : '予定なし'}
+          </p>
+        </div>
+      </div>
+
       {actionError && (
-        <div className="mb-4 rounded-lg border border-rose-300 bg-rose-50 p-3 text-sm text-rose-800">
+        <div className="mb-4 rounded-xl border border-rose-300 bg-rose-50 p-4 text-sm text-rose-800">
           {actionError}
         </div>
       )}

--- a/src/app/one-on-one/timeline/page.tsx
+++ b/src/app/one-on-one/timeline/page.tsx
@@ -126,7 +126,7 @@ export default function TimelinePage(): ReactElement {
   }
 
   return (
-    <main className="mx-auto max-w-3xl px-6 py-10">
+    <main className="mx-auto max-w-6xl px-8 py-10">
       <header className="mb-8">
         <p className="text-xs font-semibold tracking-widest text-indigo-600 uppercase">1on1</p>
         <h1 className="mt-1 text-3xl font-bold text-slate-900">タイムライン</h1>

--- a/src/app/skill-map/page.tsx
+++ b/src/app/skill-map/page.tsx
@@ -1,11 +1,10 @@
 /**
- * Issue #37 / Req 4.1, 4.2, 4.3: スキルマップ画面 (HR_MANAGER 向け)
+ * Issue #195 / スキルマップ リデザイン
+ * Req 4.1, 4.2, 4.3: スキルマップ画面 (HR_MANAGER 向け)
  *
- * - マウント時に /api/skill-analytics/summary と /heatmap を並列取得
- * - 組織サマリカード / ヒートマップを表示
- * - 社員 ID 入力 → /api/skill-analytics/radar?userId= を取得してレーダーを表示
- *
- * 権限判定はサーバ側で行う前提。UI 側は取得失敗時にエラー状態として描画する。
+ * - GET /api/skill-analytics/summary → SkillSummary
+ * - GET /api/skill-analytics/heatmap → SkillHeatmap
+ * - GET /api/skill-analytics/radar?userId= → RadarData
  */
 'use client'
 
@@ -19,6 +18,10 @@ import type {
   SkillSummary,
 } from '@/lib/skill/skill-analytics-types'
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────────────
+
 interface ApiEnvelope<T> {
   readonly success: boolean
   readonly data: T
@@ -27,11 +30,7 @@ interface ApiEnvelope<T> {
 type OverviewState =
   | { readonly kind: 'loading' }
   | { readonly kind: 'error'; readonly message: string }
-  | {
-      readonly kind: 'ready'
-      readonly summary: SkillSummary
-      readonly heatmap: SkillHeatmapData
-    }
+  | { readonly kind: 'ready'; readonly summary: SkillSummary; readonly heatmap: SkillHeatmapData }
 
 type RadarState =
   | { readonly kind: 'idle' }
@@ -39,9 +38,17 @@ type RadarState =
   | { readonly kind: 'error'; readonly userId: string; readonly message: string }
   | { readonly kind: 'ready'; readonly data: RadarData }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Constants
+// ─────────────────────────────────────────────────────────────────────────────
+
 const SUMMARY_URL = '/api/skill-analytics/summary'
 const HEATMAP_URL = '/api/skill-analytics/heatmap'
 const RADAR_URL = '/api/skill-analytics/radar'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
 
 async function fetchJson<T>(url: string): Promise<T> {
   const res = await fetch(url, { cache: 'no-store' })
@@ -49,6 +56,14 @@ async function fetchJson<T>(url: string): Promise<T> {
   const envelope = (await res.json()) as ApiEnvelope<T>
   return envelope.data
 }
+
+function readError(err: unknown): string {
+  return err instanceof Error ? err.message : '不明なエラーが発生しました'
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Page
+// ─────────────────────────────────────────────────────────────────────────────
 
 export default function SkillMapPage(): ReactElement {
   const [overview, setOverview] = useState<OverviewState>({ kind: 'loading' })
@@ -67,10 +82,7 @@ export default function SkillMapPage(): ReactElement {
         setOverview({ kind: 'ready', summary, heatmap })
       } catch (err) {
         if (cancelled) return
-        setOverview({
-          kind: 'error',
-          message: err instanceof Error ? err.message : 'unknown error',
-        })
+        setOverview({ kind: 'error', message: readError(err) })
       }
     })()
     return () => {
@@ -90,19 +102,29 @@ export default function SkillMapPage(): ReactElement {
         )
         setRadar({ kind: 'ready', data })
       } catch (err) {
-        setRadar({
-          kind: 'error',
-          userId: trimmed,
-          message: err instanceof Error ? err.message : 'unknown error',
-        })
+        setRadar({ kind: 'error', userId: trimmed, message: readError(err) })
       }
     },
     [userIdInput],
   )
 
   return (
-    <main className="mx-auto flex min-h-screen max-w-6xl flex-col gap-8 px-6 py-10">
-      <PageHeader />
+    <div className="mx-auto flex max-w-6xl flex-col gap-8 px-8 py-10">
+      <header className="flex items-end justify-between gap-4">
+        <div>
+          <p className="text-xs font-semibold tracking-[0.3em] text-emerald-600 uppercase">
+            Skill Analytics
+          </p>
+          <h1 className="mt-1 text-3xl font-semibold tracking-tight text-slate-950">
+            スキルマップ
+          </h1>
+          <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-600">
+            組織全体のスキル充足率、部署 ×
+            カテゴリのヒートマップ、社員個人のレーダーチャートを確認できます。
+          </p>
+        </div>
+      </header>
+
       <OverviewSection state={overview} />
       <RadarSection
         state={radar}
@@ -110,54 +132,57 @@ export default function SkillMapPage(): ReactElement {
         onUserIdChange={setUserIdInput}
         onSubmit={handleRadarSubmit}
       />
-    </main>
+    </div>
   )
 }
 
-function PageHeader(): ReactElement {
-  return (
-    <header className="flex flex-col gap-1">
-      <p className="text-xs font-semibold uppercase tracking-[0.2em] text-emerald-700">
-        Skill analytics
-      </p>
-      <h1 className="text-3xl font-semibold tracking-tight text-slate-900">スキルマップ</h1>
-      <p className="max-w-2xl text-sm text-slate-500">
-        組織全体のスキル充足率、部署 × カテゴリのヒートマップ、社員個人のレーダーチャートを 1 画面で確認できます。
-      </p>
-    </header>
-  )
-}
+// ─────────────────────────────────────────────────────────────────────────────
+// Overview Section
+// ─────────────────────────────────────────────────────────────────────────────
 
 function OverviewSection({ state }: { readonly state: OverviewState }): ReactElement {
   if (state.kind === 'loading') {
-    return <SkeletonCard label="組織サマリを読み込み中…" />
+    return (
+      <div className="flex flex-col gap-4">
+        <SkeletonPanel label="組織サマリを読み込み中…" height="h-32" />
+        <SkeletonPanel label="ヒートマップを読み込み中…" height="h-48" />
+      </div>
+    )
   }
+
   if (state.kind === 'error') {
     return (
       <div
         role="alert"
-        className="rounded-xl border border-red-200 bg-red-50 p-6 text-sm text-red-700"
+        className="rounded-xl border border-rose-200 bg-rose-50 p-5 text-sm text-rose-700"
       >
-        <p className="font-semibold">組織サマリを取得できませんでした。</p>
-        <p className="mt-1 text-xs text-red-600">{state.message}</p>
+        <p className="font-semibold">組織サマリを取得できませんでした</p>
+        <p className="mt-1 text-xs">{state.message}</p>
       </div>
     )
   }
+
   return (
     <div className="flex flex-col gap-6">
       <SummaryCard summary={state.summary} />
       <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
-        <header className="mb-4 flex items-baseline justify-between">
-          <h2 className="text-lg font-semibold text-slate-900">部署 × カテゴリ ヒートマップ</h2>
-          <p className="text-xs text-slate-500">
-            セルの濃さは平均スキルレベル (0〜5) を表します
-          </p>
+        <header className="mb-5 flex items-baseline justify-between">
+          <div>
+            <h2 className="text-base font-semibold text-slate-900">部署 × カテゴリ ヒートマップ</h2>
+            <p className="mt-0.5 text-xs text-slate-500">
+              セルの濃さは平均スキルレベル（0〜5）を表します
+            </p>
+          </div>
         </header>
         <SkillHeatmap data={state.heatmap} />
       </section>
     </div>
   )
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Radar Section
+// ─────────────────────────────────────────────────────────────────────────────
 
 interface RadarSectionProps {
   readonly state: RadarState
@@ -170,28 +195,31 @@ function RadarSection(props: RadarSectionProps): ReactElement {
   const { state, userId, onUserIdChange, onSubmit } = props
   return (
     <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
-      <header className="mb-4 flex flex-col gap-1">
-        <h2 className="text-lg font-semibold text-slate-900">社員レーダー</h2>
-        <p className="text-xs text-slate-500">
+      <header className="mb-5">
+        <h2 className="text-base font-semibold text-slate-900">社員レーダー</h2>
+        <p className="mt-0.5 text-xs text-slate-500">
           社員 ID を入力するとレーダーチャートでスキル分布を確認できます。
         </p>
       </header>
 
-      <form onSubmit={onSubmit} className="flex flex-wrap items-center gap-3">
-        <label className="flex flex-1 flex-col gap-1 text-xs font-medium text-slate-600">
-          <span>社員 ID</span>
+      <form onSubmit={onSubmit} className="flex flex-wrap items-end gap-3">
+        <div className="flex flex-1 flex-col gap-1.5">
+          <label htmlFor="radar-userId" className="text-xs font-medium text-slate-600">
+            社員 ID
+          </label>
           <input
+            id="radar-userId"
             type="text"
             value={userId}
             onChange={(e) => onUserIdChange(e.target.value)}
             placeholder="cm_user_xxxxxxxxx"
-            className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-100"
+            className="w-full rounded-lg border border-slate-300 px-3 py-2 font-mono text-sm text-slate-900 focus:border-emerald-500 focus:ring-1 focus:ring-emerald-500 focus:outline-none"
           />
-        </label>
+        </div>
         <button
           type="submit"
           disabled={state.kind === 'loading' || userId.trim().length === 0}
-          className="mt-5 rounded-lg bg-emerald-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-emerald-700 focus:outline-none focus:ring-2 focus:ring-emerald-200 disabled:cursor-not-allowed disabled:bg-slate-300"
+          className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-emerald-700 focus:ring-2 focus:ring-emerald-200 focus:outline-none disabled:cursor-not-allowed disabled:bg-slate-300"
         >
           {state.kind === 'loading' ? '読み込み中…' : '表示'}
         </button>
@@ -213,16 +241,16 @@ function RadarBody({ state }: { readonly state: RadarState }): ReactElement {
     )
   }
   if (state.kind === 'loading') {
-    return <SkeletonCard label={`${state.userId} のスキルを読み込み中…`} />
+    return <SkeletonPanel label={`${state.userId} のスキルを読み込み中…`} height="h-40" />
   }
   if (state.kind === 'error') {
     return (
       <div
         role="alert"
-        className="rounded-xl border border-red-200 bg-red-50 p-6 text-sm text-red-700"
+        className="rounded-xl border border-rose-200 bg-rose-50 p-5 text-sm text-rose-700"
       >
-        <p className="font-semibold">レーダーを取得できませんでした。</p>
-        <p className="mt-1 text-xs text-red-600">
+        <p className="font-semibold">レーダーを取得できませんでした</p>
+        <p className="mt-1 text-xs">
           {state.userId}: {state.message}
         </p>
       </div>
@@ -231,11 +259,21 @@ function RadarBody({ state }: { readonly state: RadarState }): ReactElement {
   return <SkillRadar data={state.data} />
 }
 
-function SkeletonCard({ label }: { readonly label: string }): ReactElement {
+// ─────────────────────────────────────────────────────────────────────────────
+// Shared
+// ─────────────────────────────────────────────────────────────────────────────
+
+function SkeletonPanel({
+  label,
+  height,
+}: {
+  readonly label: string
+  readonly height: string
+}): ReactElement {
   return (
     <div
       aria-busy="true"
-      className="flex h-40 animate-pulse items-center justify-center rounded-xl border border-slate-200 bg-slate-50 text-sm text-slate-400"
+      className={`flex ${height} animate-pulse items-center justify-center rounded-2xl border border-slate-200 bg-slate-50 text-sm text-slate-400`}
     >
       {label}
     </div>

--- a/src/app/skills/approval/page.tsx
+++ b/src/app/skills/approval/page.tsx
@@ -104,7 +104,7 @@ export default function SkillApprovalPage(): ReactElement {
   }, [])
 
   return (
-    <main className="mx-auto max-w-4xl px-6 py-10">
+    <main className="mx-auto max-w-6xl px-8 py-10">
       <header className="mb-8">
         <p className="text-xs font-semibold tracking-widest text-indigo-600 uppercase">Skills</p>
         <h1 className="mt-1 text-3xl font-bold text-slate-900">スキル承認</h1>

--- a/src/app/skills/register/page.tsx
+++ b/src/app/skills/register/page.tsx
@@ -124,7 +124,7 @@ export default function SkillRegisterPage(): ReactElement {
   )
 
   return (
-    <main className="mx-auto max-w-3xl px-6 py-10">
+    <main className="mx-auto max-w-6xl px-8 py-10">
       <header className="mb-8">
         <p className="text-xs font-semibold tracking-widest text-indigo-600 uppercase">Skills</p>
         <h1 className="mt-1 text-3xl font-bold text-slate-900">スキル登録</h1>

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,0 +1,152 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import type { ReactElement } from 'react'
+
+interface NavItem {
+  readonly href: string
+  readonly label: string
+  readonly icon: string
+}
+
+interface NavSection {
+  readonly label: string
+  readonly items: readonly NavItem[]
+}
+
+const NAV_SECTIONS: readonly NavSection[] = [
+  {
+    label: 'ホーム',
+    items: [{ href: '/dashboard', label: 'ダッシュボード', icon: '📊' }],
+  },
+  {
+    label: '人事管理',
+    items: [
+      { href: '/employees', label: '社員一覧', icon: '👥' },
+      { href: '/employees/search', label: '社員検索', icon: '🔍' },
+      { href: '/organization', label: '組織管理', icon: '🏢' },
+      { href: '/profile', label: 'プロフィール', icon: '👤' },
+    ],
+  },
+  {
+    label: 'スキル・キャリア',
+    items: [
+      { href: '/skill-map', label: 'スキルマップ', icon: '📈' },
+      { href: '/skills/register', label: 'スキル登録', icon: '✏️' },
+      { href: '/skills/approval', label: 'スキル承認', icon: '✅' },
+      { href: '/skills/candidates', label: '採用候補', icon: '🎯' },
+      { href: '/career/wish', label: 'キャリア希望', icon: '💫' },
+      { href: '/career/map', label: 'キャリアマップ', icon: '🗺️' },
+    ],
+  },
+  {
+    label: '目標管理',
+    items: [
+      { href: '/goals/personal', label: '個人目標', icon: '🎯' },
+      { href: '/goals/tree', label: '目標ツリー', icon: '🌳' },
+      { href: '/goals/progress', label: '進捗管理', icon: '📊' },
+    ],
+  },
+  {
+    label: '1on1',
+    items: [
+      { href: '/one-on-one/schedule', label: 'スケジュール', icon: '📅' },
+      { href: '/one-on-one/timeline', label: 'タイムライン', icon: '📋' },
+      { href: '/one-on-one/reminder', label: 'リマインダー', icon: '🔔' },
+    ],
+  },
+  {
+    label: '評価',
+    items: [
+      { href: '/evaluation/cycles', label: '評価サイクル', icon: '🔄' },
+      { href: '/evaluation/assignments', label: '評価割り当て', icon: '📝' },
+      { href: '/evaluation/form', label: '評価フォーム', icon: '📋' },
+      { href: '/evaluation/progress', label: '進捗確認', icon: '📊' },
+      { href: '/evaluation/feedback', label: 'フィードバック', icon: '💬' },
+      { href: '/evaluation/total/preview', label: '総合評価', icon: '🏆' },
+      { href: '/evaluation/appeals', label: '異議申立て', icon: '⚖️' },
+    ],
+  },
+  {
+    label: '管理',
+    items: [
+      { href: '/admin/ai-monitoring', label: 'AIモニタリング', icon: '🤖' },
+      { href: '/admin/users/invitations', label: 'ユーザー招待', icon: '📧' },
+      { href: '/admin/audit-log', label: '監査ログ', icon: '📜' },
+      { href: '/admin/masters', label: 'マスタ管理', icon: '⚙️' },
+    ],
+  },
+]
+
+export function Sidebar(): ReactElement {
+  const pathname = usePathname()
+
+  return (
+    <aside className="flex h-screen w-64 shrink-0 flex-col overflow-y-auto border-r border-slate-800 bg-slate-900 text-slate-100">
+      <div className="px-5 py-6">
+        <Link href="/dashboard" className="flex items-center gap-2">
+          <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-indigo-600 text-sm font-bold text-white">
+            HR
+          </span>
+          <span className="text-base font-semibold tracking-tight text-white">HR Management</span>
+        </Link>
+      </div>
+      <nav className="flex-1 px-3 pb-6">
+        {NAV_SECTIONS.map((section) => (
+          <SidebarSection key={section.label} section={section} pathname={pathname} />
+        ))}
+      </nav>
+    </aside>
+  )
+}
+
+function SidebarSection({
+  section,
+  pathname,
+}: {
+  readonly section: NavSection
+  readonly pathname: string | null
+}): ReactElement {
+  return (
+    <div className="mb-5">
+      <p className="px-3 pt-2 pb-2 text-xs font-semibold tracking-wider text-slate-400 uppercase">
+        {section.label}
+      </p>
+      <ul className="space-y-0.5">
+        {section.items.map((item) => (
+          <li key={item.href}>
+            <SidebarLink item={item} isActive={isActive(pathname, item.href)} />
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+function SidebarLink({
+  item,
+  isActive,
+}: {
+  readonly item: NavItem
+  readonly isActive: boolean
+}): ReactElement {
+  const base = 'flex items-center gap-3 rounded-md px-3 py-2 text-sm transition-colors duration-150'
+  const active = 'bg-indigo-600 text-white shadow-sm'
+  const inactive = 'text-slate-300 hover:bg-slate-800 hover:text-white'
+
+  return (
+    <Link href={item.href} className={`${base} ${isActive ? active : inactive}`}>
+      <span className="text-base leading-none" aria-hidden>
+        {item.icon}
+      </span>
+      <span className="truncate">{item.label}</span>
+    </Link>
+  )
+}
+
+function isActive(pathname: string | null, href: string): boolean {
+  if (!pathname) return false
+  if (pathname === href) return true
+  return pathname.startsWith(`${href}/`)
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
+    "allowArbitraryExtensions": true,
     "jsx": "preserve",
     "incremental": true,
     "plugins": [


### PR DESCRIPTION
## Summary

- ルートレイアウト (`src/app/layout.tsx`) に共通サイドバーを追加し、すべての画面に統一ナビゲーションを適用
- `src/components/layout/Sidebar.tsx` を新規作成 (slate-900 背景 / indigo-600 アクティブ状態 / `usePathname` によるアクティブルート判定)
- 管理機能のプレースホルダ画面を追加
  - `/admin/audit-log` — 監査ログ (期間・アクション種別フィルタ + テーブル構造)
  - `/admin/masters` — マスタ管理 (スキル・職種・グレード・部署の 4 カードレイアウト)
- TypeScript strict (`readonly` props, `any` ゼロ), Server Component 基本 / サイドバーのみ `'use client'`

## Changes

| File | Purpose |
|------|---------|
| `src/app/layout.tsx` | ルートに `<Sidebar />` + `<main>` フレックスレイアウト追加 |
| `src/components/layout/Sidebar.tsx` | 7セクションのナビゲーションコンポーネント (新規) |
| `src/app/admin/audit-log/page.tsx` | 監査ログ画面 (API 未実装プレースホルダ) |
| `src/app/admin/masters/page.tsx` | マスタ管理画面 (API 未実装プレースホルダ) |

## Test plan

- [ ] `pnpm tsc --noEmit` が通る (ローカル確認済み, exit 0)
- [ ] `/dashboard` を開いたときにサイドバーが左側に表示される
- [ ] サイドバーの各リンクをクリックすると該当ページへ遷移する
- [ ] 現在のルートに対応するサイドバー項目が indigo-600 でハイライトされる
- [ ] `/admin/audit-log` と `/admin/masters` が 404 にならず表示される
- [ ] サイドバーのホバー時に背景色が slate-800 にトランジションする
- [ ] 長いナビゲーションでも縦スクロールで全項目にアクセスできる

Refs: #195