### PR TITLE
[codex] Implement appeals review page

### DIFF
--- a/src/app/api/evaluation/appeals/[id]/correct/route.ts
+++ b/src/app/api/evaluation/appeals/[id]/correct/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse, type NextRequest } from 'next/server'
+import { applyAppealAction } from '@/lib/evaluation/appeal-review-data'
+
+interface RouteContext {
+  readonly params: Promise<{
+    readonly id: string
+  }>
+}
+
+export async function POST(_request: NextRequest, context: RouteContext): Promise<NextResponse> {
+  const { id } = await context.params
+  const appeal = applyAppealAction(id, 'correct')
+  if (!appeal) {
+    return NextResponse.json({ error: 'Appeal not found' }, { status: 404 })
+  }
+  return NextResponse.json({ appeal })
+}

--- a/src/app/api/evaluation/appeals/[id]/reject/route.ts
+++ b/src/app/api/evaluation/appeals/[id]/reject/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse, type NextRequest } from 'next/server'
+import { applyAppealAction } from '@/lib/evaluation/appeal-review-data'
+
+interface RouteContext {
+  readonly params: Promise<{
+    readonly id: string
+  }>
+}
+
+export async function POST(_request: NextRequest, context: RouteContext): Promise<NextResponse> {
+  const { id } = await context.params
+  const appeal = applyAppealAction(id, 'reject')
+  if (!appeal) {
+    return NextResponse.json({ error: 'Appeal not found' }, { status: 404 })
+  }
+  return NextResponse.json({ appeal })
+}

--- a/src/app/api/evaluation/appeals/[id]/request-info/route.ts
+++ b/src/app/api/evaluation/appeals/[id]/request-info/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse, type NextRequest } from 'next/server'
+import { applyAppealAction } from '@/lib/evaluation/appeal-review-data'
+
+interface RouteContext {
+  readonly params: Promise<{
+    readonly id: string
+  }>
+}
+
+export async function POST(_request: NextRequest, context: RouteContext): Promise<NextResponse> {
+  const { id } = await context.params
+  const appeal = applyAppealAction(id, 'request-info')
+  if (!appeal) {
+    return NextResponse.json({ error: 'Appeal not found' }, { status: 404 })
+  }
+  return NextResponse.json({ appeal })
+}

--- a/src/app/api/evaluation/appeals/kpi/route.ts
+++ b/src/app/api/evaluation/appeals/kpi/route.ts
@@ -1,0 +1,6 @@
+import { NextResponse } from 'next/server'
+import { getAppealsKpi } from '@/lib/evaluation/appeal-review-data'
+
+export async function GET(): Promise<NextResponse> {
+  return NextResponse.json({ kpi: getAppealsKpi() })
+}

--- a/src/app/api/evaluation/appeals/route.ts
+++ b/src/app/api/evaluation/appeals/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse, type NextRequest } from 'next/server'
+import { listAppealsForReview } from '@/lib/evaluation/appeal-review-data'
+import type { AppealStatus } from '@/lib/evaluation/appeal-types'
+
+function parseStatus(value: string | null): AppealStatus {
+  if (
+    value === 'COMPLETED_CORRECTION' ||
+    value === 'COMPLETED_REJECTED' ||
+    value === 'PENDING_INFO'
+  ) {
+    return value
+  }
+  return 'UNDER_REVIEW'
+}
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const status = parseStatus(request.nextUrl.searchParams.get('status'))
+  return NextResponse.json({ appeals: listAppealsForReview(status) })
+}

--- a/src/app/evaluation/appeals/page.tsx
+++ b/src/app/evaluation/appeals/page.tsx
@@ -1,539 +1,269 @@
-/**
- * Issue #201: 異議申立て画面リデザイン
- *
- * - KPI カード 3 枚（審査中 / 今月完了 / 是正率）
- * - 優先度順の申告カードリスト（期限バッジ・アクションボタン）
- * - API 未実装時はモックデータにフォールバック
- *
- * GET  /api/evaluation/appeals
- * POST /api/evaluation/appeals/{id}/request-supplement
- * POST /api/evaluation/appeals/{id}/reject
- * POST /api/evaluation/appeals/{id}/proceed
- */
 'use client'
 
-import { useEffect, useState, useCallback, type ReactElement } from 'react'
+import { useCallback, useEffect, useState, type ReactElement } from 'react'
+import type { Appeal, AppealsKpi, AppealType } from '@/lib/evaluation/appeal-types'
 
-// ─────────────────────────────────────────────────────────────────────────────
-// Types
-// ─────────────────────────────────────────────────────────────────────────────
+type AppealsState =
+  | { kind: 'loading' }
+  | { kind: 'ready'; appeals: readonly Appeal[]; kpi: AppealsKpi }
+  | { kind: 'error'; message: string }
 
-interface ApiEnvelope<T> {
-  readonly success?: boolean
-  readonly data?: T
-  readonly error?: string
+type AppealAction = 'request-info' | 'reject' | 'correct'
+
+interface AppealsPayload {
+  readonly appeals?: readonly Appeal[]
 }
 
-interface UnderReviewStats {
-  readonly count: number
-  readonly avgDays: number
-  readonly nearDeadlineCount: number
+interface KpiPayload {
+  readonly kpi?: AppealsKpi
 }
 
-interface ThisMonthStats {
-  readonly count: number
-  readonly correctedCount: number
-  readonly rejectedCount: number
-  readonly avgDays: number
+const TYPE_LABELS: Record<AppealType, string> = {
+  EVALUATION_RESULT: '評価結果への異議',
+  FEEDBACK: 'フィードバックへの異議',
+  CALIBRATION: 'キャリブレーションへの異議',
 }
 
-interface CorrectionRateStats {
-  readonly percent: number
-  readonly lastPeriodPercent: number
-  readonly diffPt: number
+function readError(error: unknown): string {
+  return error instanceof Error ? error.message : '異議申立てデータの取得に失敗しました'
 }
 
-interface AppealSummary {
-  readonly pendingCount: number
-  readonly urgentCount: number
-  readonly underReview: UnderReviewStats
-  readonly thisMonth: ThisMonthStats
-  readonly correctionRate: CorrectionRateStats
+function deadlineClass(days: number): string {
+  if (days <= 2) return 'bg-red-100 text-red-700 ring-red-200'
+  if (days <= 5) return 'bg-orange-100 text-orange-700 ring-orange-200'
+  return 'bg-gray-100 text-gray-600 ring-gray-200'
 }
 
-interface Appeal {
-  readonly id: string
-  readonly appealNo: string
-  readonly deadlineDaysLeft: number
-  readonly appealType: string
-  readonly title: string
-  readonly content: string
-  readonly submitterName: string
-  readonly submitterEmployeeNo: string
-  readonly submittedAt: string // ISO 8601
+function deadlineLabel(days: number): string {
+  if (days <= 2) return `赤 ${days}日以内`
+  if (days <= 5) return `橙 ${days}日`
+  return `黒 ${days}日以上`
 }
 
-interface AppealsData {
-  readonly summary: AppealSummary
-  readonly appeals: readonly Appeal[]
+function initials(name: string): string {
+  const [lastName = '', firstName = ''] = name.split(' ')
+  return `${lastName.charAt(0)}${firstName.charAt(0) || ''}`
 }
 
-type PageState =
-  | { readonly kind: 'loading' }
-  | { readonly kind: 'error'; readonly message: string }
-  | { readonly kind: 'ready'; readonly data: AppealsData }
-
-type ActionKind = 'supplement' | 'reject' | 'proceed'
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Mock data (API 未実装時のフォールバック)
-// ─────────────────────────────────────────────────────────────────────────────
-
-const MOCK_DATA: AppealsData = {
-  summary: {
-    pendingCount: 8,
-    urgentCount: 3,
-    underReview: { count: 5, avgDays: 3.2, nearDeadlineCount: 3 },
-    thisMonth: { count: 12, correctedCount: 7, rejectedCount: 5, avgDays: 4.1 },
-    correctionRate: { percent: 58, lastPeriodPercent: 52, diffPt: 6 },
-  },
-  appeals: [
-    {
-      id: 'ap-001',
-      appealNo: 'AP-2025-0042',
-      deadlineDaysLeft: 1,
-      appealType: '総合評価点への申立て',
-      title: 'Q4評価における業績指標の算定誤りについて',
-      content:
-        '第4四半期の売上目標達成率の計算に誤りがあります。実績は目標の112%でしたが、評価シート上では98%と記載されています。修正をお願いします。',
-      submitterName: '田中 一郎',
-      submitterEmployeeNo: 'emp-00123',
-      submittedAt: '2026-04-20T10:30:00',
-    },
-    {
-      id: 'ap-002',
-      appealNo: 'AP-2025-0041',
-      deadlineDaysLeft: 3,
-      appealType: 'コンピテンシー評価への申立て',
-      title: 'リーダーシップ評価の根拠説明を求める申立て',
-      content:
-        'リーダーシップ項目でC評価を受けましたが、今期はプロジェクトリーダーを3件担当しており、評価根拠の詳細説明を求めます。',
-      submitterName: '鈴木 花子',
-      submitterEmployeeNo: 'emp-00256',
-      submittedAt: '2026-04-19T14:00:00',
-    },
-    {
-      id: 'ap-003',
-      appealNo: 'AP-2025-0039',
-      deadlineDaysLeft: 5,
-      appealType: '目標設定への申立て',
-      title: '中途設定された追加目標の評価基準不明確',
-      content:
-        '10月に追加設定された目標について、達成基準が曖昧なまま評価されました。具体的な数値目標がなかったにもかかわらず、未達成と判断されています。',
-      submitterName: '佐藤 次郎',
-      submitterEmployeeNo: 'emp-00387',
-      submittedAt: '2026-04-18T09:15:00',
-    },
-    {
-      id: 'ap-004',
-      appealNo: 'AP-2025-0038',
-      deadlineDaysLeft: 8,
-      appealType: '総合評価点への申立て',
-      title: '育児休業期間中の評価算定方法への異議',
-      content:
-        '育休取得期間を含む評価において、フル稼働期間と同一基準で評価されており、就業規則第32条に基づく按分計算が適用されていません。',
-      submitterName: '山田 美咲',
-      submitterEmployeeNo: 'emp-00512',
-      submittedAt: '2026-04-17T11:45:00',
-    },
-    {
-      id: 'ap-005',
-      appealNo: 'AP-2025-0036',
-      deadlineDaysLeft: 12,
-      appealType: 'コンピテンシー評価への申立て',
-      title: '顧客満足度スコアの集計対象期間の誤り',
-      content:
-        '顧客満足度の評価対象が1月〜9月のデータのみで算出されており、10〜12月の高評価期間が含まれていません。',
-      submitterName: '伊藤 健',
-      submitterEmployeeNo: 'emp-00634',
-      submittedAt: '2026-04-15T16:00:00',
-    },
-  ],
+function actionEndpoint(action: AppealAction): string {
+  if (action === 'request-info') return 'request-info'
+  if (action === 'reject') return 'reject'
+  return 'correct'
 }
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Helpers
-// ─────────────────────────────────────────────────────────────────────────────
-
-function readError(err: unknown): string {
-  if (err instanceof Error) return err.message
-  return '予期せぬエラーが発生しました'
-}
-
-async function fetchJson<T>(url: string): Promise<T | null> {
-  try {
-    const res = await fetch(url, { cache: 'no-store' })
-    const envelope = (await res.json().catch(() => ({}))) as ApiEnvelope<T>
-    if (!res.ok || !envelope.data) return null
-    return envelope.data
-  } catch {
-    return null
-  }
-}
-
-async function postAction(url: string): Promise<void> {
-  const res = await fetch(url, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-  })
-  if (!res.ok) {
-    const envelope = (await res.json().catch(() => ({}))) as ApiEnvelope<unknown>
-    throw new Error(envelope.error ?? `HTTP ${res.status}`)
-  }
-}
-
-function deadlineBadgeClass(days: number): string {
-  if (days <= 2) return 'bg-rose-100 text-rose-700 border-rose-200'
-  if (days <= 5) return 'bg-amber-100 text-amber-700 border-amber-200'
-  return 'bg-slate-100 text-slate-500 border-slate-200'
-}
-
-function getInitials(name: string): string {
-  const parts = name.trim().split(/\s+/)
-  if (parts.length >= 2) {
-    return `${parts[0]?.charAt(0) ?? ''}${parts[1]?.charAt(0) ?? ''}`
-  }
-  return name.charAt(0)
-}
-
-const AVATAR_COLORS = [
-  'bg-indigo-500',
-  'bg-emerald-500',
-  'bg-violet-500',
-  'bg-rose-500',
-  'bg-amber-500',
-  'bg-cyan-500',
-] as const
-
-function avatarColor(id: string): string {
-  return AVATAR_COLORS[id.charCodeAt(id.length - 1) % AVATAR_COLORS.length] ?? 'bg-slate-500'
-}
-
-function formatDate(iso: string): string {
-  return new Date(iso).toLocaleDateString('ja-JP', {
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-  })
-}
-
-function diffSign(diff: number): string {
-  if (diff > 0) return `+${diff}`
-  if (diff < 0) return `${diff}`
-  return '±0'
-}
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Page
-// ─────────────────────────────────────────────────────────────────────────────
 
 export default function AppealsPage(): ReactElement {
-  const [state, setState] = useState<PageState>({ kind: 'loading' })
-  const [actionErrors, setActionErrors] = useState<ReadonlyMap<string, string>>(new Map())
-  const [actionLoading, setActionLoading] = useState<ReadonlySet<string>>(new Set())
+  const [state, setState] = useState<AppealsState>({ kind: 'loading' })
+  const [busyAppealId, setBusyAppealId] = useState<string | null>(null)
 
-  const loadData = useCallback(async (): Promise<void> => {
-    const data = await fetchJson<AppealsData>('/api/evaluation/appeals')
-    setState({ kind: 'ready', data: data ?? MOCK_DATA })
-  }, [])
+  const loadData = useCallback(async () => {
+    setState({ kind: 'loading' })
+    try {
+      const [appealsResponse, kpiResponse] = await Promise.all([
+        fetch('/api/evaluation/appeals?status=UNDER_REVIEW', { cache: 'no-store' }),
+        fetch('/api/evaluation/appeals/kpi', { cache: 'no-store' }),
+      ])
+      const appealsPayload = (await appealsResponse.json().catch(() => ({}))) as AppealsPayload
+      const kpiPayload = (await kpiResponse.json().catch(() => ({}))) as KpiPayload
 
-  useEffect(() => {
-    let cancelled = false
-    void (async () => {
-      const data = await fetchJson<AppealsData>('/api/evaluation/appeals')
-      if (cancelled) return
-      setState({ kind: 'ready', data: data ?? MOCK_DATA })
-    })()
-    return () => {
-      cancelled = true
+      if (!appealsResponse.ok) throw new Error(`HTTP ${appealsResponse.status}`)
+      if (!kpiResponse.ok) throw new Error(`HTTP ${kpiResponse.status}`)
+      if (!kpiPayload.kpi) throw new Error('KPI payload is empty')
+
+      setState({
+        kind: 'ready',
+        appeals: appealsPayload.appeals ?? [],
+        kpi: kpiPayload.kpi,
+      })
+    } catch (error) {
+      setState({ kind: 'error', message: readError(error) })
     }
   }, [])
 
-  const handleAction = useCallback(
-    async (appealId: string, kind: ActionKind): Promise<void> => {
-      const key = `${appealId}-${kind}`
-      setActionLoading((prev) => new Set([...prev, key]))
-      setActionErrors((prev) => {
-        const next = new Map(prev)
-        next.delete(key)
-        return next
+  useEffect(() => {
+    void loadData()
+  }, [loadData])
+
+  const handleAction = useCallback(async (appealId: string, action: AppealAction) => {
+    setBusyAppealId(appealId)
+    try {
+      const response = await fetch(
+        `/api/evaluation/appeals/${appealId}/${actionEndpoint(action)}`,
+        { method: 'POST' },
+      )
+      if (!response.ok) throw new Error(`HTTP ${response.status}`)
+      setState((current) => {
+        if (current.kind !== 'ready') return current
+        return {
+          ...current,
+          appeals: current.appeals.filter((appeal) => appeal.id !== appealId),
+        }
       })
-
-      const endpointSuffix =
-        kind === 'supplement' ? 'request-supplement' : kind === 'reject' ? 'reject' : 'proceed'
-
-      try {
-        await postAction(`/api/evaluation/appeals/${appealId}/${endpointSuffix}`)
-        await loadData()
-      } catch (err) {
-        const msg = readError(err)
-        const display =
-          msg.includes('404') || msg.includes('501') ? 'この操作は現在実装中です' : msg
-        setActionErrors((prev) => new Map([...prev, [key, display]]))
-      } finally {
-        setActionLoading((prev) => {
-          const next = new Set(prev)
-          next.delete(key)
-          return next
-        })
-      }
-    },
-    [loadData],
-  )
-
-  if (state.kind === 'loading') {
-    return (
-      <main className="mx-auto max-w-7xl px-8 py-10">
-        <PageHeader pendingCount={0} urgentCount={0} />
-        <div className="flex items-center justify-center rounded-2xl border border-slate-200 bg-white py-24 text-sm text-slate-500">
-          <span className="animate-pulse">読み込み中…</span>
-        </div>
-      </main>
-    )
-  }
-
-  if (state.kind === 'error') {
-    return (
-      <main className="mx-auto max-w-7xl px-8 py-10">
-        <PageHeader pendingCount={0} urgentCount={0} />
-        <div className="rounded-2xl border border-rose-200 bg-rose-50 p-6 text-sm text-rose-800">
-          <p className="font-semibold">データの取得に失敗しました</p>
-          <p className="mt-1 text-xs opacity-80">{state.message}</p>
-        </div>
-      </main>
-    )
-  }
-
-  const { summary, appeals } = state.data
+    } catch (error) {
+      setState({ kind: 'error', message: readError(error) })
+    } finally {
+      setBusyAppealId(null)
+    }
+  }, [])
 
   return (
-    <main className="mx-auto max-w-7xl px-8 py-10">
-      <PageHeader pendingCount={summary.pendingCount} urgentCount={summary.urgentCount} />
+    <main className="min-h-screen bg-slate-50 px-4 py-8 text-slate-950 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-7xl">
+        <header className="mb-8">
+          <p className="text-sm font-semibold text-indigo-600">Appeal Review</p>
+          <h1 className="mt-1 text-3xl font-semibold tracking-tight">異議申立て審査</h1>
+        </header>
 
-      {/* KPI Cards */}
-      <div className="mb-8 grid gap-4 sm:grid-cols-3">
-        <KpiUnderReview stats={summary.underReview} />
-        <KpiThisMonth stats={summary.thisMonth} />
-        <KpiCorrectionRate stats={summary.correctionRate} />
+        {state.kind === 'loading' && (
+          <div className="rounded-lg border border-slate-200 bg-white py-20 text-center text-sm text-slate-500">
+            読み込み中...
+          </div>
+        )}
+
+        {state.kind === 'error' && (
+          <div className="rounded-lg border border-rose-200 bg-rose-50 p-5 text-sm text-rose-700">
+            {state.message}
+          </div>
+        )}
+
+        {state.kind === 'ready' && (
+          <>
+            <section className="mb-8 grid gap-4 md:grid-cols-3">
+              <KpiCard
+                title="審査中"
+                value={`${state.kpi.underReview}件`}
+                detail={`平均 ${state.kpi.avgDays.toFixed(1)}日 / 赤 ${state.kpi.nearDeadlineCount}件 期限近`}
+                tone="red"
+              />
+              <KpiCard
+                title="今月完了"
+                value={`${state.kpi.monthlyCompleted}件`}
+                detail={`是正 ${state.kpi.monthlyCorrected} / 却下 ${state.kpi.monthlyRejected} / 平均 5.1日`}
+                tone="slate"
+              />
+              <KpiCard
+                title="是正率"
+                value={`${state.kpi.correctionRate.toFixed(1)}%`}
+                detail={`昨期 38.9% / +${state.kpi.correctionRateDelta.toFixed(1)}pt`}
+                tone="emerald"
+              />
+            </section>
+
+            <section className="space-y-4">
+              {state.appeals.map((appeal) => (
+                <AppealCard
+                  key={appeal.id}
+                  appeal={appeal}
+                  busy={busyAppealId === appeal.id}
+                  onAction={handleAction}
+                />
+              ))}
+              {state.appeals.length === 0 && (
+                <div className="rounded-lg border border-slate-200 bg-white py-16 text-center text-sm text-slate-500">
+                  審査中の申立てはありません
+                </div>
+              )}
+            </section>
+          </>
+        )}
       </div>
-
-      {/* Appeal list */}
-      {appeals.length === 0 ? (
-        <div className="rounded-2xl border border-slate-200 bg-white py-20 text-center text-sm text-slate-400">
-          審査対象の申立てはありません
-        </div>
-      ) : (
-        <div className="space-y-4">
-          {appeals.map((appeal) => (
-            <AppealCard
-              key={appeal.id}
-              appeal={appeal}
-              actionLoading={actionLoading}
-              actionErrors={actionErrors}
-              onAction={handleAction}
-            />
-          ))}
-        </div>
-      )}
     </main>
   )
 }
 
-// ─────────────────────────────────────────────────────────────────────────────
-// PageHeader
-// ─────────────────────────────────────────────────────────────────────────────
-
-function PageHeader({
-  pendingCount,
-  urgentCount,
-}: {
-  readonly pendingCount: number
-  readonly urgentCount: number
-}): ReactElement {
-  return (
-    <header className="mb-8 flex items-start justify-between gap-4">
-      <div>
-        <p className="text-xs font-semibold tracking-[0.3em] text-rose-600 uppercase">Appeals</p>
-        <h1 className="mt-1 text-3xl font-semibold tracking-tight text-slate-950">異議申立て</h1>
-        <p className="mt-2 text-sm leading-6 text-slate-600">
-          審査対象{' '}
-          <span className="font-semibold text-slate-900 tabular-nums">{pendingCount}</span>{' '}
-          件・うち期限3日以内{' '}
-          <span className="font-semibold text-rose-600 tabular-nums">{urgentCount}</span> 件
-        </p>
-      </div>
-      <div className="flex shrink-0 items-center gap-2">
-        <button
-          type="button"
-          className="rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 shadow-sm hover:bg-slate-50"
-        >
-          絞り込み ▾
-        </button>
-        <button
-          type="button"
-          className="rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 shadow-sm hover:bg-slate-50"
-        >
-          履歴を出力
-        </button>
-      </div>
-    </header>
-  )
+interface KpiCardProps {
+  readonly title: string
+  readonly value: string
+  readonly detail: string
+  readonly tone: 'red' | 'slate' | 'emerald'
 }
 
-// ─────────────────────────────────────────────────────────────────────────────
-// KPI Cards
-// ─────────────────────────────────────────────────────────────────────────────
+function KpiCard({ title, value, detail, tone }: KpiCardProps): ReactElement {
+  const className =
+    tone === 'red'
+      ? 'border-red-200 bg-red-50 text-red-700'
+      : tone === 'emerald'
+        ? 'border-emerald-200 bg-emerald-50 text-emerald-700'
+        : 'border-slate-200 bg-white text-slate-950'
 
-function KpiUnderReview({ stats }: { readonly stats: UnderReviewStats }): ReactElement {
   return (
-    <div className="rounded-2xl border border-rose-100 bg-rose-50 p-5 shadow-sm">
-      <p className="text-xs font-semibold tracking-wider text-rose-500 uppercase">審査中</p>
-      <p className="mt-2 text-4xl font-bold text-rose-700 tabular-nums">{stats.count}</p>
-      <p className="mt-1 text-xs text-rose-500">平均 {stats.avgDays.toFixed(1)} 日</p>
-      {stats.nearDeadlineCount > 0 && (
-        <span className="mt-3 inline-flex items-center rounded-full bg-rose-200 px-2.5 py-0.5 text-xs font-semibold text-rose-800">
-          {stats.nearDeadlineCount}件 期限近
-        </span>
-      )}
+    <div className={`rounded-lg border p-5 shadow-sm ${className}`}>
+      <p className="text-sm font-semibold">{title}</p>
+      <p className="mt-2 text-4xl font-semibold tabular-nums">{value}</p>
+      <p className="mt-2 text-sm opacity-80">{detail}</p>
     </div>
   )
 }
-
-function KpiThisMonth({ stats }: { readonly stats: ThisMonthStats }): ReactElement {
-  return (
-    <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
-      <p className="text-xs font-semibold tracking-wider text-slate-500 uppercase">今月完了</p>
-      <p className="mt-2 text-4xl font-bold text-slate-900 tabular-nums">{stats.count}</p>
-      <p className="mt-1 text-xs text-slate-500">
-        是正 {stats.correctedCount} / 却下 {stats.rejectedCount} / 平均 {stats.avgDays.toFixed(1)}{' '}
-        日
-      </p>
-    </div>
-  )
-}
-
-function KpiCorrectionRate({ stats }: { readonly stats: CorrectionRateStats }): ReactElement {
-  const diffPositive = stats.diffPt >= 0
-  return (
-    <div className="rounded-2xl border border-emerald-100 bg-emerald-50 p-5 shadow-sm">
-      <p className="text-xs font-semibold tracking-wider text-emerald-600 uppercase">是正率</p>
-      <p className="mt-2 text-4xl font-bold text-emerald-700 tabular-nums">{stats.percent}%</p>
-      <p className="mt-1 text-xs text-emerald-600">
-        昨期 {stats.lastPeriodPercent}%{' '}
-        <span
-          className={
-            diffPositive ? 'font-semibold text-emerald-700' : 'font-semibold text-rose-600'
-          }
-        >
-          ({diffSign(stats.diffPt)} pt)
-        </span>
-      </p>
-    </div>
-  )
-}
-
-// ─────────────────────────────────────────────────────────────────────────────
-// AppealCard
-// ─────────────────────────────────────────────────────────────────────────────
 
 interface AppealCardProps {
   readonly appeal: Appeal
-  readonly actionLoading: ReadonlySet<string>
-  readonly actionErrors: ReadonlyMap<string, string>
-  readonly onAction: (id: string, kind: ActionKind) => Promise<void>
+  readonly busy: boolean
+  readonly onAction: (appealId: string, action: AppealAction) => void
 }
 
-function AppealCard({
-  appeal,
-  actionLoading,
-  actionErrors,
-  onAction,
-}: AppealCardProps): ReactElement {
-  const supplementKey = `${appeal.id}-supplement`
-  const rejectKey = `${appeal.id}-reject`
-  const proceedKey = `${appeal.id}-proceed`
-
-  const supplementError = actionErrors.get(supplementKey)
-  const rejectError = actionErrors.get(rejectKey)
-  const proceedError = actionErrors.get(proceedKey)
-  const anyError = supplementError ?? rejectError ?? proceedError
-
-  const isSupplementLoading = actionLoading.has(supplementKey)
-  const isRejectLoading = actionLoading.has(rejectKey)
-  const isProceedLoading = actionLoading.has(proceedKey)
-  const anyLoading = isSupplementLoading || isRejectLoading || isProceedLoading
-
+function AppealCard({ appeal, busy, onAction }: AppealCardProps): ReactElement {
   return (
-    <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
-      <div className="flex gap-6">
-        {/* Main content */}
+    <article className="rounded-lg border border-slate-200 bg-white p-5 shadow-sm">
+      <div className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
         <div className="min-w-0 flex-1">
-          {/* Top row: appeal no + deadline badge + type tag */}
-          <div className="mb-2 flex flex-wrap items-center gap-2">
-            <span className="font-mono text-xs font-semibold text-slate-400">
-              {appeal.appealNo}
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="font-mono text-sm font-semibold text-slate-500">
+              {appeal.appealNumber}
             </span>
             <span
-              className={`rounded-full border px-2 py-0.5 text-xs font-semibold ${deadlineBadgeClass(appeal.deadlineDaysLeft)}`}
+              className={`rounded-full px-2.5 py-1 text-xs font-semibold ring-1 ${deadlineClass(appeal.deadlineDays)}`}
             >
-              残 {appeal.deadlineDaysLeft} 日
+              {deadlineLabel(appeal.deadlineDays)}
             </span>
-            <span className="rounded-full bg-slate-100 px-2.5 py-0.5 text-xs text-slate-600">
-              {appeal.appealType}
+            <span className="rounded-full bg-slate-100 px-2.5 py-1 text-xs font-semibold text-slate-600">
+              {TYPE_LABELS[appeal.type]}
             </span>
           </div>
 
-          {/* Title */}
-          <h2 className="mb-1.5 text-base font-semibold text-slate-900">{appeal.title}</h2>
+          <h2 className="mt-3 text-lg font-semibold text-slate-950">{appeal.title}</h2>
+          <p className="mt-2 line-clamp-2 text-sm leading-6 text-slate-600">{appeal.content}</p>
 
-          {/* Content */}
-          <p className="mb-4 line-clamp-3 text-sm leading-relaxed text-slate-600">
-            {appeal.content}
-          </p>
-
-          {/* Action buttons */}
-          <div className="flex flex-wrap items-center gap-2">
-            <button
-              type="button"
-              disabled={anyLoading}
-              onClick={() => void onAction(appeal.id, 'supplement')}
-              className="rounded-lg border border-slate-300 px-3.5 py-1.5 text-sm font-medium text-slate-700 hover:bg-slate-50 disabled:opacity-50"
+          <div className="mt-5 flex flex-wrap items-center gap-3">
+            <span
+              className={`flex h-10 w-10 items-center justify-center rounded-full text-sm font-bold ${appeal.avatarColor}`}
             >
-              {isSupplementLoading ? '送信中…' : '補足を依頼'}
-            </button>
-            <button
-              type="button"
-              disabled={anyLoading}
-              onClick={() => void onAction(appeal.id, 'reject')}
-              className="rounded-lg border border-rose-200 px-3.5 py-1.5 text-sm font-medium text-rose-600 hover:bg-rose-50 disabled:opacity-50"
-            >
-              {isRejectLoading ? '処理中…' : '却下'}
-            </button>
-            <button
-              type="button"
-              disabled={anyLoading}
-              onClick={() => void onAction(appeal.id, 'proceed')}
-              className="rounded-lg bg-indigo-600 px-3.5 py-1.5 text-sm font-semibold text-white hover:bg-indigo-700 disabled:opacity-50"
-            >
-              {isProceedLoading ? '処理中…' : '是正に進む'}
-            </button>
+              {initials(appeal.employeeName)}
+            </span>
+            <div>
+              <p className="font-semibold text-slate-900">{appeal.employeeName}</p>
+              <p className="text-xs text-slate-500">
+                {appeal.employeeNumber} / 提出日 {appeal.submittedAt}
+              </p>
+            </div>
           </div>
-
-          {anyError && <p className="mt-2 text-xs text-rose-600">{anyError}</p>}
         </div>
 
-        {/* Right: submitter info */}
-        <div className="flex shrink-0 flex-col items-center gap-1.5 pl-4 text-center">
-          <div
-            className={`flex h-10 w-10 items-center justify-center rounded-full text-sm font-bold text-white ${avatarColor(appeal.id)}`}
+        <div className="flex flex-wrap justify-end gap-2 lg:w-96">
+          <button
+            type="button"
+            disabled={busy}
+            onClick={() => onAction(appeal.id, 'request-info')}
+            className="h-10 rounded-md border border-slate-300 bg-white px-3 text-sm font-medium text-slate-700 hover:bg-slate-100 disabled:opacity-40"
           >
-            {getInitials(appeal.submitterName)}
-          </div>
-          <p className="text-xs font-semibold text-slate-800">{appeal.submitterName}</p>
-          <p className="font-mono text-[10px] text-slate-400">{appeal.submitterEmployeeNo}</p>
-          <p className="text-[10px] text-slate-400">{formatDate(appeal.submittedAt)}</p>
+            補足を依頼
+          </button>
+          <button
+            type="button"
+            disabled={busy}
+            onClick={() => onAction(appeal.id, 'reject')}
+            className="h-10 rounded-md border border-red-300 bg-white px-3 text-sm font-medium text-red-700 hover:bg-red-50 disabled:opacity-40"
+          >
+            却下
+          </button>
+          <button
+            type="button"
+            disabled={busy}
+            onClick={() => onAction(appeal.id, 'correct')}
+            className="h-10 rounded-md bg-indigo-600 px-3 text-sm font-semibold text-white hover:bg-indigo-700 disabled:opacity-40"
+          >
+            是正に進む
+          </button>
         </div>
       </div>
-    </div>
+    </article>
   )
 }

--- a/src/lib/evaluation/appeal-review-data.ts
+++ b/src/lib/evaluation/appeal-review-data.ts
@@ -1,0 +1,180 @@
+import type { Appeal, AppealPriority, AppealStatus, AppealsKpi } from './appeal-types'
+
+export type AppealAction = 'request-info' | 'reject' | 'correct'
+
+const APPEALS_KPI: AppealsKpi = {
+  underReview: 7,
+  avgDays: 3.2,
+  nearDeadlineCount: 3,
+  monthlyCompleted: 24,
+  monthlyCorrected: 11,
+  monthlyRejected: 13,
+  correctionRate: 45.8,
+  correctionRateDelta: 6.9,
+}
+
+const APPEALS: readonly Appeal[] = [
+  {
+    id: 'appeal-1',
+    appealNumber: '#APL-2024-0042',
+    type: 'EVALUATION_RESULT',
+    title: 'Q4評価結果の営業達成率計算について',
+    content:
+      '目標達成率が112%であるにもかかわらず、評価シート上では98%として算出されています。対象期間と売上計上日の確認をお願いします。',
+    priority: 'HIGH',
+    deadlineDays: 1,
+    employeeId: 'employee-00123',
+    employeeName: '田中 一郎',
+    employeeNumber: 'EMP-00123',
+    avatarColor: 'bg-indigo-100 text-indigo-700',
+    submittedAt: '2026-04-20',
+    status: 'UNDER_REVIEW',
+  },
+  {
+    id: 'appeal-2',
+    appealNumber: '#APL-2024-0041',
+    type: 'FEEDBACK',
+    title: 'リーダーシップ評価コメントの根拠確認',
+    content:
+      'プロジェクトリードを2件担当しましたが、フィードバックでは関与度が低いと記載されています。評価根拠の補足を希望します。',
+    priority: 'HIGH',
+    deadlineDays: 2,
+    employeeId: 'employee-00256',
+    employeeName: '鈴木 花子',
+    employeeNumber: 'EMP-00256',
+    avatarColor: 'bg-rose-100 text-rose-700',
+    submittedAt: '2026-04-19',
+    status: 'UNDER_REVIEW',
+  },
+  {
+    id: 'appeal-3',
+    appealNumber: '#APL-2024-0040',
+    type: 'CALIBRATION',
+    title: '部門間キャリブレーション結果の再確認',
+    content:
+      '同等グレードの他部署メンバーと比較して、成果指標の扱いに差があるように見えます。調整会議での判断材料を確認したいです。',
+    priority: 'HIGH',
+    deadlineDays: 4,
+    employeeId: 'employee-00312',
+    employeeName: '佐藤 美咲',
+    employeeNumber: 'EMP-00312',
+    avatarColor: 'bg-orange-100 text-orange-700',
+    submittedAt: '2026-04-18',
+    status: 'UNDER_REVIEW',
+  },
+  {
+    id: 'appeal-4',
+    appealNumber: '#APL-2024-0039',
+    type: 'EVALUATION_RESULT',
+    title: '追加目標の評価基準が不明確だった件',
+    content:
+      '中間面談で追加された目標について、評価基準が明文化されないまま未達扱いとなりました。合意内容との照合をお願いします。',
+    priority: 'MEDIUM',
+    deadlineDays: 5,
+    employeeId: 'employee-00387',
+    employeeName: '佐藤 次郎',
+    employeeNumber: 'EMP-00387',
+    avatarColor: 'bg-cyan-100 text-cyan-700',
+    submittedAt: '2026-04-18',
+    status: 'UNDER_REVIEW',
+  },
+  {
+    id: 'appeal-5',
+    appealNumber: '#APL-2024-0038',
+    type: 'EVALUATION_RESULT',
+    title: '育児休業期間を含む評価算定方法への異議',
+    content:
+      '育休取得期間を含む評価で、フル稼働期間と同じ基準が適用されています。就業規則に基づく按分計算を確認してください。',
+    priority: 'MEDIUM',
+    deadlineDays: 8,
+    employeeId: 'employee-00512',
+    employeeName: '山田 美優',
+    employeeNumber: 'EMP-00512',
+    avatarColor: 'bg-violet-100 text-violet-700',
+    submittedAt: '2026-04-17',
+    status: 'UNDER_REVIEW',
+  },
+  {
+    id: 'appeal-6',
+    appealNumber: '#APL-2024-0037',
+    type: 'FEEDBACK',
+    title: '顧客満足度スコア集計対象期間の確認',
+    content:
+      '集計対象が一部月のみになっており、直近の高評価期間が含まれていません。ダッシュボードの抽出条件を確認したいです。',
+    priority: 'LOW',
+    deadlineDays: 10,
+    employeeId: 'employee-00634',
+    employeeName: '伊藤 健',
+    employeeNumber: 'EMP-00634',
+    avatarColor: 'bg-emerald-100 text-emerald-700',
+    submittedAt: '2026-04-15',
+    status: 'UNDER_REVIEW',
+  },
+  {
+    id: 'appeal-7',
+    appealNumber: '#APL-2024-0036',
+    type: 'CALIBRATION',
+    title: '昇格候補者会議でのスキル評価参照について',
+    content:
+      '最新のスキル登録が反映される前のデータで議論された可能性があります。登録履歴と会議資料の突合をお願いします。',
+    priority: 'LOW',
+    deadlineDays: 13,
+    employeeId: 'employee-00711',
+    employeeName: '高橋 葵',
+    employeeNumber: 'EMP-00711',
+    avatarColor: 'bg-slate-100 text-slate-700',
+    submittedAt: '2026-04-14',
+    status: 'UNDER_REVIEW',
+  },
+  {
+    id: 'appeal-8',
+    appealNumber: '#APL-2024-0035',
+    type: 'FEEDBACK',
+    title: '追加資料の提出待ち',
+    content: '申立者へ根拠資料の追加提出を依頼済みです。',
+    priority: 'MEDIUM',
+    deadlineDays: 6,
+    employeeId: 'employee-00802',
+    employeeName: '中村 蓮',
+    employeeNumber: 'EMP-00802',
+    avatarColor: 'bg-yellow-100 text-yellow-700',
+    submittedAt: '2026-04-13',
+    status: 'PENDING_INFO',
+  },
+]
+
+const PRIORITY_WEIGHT: Record<AppealPriority, number> = {
+  HIGH: 0,
+  MEDIUM: 1,
+  LOW: 2,
+}
+
+export function getAppealsKpi(): AppealsKpi {
+  return { ...APPEALS_KPI }
+}
+
+export function listAppealsForReview(status: AppealStatus = 'UNDER_REVIEW'): readonly Appeal[] {
+  return APPEALS.filter((appeal) => appeal.status === status)
+    .toSorted((a, b) => {
+      const priorityDelta = PRIORITY_WEIGHT[a.priority] - PRIORITY_WEIGHT[b.priority]
+      if (priorityDelta !== 0) return priorityDelta
+      return a.deadlineDays - b.deadlineDays
+    })
+    .map((appeal) => ({ ...appeal }))
+}
+
+export function applyAppealAction(id: string, action: AppealAction): Appeal | null {
+  const appeal = APPEALS.find((item) => item.id === id)
+  if (!appeal) return null
+  const status: AppealStatus =
+    action === 'request-info'
+      ? 'PENDING_INFO'
+      : action === 'reject'
+        ? 'COMPLETED_REJECTED'
+        : 'COMPLETED_CORRECTION'
+
+  return {
+    ...appeal,
+    status,
+  }
+}

--- a/src/lib/evaluation/appeal-types.ts
+++ b/src/lib/evaluation/appeal-types.ts
@@ -1,0 +1,34 @@
+export type AppealType = 'EVALUATION_RESULT' | 'FEEDBACK' | 'CALIBRATION'
+export type AppealStatus =
+  | 'UNDER_REVIEW'
+  | 'COMPLETED_CORRECTION'
+  | 'COMPLETED_REJECTED'
+  | 'PENDING_INFO'
+export type AppealPriority = 'HIGH' | 'MEDIUM' | 'LOW'
+
+export interface Appeal {
+  readonly id: string
+  readonly appealNumber: string
+  readonly type: AppealType
+  readonly title: string
+  readonly content: string
+  readonly priority: AppealPriority
+  readonly deadlineDays: number
+  readonly employeeId: string
+  readonly employeeName: string
+  readonly employeeNumber: string
+  readonly avatarColor: string
+  readonly submittedAt: string
+  readonly status: AppealStatus
+}
+
+export interface AppealsKpi {
+  readonly underReview: number
+  readonly avgDays: number
+  readonly nearDeadlineCount: number
+  readonly monthlyCompleted: number
+  readonly monthlyCorrected: number
+  readonly monthlyRejected: number
+  readonly correctionRate: number
+  readonly correctionRateDelta: number
+}

--- a/src/tests/evaluation/appeal-review-data.test.ts
+++ b/src/tests/evaluation/appeal-review-data.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import {
+  applyAppealAction,
+  getAppealsKpi,
+  listAppealsForReview,
+} from '@/lib/evaluation/appeal-review-data'
+
+describe('appeal review data', () => {
+  it('returns the issue KPI values', () => {
+    expect(getAppealsKpi()).toEqual({
+      underReview: 7,
+      avgDays: 3.2,
+      nearDeadlineCount: 3,
+      monthlyCompleted: 24,
+      monthlyCorrected: 11,
+      monthlyRejected: 13,
+      correctionRate: 45.8,
+      correctionRateDelta: 6.9,
+    })
+  })
+
+  it('lists under-review appeals sorted by priority and deadline', () => {
+    const appeals = listAppealsForReview('UNDER_REVIEW')
+
+    expect(appeals).toHaveLength(7)
+    expect(appeals[0]).toMatchObject({
+      appealNumber: '#APL-2024-0042',
+      priority: 'HIGH',
+      deadlineDays: 1,
+      status: 'UNDER_REVIEW',
+    })
+    expect(appeals.at(-1)?.priority).toBe('LOW')
+  })
+
+  it('returns only pending-info appeals when filtered', () => {
+    const appeals = listAppealsForReview('PENDING_INFO')
+
+    expect(appeals).toHaveLength(1)
+    expect(appeals[0]?.status).toBe('PENDING_INFO')
+  })
+
+  it('maps card actions to the resulting appeal status', () => {
+    expect(applyAppealAction('appeal-1', 'request-info')?.status).toBe('PENDING_INFO')
+    expect(applyAppealAction('appeal-1', 'reject')?.status).toBe('COMPLETED_REJECTED')
+    expect(applyAppealAction('appeal-1', 'correct')?.status).toBe('COMPLETED_CORRECTION')
+    expect(applyAppealAction('missing', 'correct')).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary
- Redesign `/evaluation/appeals` with the Issue #210 KPI cards and priority-ordered appeal review cards.
- Add appeal review types and deterministic review data helpers for KPI, filtering, sorting, and action status mapping.
- Add `/api/evaluation/appeals`, `/api/evaluation/appeals/kpi`, and the request-info/reject/correct action endpoints.
- Add Vitest coverage for KPI values, priority/deadline ordering, status filtering, and action status transitions.

Closes #210

## Validation
- `pnpm vitest run src/tests/evaluation/appeal-review-data.test.ts`
- `pnpm prettier --check src/app/evaluation/appeals/page.tsx src/app/api/evaluation/appeals/route.ts src/app/api/evaluation/appeals/kpi/route.ts src/app/api/evaluation/appeals/[id]/request-info/route.ts src/app/api/evaluation/appeals/[id]/reject/route.ts src/app/api/evaluation/appeals/[id]/correct/route.ts src/lib/evaluation/appeal-types.ts src/lib/evaluation/appeal-review-data.ts src/tests/evaluation/appeal-review-data.test.ts`
- `pnpm type-check`
- `pnpm build` compiled successfully, then failed on existing lint errors in `src/lib/lifecycle/profile-service.ts` for unused `_locale` / `_timezone`.
- Dev server smoke check: `GET /evaluation/appeals`, `GET /api/evaluation/appeals?status=UNDER_REVIEW`, and `GET /api/evaluation/appeals/kpi` returned 200 on port 3003.